### PR TITLE
feat: implementa endpoint POST /api/auth/register con bcrypt

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,11 +9,14 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "bcrypt": "^6.0.0",
         "cors": "^2.8.6",
         "dotenv": "^17.3.1",
         "express": "^5.2.1"
       },
       "devDependencies": {
+        "@types/bcrypt": "^6.0.0",
+        "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
         "@types/node": "^25.5.0",
         "nodemon": "^3.1.14",
@@ -331,6 +334,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -346,6 +359,16 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -518,6 +541,20 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/binary-extensions": {
@@ -1660,12 +1697,32 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
+      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-fetch-native": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
     },
     "node_modules/nodemon": {
       "version": "3.1.14",

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,11 +13,14 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "bcrypt": "^6.0.0",
     "cors": "^2.8.6",
     "dotenv": "^17.3.1",
     "express": "^5.2.1"
   },
   "devDependencies": {
+    "@types/bcrypt": "^6.0.0",
+    "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "@types/node": "^25.5.0",
     "nodemon": "^3.1.14",

--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -1,0 +1,34 @@
+import express from 'express';
+import bcrypt from 'bcrypt';
+import { prisma } from '../lib/prisma';
+import { RolUsuario } from '../generated/prisma/client';
+
+export const register: express.RequestHandler = async (req, res) => {
+  const { nombre, apellidos, dni, email, password, telefono, rol } = req.body as {
+    nombre: string;
+    apellidos: string;
+    dni: string;
+    email: string;
+    password: string;
+    telefono?: string;
+    rol: RolUsuario;
+  };
+
+  const existing = await prisma.usuario.findFirst({
+    where: { OR: [{ email }, { dni }] },
+  });
+
+  if (existing) {
+    res.status(400).json({ error: 'El email o DNI ya está registrado.' });
+    return;
+  }
+
+  const password_hash = await bcrypt.hash(password, 10);
+
+  const usuario = await prisma.usuario.create({
+    data: { nombre, apellidos, dni, email, password_hash, telefono, rol },
+  });
+
+  const { password_hash: _omit, ...usuarioSinPassword } = usuario;
+  res.status(201).json(usuarioSinPassword);
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,5 +1,7 @@
+import 'dotenv/config';
 import express from 'express';
 import cors from 'cors';
+import authRoutes from './routes/auth.routes';
 
 const app = express();
 const PORT = 3000;
@@ -10,6 +12,8 @@ app.use(express.json());
 app.get('/ping', (_req, res) => {
   res.send('pong');
 });
+
+app.use('/api/auth', authRoutes);
 
 app.listen(PORT, () => {
   console.log(`Server running on http://localhost:${PORT}`);

--- a/backend/src/lib/prisma.ts
+++ b/backend/src/lib/prisma.ts
@@ -1,0 +1,14 @@
+import { PrismaClient } from '../generated/prisma/client';
+
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClient | undefined;
+};
+
+export const prisma =
+  globalForPrisma.prisma ?? new PrismaClient({
+    accelerateUrl: process.env['DATABASE_URL']!,
+  });
+
+if (process.env['NODE_ENV'] !== 'production') {
+  globalForPrisma.prisma = prisma;
+}

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+import { register } from '../controllers/auth.controller';
+
+const router = express.Router();
+
+router.post('/register', register);
+
+export default router;

--- a/docs/changelog/epica-1-issue-6-auth-register.md
+++ b/docs/changelog/epica-1-issue-6-auth-register.md
@@ -1,0 +1,43 @@
+# Issue #6 — Endpoint POST /auth/register
+
+**Épica:** 1 — Setup inicial del proyecto
+**Fecha:** 2026-03-26
+**Rama:** `dev`
+
+## Qué se hizo
+
+- Instalada librería `bcrypt` para hasheo de contraseñas (10 salt rounds).
+- Ejecutado `npx prisma generate` para generar el cliente Prisma en `src/generated/prisma/`.
+- Creado `src/lib/prisma.ts`: singleton `PrismaClient` con patrón global para evitar múltiples conexiones durante hot-reload con nodemon.
+- Creado `src/controllers/auth.controller.ts` con la función `register`:
+  - Comprueba si ya existe un usuario con el mismo email o DNI → 400 si existe.
+  - Hashea la contraseña con bcrypt (10 rounds).
+  - Crea el usuario en BD y devuelve 201 con los datos sin `password_hash`.
+- Creado `src/routes/auth.routes.ts` con la ruta `POST /register`.
+- Actualizado `src/index.ts` para montar las rutas de auth en `/api/auth` y añadir `dotenv/config`.
+
+## Endpoint disponible
+
+```
+POST /api/auth/register
+Content-Type: application/json
+
+{
+  "nombre": "string",
+  "apellidos": "string",
+  "dni": "string",
+  "email": "string",
+  "password": "string",
+  "telefono": "string (opcional)",
+  "rol": "CASERO | INQUILINO"
+}
+```
+
+**Respuestas:**
+- `201 Created` — usuario creado (sin `password_hash`)
+- `400 Bad Request` — email o DNI ya registrado
+
+## Notas
+
+- `dni` no tiene `@unique` en el schema, por lo que la unicidad se valida con `findFirst` antes del insert.
+- No implementado Login ni JWT (pendiente issue #7 o similar).


### PR DESCRIPTION
- Singleton PrismaClient en src/lib/prisma.ts
- Controlador register: valida email/DNI único, hashea password (bcrypt 10 rounds), devuelve 201 sin password_hash
- Rutas auth montadas en /api/auth
- Añade dotenv/config a index.ts.