### PR TITLE
feat: añade endpoint POST /api/viviendas para crear vivienda

### DIFF
--- a/backend/src/controllers/vivienda.controller.ts
+++ b/backend/src/controllers/vivienda.controller.ts
@@ -1,0 +1,36 @@
+import express from 'express';
+import { prisma } from '../lib/prisma';
+import { RolUsuario } from '../generated/prisma/client';
+
+export const crearVivienda: express.RequestHandler = async (req, res) => {
+  if (req.usuario!.rol !== RolUsuario.CASERO) {
+    res.status(403).json({ error: 'Solo los caseros pueden crear viviendas.' });
+    return;
+  }
+
+  const { alias_nombre, direccion, codigo_postal, ciudad, provincia } = req.body as {
+    alias_nombre: string;
+    direccion: string;
+    codigo_postal: string;
+    ciudad: string;
+    provincia: string;
+  };
+
+  if (!alias_nombre || !direccion || !codigo_postal || !ciudad || !provincia) {
+    res.status(400).json({ error: 'alias_nombre, direccion, codigo_postal, ciudad y provincia son obligatorios.' });
+    return;
+  }
+
+  const vivienda = await prisma.vivienda.create({
+    data: {
+      casero_id: req.usuario!.id,
+      alias_nombre,
+      direccion,
+      codigo_postal,
+      ciudad,
+      provincia,
+    },
+  });
+
+  res.status(201).json(vivienda);
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,6 +2,7 @@ import 'dotenv/config';
 import express from 'express';
 import cors from 'cors';
 import authRoutes from './routes/auth.routes';
+import viviendaRoutes from './routes/vivienda.routes';
 
 const app = express();
 const PORT = 3000;
@@ -14,6 +15,7 @@ app.get('/ping', (_req, res) => {
 });
 
 app.use('/api/auth', authRoutes);
+app.use('/api/viviendas', viviendaRoutes);
 
 app.listen(PORT, () => {
   console.log(`Server running on http://localhost:${PORT}`);

--- a/backend/src/routes/vivienda.routes.ts
+++ b/backend/src/routes/vivienda.routes.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+import { verificarToken } from '../middlewares/auth.middleware';
+import { crearVivienda } from '../controllers/vivienda.controller';
+
+const router = express.Router();
+
+router.post('/', verificarToken, crearVivienda);
+
+export default router;

--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -107,3 +107,45 @@ Devuelve el payload del token activo. No consulta la base de datos.
   "rol": "CASERO"
 }
 ```
+
+---
+
+## Viviendas (`/viviendas`)
+
+### POST `/viviendas`
+
+Crea una nueva vivienda. Solo accesible para usuarios con rol `CASERO`.
+
+**Auth requerida:** Sí — `Authorization: Bearer <token>`
+
+**Body (JSON):**
+
+| Campo | Tipo | Requerido | Descripción |
+|---|---|---|---|
+| `alias_nombre` | string | Sí | Nombre identificativo de la vivienda |
+| `direccion` | string | Sí | Dirección completa |
+| `codigo_postal` | string | Sí | Código postal |
+| `ciudad` | string | Sí | Ciudad |
+| `provincia` | string | Sí | Provincia |
+
+**Respuestas:**
+
+| Código | Descripción |
+|---|---|
+| `201` | Vivienda creada. Devuelve el objeto completo de la vivienda. |
+| `400` | Falta alguno de los campos obligatorios. |
+| `401` | Sin token. |
+| `403` | El usuario tiene rol `INQUILINO`. |
+
+**Ejemplo respuesta 201:**
+```json
+{
+  "id": 1,
+  "casero_id": 1,
+  "alias_nombre": "Piso Centro",
+  "direccion": "Calle Mayor 10, 3ºB",
+  "codigo_postal": "28013",
+  "ciudad": "Madrid",
+  "provincia": "Madrid"
+}
+```

--- a/docs/changelog/epica-2-issue-9-vivienda-crear.md
+++ b/docs/changelog/epica-2-issue-9-vivienda-crear.md
@@ -1,0 +1,27 @@
+# Épica 2 — Issue #9: Endpoint para Crear Vivienda (POST /api/viviendas)
+
+## Qué se hizo
+
+- Controlador `crearVivienda` en `src/controllers/vivienda.controller.ts`
+- Ruta `POST /api/viviendas` protegida con middleware `verificarToken`
+- Validación de rol: solo `CASERO` puede crear viviendas (403 si es `INQUILINO`)
+- Validación de campos obligatorios: `alias_nombre` y `direccion` (400 si faltan)
+- `casero_id` se asigna automáticamente desde `req.usuario.id`
+
+## Archivos creados / modificados
+
+| Acción | Archivo |
+|---|---|
+| Nuevo | `src/controllers/vivienda.controller.ts` |
+| Nuevo | `src/routes/vivienda.routes.ts` |
+| Modificado | `src/index.ts` — monta `/api/viviendas` |
+| Nuevo | `docs/backend/api.md` — sección viviendas |
+
+## Respuestas del endpoint
+
+| Código | Condición |
+|---|---|
+| `201` | Vivienda creada correctamente |
+| `400` | Falta `alias_nombre` o `direccion` |
+| `401` | Sin token |
+| `403` | Usuario con rol `INQUILINO` |


### PR DESCRIPTION
- Controlador crearVivienda con validación de rol (403 si INQUILINO)
- Validación de los 5 campos obligatorios (400 si falta alguno)
- casero_id asignado automáticamente desde req.usuario.id (token JWT)
- Ruta protegida con middleware verificarToken
- Monta /api/viviendas en src/index.ts
- Actualiza docs/backend/api.md con la nueva sección de viviendas