### PR TITLE
feat: añade endpoint POST /api/viviendas/:id/habitaciones con código …

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -18,6 +18,14 @@ enum EstadoIncidencia {
   RESUELTA
 }
 
+enum TipoHabitacion {
+  DORMITORIO
+  BANO
+  COCINA
+  SALON
+  OTRO
+}
+
 model Usuario {
   id            Int          @id @default(autoincrement())
   nombre        String
@@ -46,13 +54,16 @@ model Vivienda {
 }
 
 model Habitacion {
-  id                Int       @id @default(autoincrement())
+  id                Int            @id @default(autoincrement())
   vivienda_id       Int
-  vivienda          Vivienda  @relation(fields: [vivienda_id], references: [id])
+  vivienda          Vivienda       @relation(fields: [vivienda_id], references: [id])
   inquilino_id      Int?
-  inquilino         Usuario?  @relation(fields: [inquilino_id], references: [id])
+  inquilino         Usuario?       @relation(fields: [inquilino_id], references: [id])
   nombre            String
-  codigo_invitacion String    @unique
+  tipo              TipoHabitacion @default(DORMITORIO)
+  es_habitable      Boolean        @default(true)
+  metros_cuadrados  Float?
+  codigo_invitacion String?        @unique
 }
 
 model Incidencia {

--- a/backend/src/controllers/vivienda.controller.ts
+++ b/backend/src/controllers/vivienda.controller.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import { prisma } from '../lib/prisma';
-import { RolUsuario } from '../generated/prisma/client';
+import { RolUsuario, TipoHabitacion } from '../generated/prisma/client';
+import { generarCodigoInvitacion } from '../utils/generarCodigo';
 
 export const crearVivienda: express.RequestHandler = async (req, res) => {
   if (req.usuario!.rol !== RolUsuario.CASERO) {
@@ -33,4 +34,42 @@ export const crearVivienda: express.RequestHandler = async (req, res) => {
   });
 
   res.status(201).json(vivienda);
+};
+
+export const crearHabitacion: express.RequestHandler = async (req, res) => {
+  const viviendaId = parseInt(req.params['id'] as string, 10);
+
+  const { nombre, tipo, es_habitable, metros_cuadrados } = req.body as {
+    nombre: string;
+    tipo?: TipoHabitacion;
+    es_habitable?: boolean;
+    metros_cuadrados?: number;
+  };
+
+  if (!nombre) {
+    res.status(400).json({ error: 'nombre es obligatorio.' });
+    return;
+  }
+
+  const vivienda = await prisma.vivienda.findUnique({ where: { id: viviendaId } });
+  if (!vivienda || vivienda.casero_id !== req.usuario!.id) {
+    res.status(403).json({ error: 'No tienes permiso para añadir habitaciones a esta vivienda.' });
+    return;
+  }
+
+  const habitable = es_habitable !== false;
+  const codigo_invitacion = habitable ? await generarCodigoInvitacion() : null;
+
+  const habitacion = await prisma.habitacion.create({
+    data: {
+      vivienda_id: viviendaId,
+      nombre,
+      tipo: tipo ?? TipoHabitacion.DORMITORIO,
+      es_habitable: habitable,
+      metros_cuadrados: metros_cuadrados ?? null,
+      codigo_invitacion,
+    },
+  });
+
+  res.status(201).json(habitacion);
 };

--- a/backend/src/routes/vivienda.routes.ts
+++ b/backend/src/routes/vivienda.routes.ts
@@ -1,9 +1,10 @@
 import express from 'express';
 import { verificarToken } from '../middlewares/auth.middleware';
-import { crearVivienda } from '../controllers/vivienda.controller';
+import { crearVivienda, crearHabitacion } from '../controllers/vivienda.controller';
 
 const router = express.Router();
 
 router.post('/', verificarToken, crearVivienda);
+router.post('/:id/habitaciones', verificarToken, crearHabitacion);
 
 export default router;

--- a/backend/src/utils/generarCodigo.ts
+++ b/backend/src/utils/generarCodigo.ts
@@ -1,0 +1,20 @@
+import { prisma } from '../lib/prisma';
+
+function randomCode(): string {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  let code = 'ROOM-';
+  for (let i = 0; i < 4; i++) {
+    code += chars[Math.floor(Math.random() * chars.length)];
+  }
+  return code;
+}
+
+export async function generarCodigoInvitacion(): Promise<string> {
+  while (true) {
+    const code = randomCode();
+    const exists = await prisma.habitacion.findUnique({
+      where: { codigo_invitacion: code },
+    });
+    if (!exists) return code;
+  }
+}

--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -149,3 +149,66 @@ Crea una nueva vivienda. Solo accesible para usuarios con rol `CASERO`.
   "provincia": "Madrid"
 }
 ```
+
+---
+
+### POST `/viviendas/:id/habitaciones`
+
+Añade una habitación a una vivienda. Solo el casero propietario de la vivienda puede añadir habitaciones.
+
+**Auth requerida:** Sí — `Authorization: Bearer <token>`
+
+**Params:**
+
+| Param | Descripción |
+|---|---|
+| `id` | ID de la vivienda |
+
+**Body (JSON):**
+
+| Campo | Tipo | Requerido | Descripción |
+|---|---|---|---|
+| `nombre` | string | Sí | Nombre descriptivo de la habitación |
+| `tipo` | `DORMITORIO` \| `BANO` \| `COCINA` \| `SALON` \| `OTRO` | No | Default: `DORMITORIO` |
+| `es_habitable` | boolean | No | Si es habitable por un inquilino. Default: `true` |
+| `metros_cuadrados` | number | No | Superficie en m² |
+
+**Respuestas:**
+
+| Código | Descripción |
+|---|---|
+| `201` | Habitación creada. Devuelve el objeto completo. |
+| `400` | Falta `nombre`. |
+| `401` | Sin token. |
+| `403` | La vivienda no pertenece al casero logueado. |
+
+> Si `es_habitable: true` se genera automáticamente un `codigo_invitacion` con formato `ROOM-XXXX`.
+> Si `es_habitable: false` (zona común), `codigo_invitacion` es `null`.
+
+**Ejemplo respuesta 201 (dormitorio):**
+```json
+{
+  "id": 1,
+  "vivienda_id": 1,
+  "inquilino_id": null,
+  "nombre": "Habitación 1",
+  "tipo": "DORMITORIO",
+  "es_habitable": true,
+  "metros_cuadrados": 12.5,
+  "codigo_invitacion": "ROOM-AB3X"
+}
+```
+
+**Ejemplo respuesta 201 (zona común):**
+```json
+{
+  "id": 2,
+  "vivienda_id": 1,
+  "inquilino_id": null,
+  "nombre": "Cocina",
+  "tipo": "COCINA",
+  "es_habitable": false,
+  "metros_cuadrados": null,
+  "codigo_invitacion": null
+}
+```

--- a/docs/changelog/epica-2-issue-11-12-habitaciones.md
+++ b/docs/changelog/epica-2-issue-11-12-habitaciones.md
@@ -1,0 +1,33 @@
+# Épica 2 — Issues #11 y #12: Añadir Habitaciones + Código de Invitación
+
+## Qué se hizo
+
+- Nuevo enum `TipoHabitacion` en el schema (`DORMITORIO`, `BANO`, `COCINA`, `SALON`, `OTRO`)
+- Campos añadidos al modelo `Habitacion`: `tipo`, `es_habitable`, `metros_cuadrados`
+- `codigo_invitacion` pasa a ser opcional (`String?`): las zonas comunes no tienen código
+- Utilidad `generarCodigoInvitacion()` genera códigos únicos con formato `ROOM-XXXX` y reintenta si hay colisión
+- Controlador `crearHabitacion`: verifica que la vivienda pertenece al casero logueado (403 si no), genera código solo si `es_habitable: true`
+- Ruta `POST /api/viviendas/:id/habitaciones` protegida con `verificarToken`
+
+## Archivos creados / modificados
+
+| Acción | Archivo |
+|---|---|
+| Modificado | `prisma/schema.prisma` — enum TipoHabitacion + campos Habitacion |
+| Nuevo | `src/utils/generarCodigo.ts` |
+| Modificado | `src/controllers/vivienda.controller.ts` — añade crearHabitacion |
+| Modificado | `src/routes/vivienda.routes.ts` — añade POST /:id/habitaciones |
+| Modificado | `docs/backend/api.md` — sección habitaciones |
+
+## Lógica de negocio clave
+
+| Condición | Resultado |
+|---|---|
+| `es_habitable: true` (o no enviado) | Se genera `codigo_invitacion: "ROOM-XXXX"` |
+| `es_habitable: false` | `codigo_invitacion: null` |
+| La vivienda no pertenece al casero logueado | `403 Forbidden` |
+| No se envía `nombre` | `400 Bad Request` |
+
+## Nota de base de datos
+
+Ejecutar `npx prisma db push` con `npx prisma dev` activo para sincronizar el schema con la BD.


### PR DESCRIPTION
…de invitación

- Enum TipoHabitacion (DORMITORIO, BANO, COCINA, SALON, OTRO) en schema.prisma
- Campos tipo, es_habitable, metros_cuadrados añadidos a Habitacion
- codigo_invitacion pasa a opcional: zonas comunes (es_habitable: false) tienen null
- src/utils/generarCodigo.ts: genera ROOM-XXXX único con retry ante colisión
- crearHabitacion: verifica ownership de vivienda (403), genera código solo si habitable
- Ruta protegida con verificarToken
- Actualiza docs/backend/api.md con la nueva sección de habitaciones