### PR TITLE
feat: oculta códigos de invitación con autenticación biométrica/PIN

### DIFF
--- a/docs/changelog/epica-2-issue-35-biometria-codigos.md
+++ b/docs/changelog/epica-2-issue-35-biometria-codigos.md
@@ -1,0 +1,28 @@
+# Épica 2 — Issue #35: Ocultar códigos de invitación con autenticación biométrica/PIN
+
+## Qué se hizo
+
+- Instalado `expo-local-authentication` (SDK 54 compatible)
+- Estado `codigosRevelados: Record<number, boolean>` — registra qué habitaciones tienen el código visible
+- Función `revelarCodigo(habitacionId)` — llama a `LocalAuthentication.authenticateAsync` y solo actualiza el estado si el resultado es `success: true`
+- Renderizado condicional por habitación:
+  - **No revelado**: muestra `••••••••` + "Toca para revelar" (Pressable que dispara la autenticación)
+  - **Revelado**: muestra el código real en `Courier New`
+- Nuevos estilos en `detalle.styles.ts`: `codigoOculto` y `revelarTexto`
+
+## Archivos modificados
+
+| Acción | Archivo |
+|---|---|
+| Modificado | `frontend/app/casero/vivienda/[id].tsx` |
+| Modificado | `frontend/styles/casero/vivienda/detalle.styles.ts` |
+
+## Comportamiento
+
+- Cada código se revela de forma independiente (tocar en uno no revela los demás)
+- Si la autenticación falla o el usuario cancela, el código permanece oculto
+- Al navegar fuera y volver, los códigos vuelven a estar ocultos (estado local, no persistido)
+
+## Nota
+
+`expo-local-authentication` usa Face ID / Touch ID en iOS y huella / PIN en Android. En el simulador de iOS la autenticación siempre falla (no hay biométrica); usar dispositivo físico o emulador Android para probar.

--- a/frontend/app/casero/vivienda/[id].tsx
+++ b/frontend/app/casero/vivienda/[id].tsx
@@ -1,6 +1,7 @@
 import { View, Text, ScrollView, Pressable } from 'react-native';
 import { useState } from 'react';
 import { useLocalSearchParams } from 'expo-router';
+import * as LocalAuthentication from 'expo-local-authentication';
 import { styles } from '@/styles/casero/vivienda/detalle.styles';
 
 type Habitacion = {
@@ -62,6 +63,16 @@ const MOCK_VIVIENDA: Vivienda = {
 export default function DetalleViviendaScreen() {
   const { id } = useLocalSearchParams();
   const [vivienda] = useState<Vivienda>(MOCK_VIVIENDA);
+  const [codigosRevelados, setCodigosRevelados] = useState<Record<number, boolean>>({});
+
+  const revelarCodigo = async (habitacionId: number) => {
+    const resultado = await LocalAuthentication.authenticateAsync({
+      promptMessage: 'Autentícate para ver el código de invitación',
+    });
+    if (resultado.success) {
+      setCodigosRevelados((prev) => ({ ...prev, [habitacionId]: true }));
+    }
+  };
 
   return (
     <View style={styles.container}>
@@ -78,7 +89,14 @@ export default function DetalleViviendaScreen() {
             {habitacion.es_habitable && habitacion.codigo_invitacion ? (
               <View style={styles.codigoContainer}>
                 <Text style={styles.codigoLabel}>Código de invitación</Text>
-                <Text style={styles.codigo}>{habitacion.codigo_invitacion}</Text>
+                {codigosRevelados[habitacion.id] ? (
+                  <Text style={styles.codigo}>{habitacion.codigo_invitacion}</Text>
+                ) : (
+                  <Pressable onPress={() => revelarCodigo(habitacion.id)}>
+                    <Text style={styles.codigoOculto}>••••••••</Text>
+                    <Text style={styles.revelarTexto}>Toca para revelar</Text>
+                  </Pressable>
+                )}
               </View>
             ) : (
               <Text style={styles.zonaComun}>Zona común · Sin código</Text>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "expo-haptics": "~15.0.8",
         "expo-image": "~3.0.11",
         "expo-linking": "~8.0.11",
+        "expo-local-authentication": "~17.0.8",
         "expo-router": "~6.0.23",
         "expo-splash-screen": "~31.0.13",
         "expo-status-bar": "~3.0.9",
@@ -6137,6 +6138,18 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-local-authentication": {
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/expo-local-authentication/-/expo-local-authentication-17.0.8.tgz",
+      "integrity": "sha512-Q5fXHhu6w3pVPlFCibU72SYIAN+9wX7QpFn9h49IUqs0Equ44QgswtGrxeh7fdnDqJrrYGPet5iBzjnE70uolA==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",
     "expo-linking": "~8.0.11",
+    "expo-local-authentication": "~17.0.8",
     "expo-router": "~6.0.23",
     "expo-splash-screen": "~31.0.13",
     "expo-status-bar": "~3.0.9",
@@ -31,11 +32,11 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.5",
     "react-native-gesture-handler": "~2.28.0",
-    "react-native-worklets": "0.5.1",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
-    "react-native-web": "~0.21.0"
+    "react-native-web": "~0.21.0",
+    "react-native-worklets": "0.5.1"
   },
   "devDependencies": {
     "@types/react": "~19.1.0",

--- a/frontend/styles/casero/vivienda/detalle.styles.ts
+++ b/frontend/styles/casero/vivienda/detalle.styles.ts
@@ -38,6 +38,14 @@ export const styles = StyleSheet.create({
     color: '#212529',
   },
   zonaComun: { fontSize: 13, color: '#9e9e9e', fontStyle: 'italic' },
+  codigoOculto: {
+    fontSize: 22,
+    letterSpacing: 4,
+    color: '#9e9e9e',
+    fontWeight: '700',
+    marginBottom: 4,
+  },
+  revelarTexto: { fontSize: 11, color: '#007AFF', marginTop: 2 },
   fab: {
     position: 'absolute',
     bottom: 24,


### PR DESCRIPTION
- expo-local-authentication instalado (SDK 54)
- Estado codigosRevelados por ID de habitación
- revelarCodigo(): autenticación biométrica antes de mostrar el código
- Códigos ocultos muestran •••••••• + "Toca para revelar"
- Nuevos estilos codigoOculto y revelarTexto en detalle.styles.ts