### PR TITLE
feat: añade endpoint PATCH /api/incidencias/:id/estado

### DIFF
--- a/backend/src/controllers/incidencia.controller.ts
+++ b/backend/src/controllers/incidencia.controller.ts
@@ -1,8 +1,9 @@
 import express from 'express';
 import { prisma } from '../lib/prisma';
-import { RolUsuario, PrioridadIncidencia } from '../generated/prisma/client';
+import { RolUsuario, EstadoIncidencia, PrioridadIncidencia } from '../generated/prisma/client';
 
 const PRIORIDADES_VALIDAS = Object.values(PrioridadIncidencia);
+const ESTADOS_VALIDOS = Object.values(EstadoIncidencia);
 
 export const crearIncidencia: express.RequestHandler = async (req, res) => {
   const { titulo, descripcion, vivienda_id, prioridad } = req.body as {
@@ -91,4 +92,50 @@ export const listarIncidencias: express.RequestHandler = async (req, res) => {
   });
 
   res.status(200).json(incidencias);
+};
+
+export const actualizarEstadoIncidencia: express.RequestHandler = async (req, res) => {
+  const id = parseInt(req.params['id'] as string, 10);
+  const { estado } = req.body as { estado: EstadoIncidencia };
+
+  if (!estado || !ESTADOS_VALIDOS.includes(estado)) {
+    res.status(400).json({ error: 'estado debe ser PENDIENTE, EN_PROCESO o RESUELTA.' });
+    return;
+  }
+
+  const incidencia = await prisma.incidencia.findUnique({
+    where: { id },
+    include: { vivienda: true },
+  });
+
+  if (!incidencia) {
+    res.status(404).json({ error: 'Incidencia no encontrada.' });
+    return;
+  }
+
+  const usuarioId = req.usuario!.id;
+  const rol = req.usuario!.rol;
+
+  if (rol === RolUsuario.CASERO) {
+    if (incidencia.vivienda.casero_id !== usuarioId) {
+      res.status(403).json({ error: 'No tienes permiso para modificar esta incidencia.' });
+      return;
+    }
+  } else {
+    // INQUILINO: debe tener habitación en la misma vivienda
+    const habitacion = await prisma.habitacion.findFirst({
+      where: { vivienda_id: incidencia.vivienda_id, inquilino_id: usuarioId },
+    });
+    if (!habitacion) {
+      res.status(403).json({ error: 'No tienes permiso para modificar esta incidencia.' });
+      return;
+    }
+  }
+
+  const incidenciaActualizada = await prisma.incidencia.update({
+    where: { id },
+    data: { estado },
+  });
+
+  res.status(200).json(incidenciaActualizada);
 };

--- a/backend/src/routes/incidencia.routes.ts
+++ b/backend/src/routes/incidencia.routes.ts
@@ -1,10 +1,11 @@
 import express from 'express';
 import { verificarToken } from '../middlewares/auth.middleware';
-import { crearIncidencia, listarIncidencias } from '../controllers/incidencia.controller';
+import { crearIncidencia, listarIncidencias, actualizarEstadoIncidencia } from '../controllers/incidencia.controller';
 
 const router = express.Router();
 
 router.get('/', verificarToken, listarIncidencias);
 router.post('/', verificarToken, crearIncidencia);
+router.patch('/:id/estado', verificarToken, actualizarEstadoIncidencia);
 
 export default router;

--- a/docs/changelog/epica-4-issue-19-patch-estado-incidencia.md
+++ b/docs/changelog/epica-4-issue-19-patch-estado-incidencia.md
@@ -1,0 +1,35 @@
+# Épica 4 — Issue #19: Endpoint PATCH /api/incidencias/:id/estado
+
+## Qué se hizo
+
+- Función `actualizarEstadoIncidencia` añadida a `src/controllers/incidencia.controller.ts`
+- Ruta `PATCH /api/incidencias/:id/estado` protegida con `verificarToken`
+- Sin cambios en el schema (el enum `EstadoIncidencia` ya existía)
+
+## Lógica
+
+1. Parsea `id` del param y `estado` del body
+2. Valida que `estado` sea `PENDIENTE`, `EN_PROCESO` o `RESUELTA` — 400 si es inválido
+3. Busca la incidencia con `include: { vivienda: true }` — 404 si no existe
+4. Autorización por rol:
+   - `CASERO`: debe ser propietario de la vivienda de la incidencia (`vivienda.casero_id === usuarioId`)
+   - `INQUILINO`: debe tener una habitación asignada en la misma vivienda (`findFirst { vivienda_id, inquilino_id }`)
+   - 403 si no cumple ninguna condición
+5. Actualiza con `prisma.incidencia.update` y devuelve la incidencia actualizada
+
+## Archivos modificados
+
+| Acción | Archivo |
+|---|---|
+| Modificado | `src/controllers/incidencia.controller.ts` — añade `actualizarEstadoIncidencia` + import de `EstadoIncidencia` |
+| Modificado | `src/routes/incidencia.routes.ts` — añade `PATCH /:id/estado` |
+
+## Respuestas del endpoint
+
+| Código | Condición |
+|---|---|
+| `200` | Estado actualizado. Devuelve la incidencia completa. |
+| `400` | `estado` ausente o valor fuera de enum. |
+| `401` | Sin token. |
+| `403` | CASERO no propietario, o INQUILINO sin habitación en esa vivienda. |
+| `404` | Incidencia no encontrada. |


### PR DESCRIPTION
- Valida que el estado sea PENDIENTE, EN_PROCESO o RESUELTA
- CASERO solo puede modificar incidencias de sus viviendas
- INQUILINO solo puede modificar incidencias de la vivienda donde tiene habitación asignada