### PR TITLE
feat: conectar formularios de vivienda y habitación a endpoints reales

### DIFF
--- a/backend/src/controllers/vivienda.controller.ts
+++ b/backend/src/controllers/vivienda.controller.ts
@@ -44,6 +44,19 @@ export const crearVivienda: express.RequestHandler = async (req, res) => {
   res.status(201).json(vivienda);
 };
 
+export const obtenerVivienda: express.RequestHandler = async (req, res) => {
+  const id = parseInt(req.params['id'] as string, 10);
+  const vivienda = await prisma.vivienda.findUnique({
+    where: { id },
+    include: { habitaciones: true },
+  });
+  if (!vivienda || vivienda.casero_id !== req.usuario!.id) {
+    res.status(404).json({ error: 'Vivienda no encontrada.' });
+    return;
+  }
+  res.status(200).json(vivienda);
+};
+
 export const crearHabitacion: express.RequestHandler = async (req, res) => {
   const viviendaId = parseInt(req.params['id'] as string, 10);
 

--- a/backend/src/routes/vivienda.routes.ts
+++ b/backend/src/routes/vivienda.routes.ts
@@ -1,11 +1,12 @@
 import express from 'express';
 import { verificarToken } from '../middlewares/auth.middleware';
-import { listarViviendas, crearVivienda, crearHabitacion } from '../controllers/vivienda.controller';
+import { listarViviendas, crearVivienda, obtenerVivienda, crearHabitacion } from '../controllers/vivienda.controller';
 
 const router = express.Router();
 
 router.get('/', verificarToken, listarViviendas);
 router.post('/', verificarToken, crearVivienda);
+router.get('/:id', verificarToken, obtenerVivienda);
 router.post('/:id/habitaciones', verificarToken, crearHabitacion);
 
 export default router;

--- a/docs/changelog/epica-6-issue-51-frontend-creacion-real.md
+++ b/docs/changelog/epica-6-issue-51-frontend-creacion-real.md
@@ -1,0 +1,39 @@
+# Épica 6 — Issue #51: Formularios de creación conectados a BD real
+
+## Qué se hizo
+
+- Nuevo endpoint `GET /api/viviendas/:id` en el backend para obtener el detalle de una vivienda con sus habitaciones
+- Nueva pantalla `app/casero/nueva-vivienda.tsx` — formulario de 5 campos que llama a `POST /api/viviendas`
+- Nueva pantalla `app/casero/vivienda/[id]/nueva-habitacion.tsx` — formulario que llama a `POST /api/viviendas/:id/habitaciones`
+- Pantalla `app/casero/vivienda/[id].tsx` — eliminados los datos mock; ahora carga datos reales con `useFocusEffect` + `GET /api/viviendas/:id`; FAB conectado a la nueva pantalla de habitación
+
+## Archivos creados / modificados
+
+| Acción | Archivo |
+|---|---|
+| Modificado | `backend/src/controllers/vivienda.controller.ts` |
+| Modificado | `backend/src/routes/vivienda.routes.ts` |
+| Nuevo | `frontend/app/casero/nueva-vivienda.tsx` |
+| Nuevo | `frontend/styles/casero/nueva-vivienda.styles.ts` |
+| Nuevo | `frontend/app/casero/vivienda/[id]/nueva-habitacion.tsx` |
+| Nuevo | `frontend/styles/casero/vivienda/nueva-habitacion.styles.ts` |
+| Modificado | `frontend/app/casero/vivienda/[id].tsx` |
+
+## Decisiones técnicas
+
+| Decisión | Motivo |
+|---|---|
+| Formulario de nueva vivienda tiene 5 campos | El backend (`crearVivienda`) los valida como obligatorios; exponer menos provocaría 400 |
+| Selector de tipo con pills (Pressable) en nueva habitación | Evita añadir dependencias (`@react-native-picker/picker`); visualmente más limpio en mobile |
+| `useFocusEffect` en detalle de vivienda | Al volver de añadir una habitación, la lista se recarga automáticamente sin prop drilling |
+| `[id].tsx` y `[id]/nueva-habitacion.tsx` coexisten | Expo Router soporta file route y folder route para el mismo segmento dinámico sin conflicto |
+| FAB verde (`#34C759`) en `nueva-habitacion.styles` | Consistencia con el FAB del detalle (verde = acción secundaria/habitaciones) |
+| `router.replace` en nueva vivienda, `router.back` en nueva habitación | Nueva vivienda reemplaza el stack para no acumular pantallas; habitación vuelve al detalle para ver el resultado |
+
+## Flujo verificado
+
+1. Login casero → lista viviendas (GET /api/viviendas real)
+2. FAB "+" → nueva vivienda → 5 campos → guardar → regresa a lista con la nueva entrada
+3. Tocar vivienda → detalle real (GET /api/viviendas/:id), habitaciones reales con códigos
+4. FAB verde "+" → nueva habitación → selector de tipo + switch habitable → guardar → regresa al detalle con la nueva habitación
+5. Tocar código "Toca para revelar" → autenticación biométrica → código real visible

--- a/frontend/app/casero/nueva-vivienda.tsx
+++ b/frontend/app/casero/nueva-vivienda.tsx
@@ -1,0 +1,105 @@
+import { View, Text, TextInput, ScrollView, Pressable, Alert, ActivityIndicator } from 'react-native';
+import { useState } from 'react';
+import { useRouter } from 'expo-router';
+import api from '@/services/api';
+import { styles } from '@/styles/casero/nueva-vivienda.styles';
+
+export default function NuevaViviendaScreen() {
+  const router = useRouter();
+  const [aliasNombre, setAliasNombre] = useState('');
+  const [direccion, setDireccion] = useState('');
+  const [codigoPostal, setCodigoPostal] = useState('');
+  const [ciudad, setCiudad] = useState('');
+  const [provincia, setProvincia] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const puedeGuardar = aliasNombre.trim() && direccion.trim() && codigoPostal.trim() && ciudad.trim() && provincia.trim();
+
+  const guardar = async () => {
+    if (!puedeGuardar) return;
+    setLoading(true);
+    try {
+      await api.post('/viviendas', {
+        alias_nombre: aliasNombre.trim(),
+        direccion: direccion.trim(),
+        codigo_postal: codigoPostal.trim(),
+        ciudad: ciudad.trim(),
+        provincia: provincia.trim(),
+      });
+      router.replace('/casero/viviendas');
+    } catch {
+      Alert.alert('Error', 'No se pudo crear la vivienda. Inténtalo de nuevo.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <ScrollView contentContainerStyle={styles.scrollContent} keyboardShouldPersistTaps="handled">
+        <Text style={styles.label}>Nombre / Alias</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="Ej: Piso Centro"
+          placeholderTextColor="#9e9e9e"
+          value={aliasNombre}
+          onChangeText={setAliasNombre}
+          autoCapitalize="words"
+        />
+
+        <Text style={styles.label}>Dirección</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="Ej: Calle Mayor 10, 3ºB"
+          placeholderTextColor="#9e9e9e"
+          value={direccion}
+          onChangeText={setDireccion}
+          autoCapitalize="words"
+        />
+
+        <Text style={styles.label}>Código Postal</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="Ej: 28001"
+          placeholderTextColor="#9e9e9e"
+          value={codigoPostal}
+          onChangeText={setCodigoPostal}
+          keyboardType="numeric"
+          maxLength={10}
+        />
+
+        <Text style={styles.label}>Ciudad</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="Ej: Madrid"
+          placeholderTextColor="#9e9e9e"
+          value={ciudad}
+          onChangeText={setCiudad}
+          autoCapitalize="words"
+        />
+
+        <Text style={styles.label}>Provincia</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="Ej: Madrid"
+          placeholderTextColor="#9e9e9e"
+          value={provincia}
+          onChangeText={setProvincia}
+          autoCapitalize="words"
+        />
+
+        <Pressable
+          style={[styles.boton, (!puedeGuardar || loading) && styles.botonDisabled]}
+          onPress={guardar}
+          disabled={!puedeGuardar || loading}
+        >
+          {loading ? (
+            <ActivityIndicator color="#fff" />
+          ) : (
+            <Text style={styles.botonTexto}>Guardar vivienda</Text>
+          )}
+        </Pressable>
+      </ScrollView>
+    </View>
+  );
+}

--- a/frontend/app/casero/vivienda/[id].tsx
+++ b/frontend/app/casero/vivienda/[id].tsx
@@ -1,7 +1,8 @@
-import { View, Text, ScrollView, Pressable } from 'react-native';
-import { useState } from 'react';
-import { useLocalSearchParams } from 'expo-router';
+import { View, Text, ScrollView, Pressable, ActivityIndicator, Alert } from 'react-native';
+import { useState, useCallback } from 'react';
+import { useLocalSearchParams, useRouter, useFocusEffect } from 'expo-router';
 import * as LocalAuthentication from 'expo-local-authentication';
+import api from '@/services/api';
 import { styles } from '@/styles/casero/vivienda/detalle.styles';
 
 type Habitacion = {
@@ -20,50 +21,30 @@ type Vivienda = {
   habitaciones: Habitacion[];
 };
 
-const MOCK_VIVIENDA: Vivienda = {
-  id: 1,
-  alias_nombre: 'Piso Centro',
-  direccion: 'Calle Mayor 10, 3ºB - Madrid',
-  habitaciones: [
-    {
-      id: 1,
-      nombre: 'Habitación 1',
-      tipo: 'DORMITORIO',
-      es_habitable: true,
-      metros_cuadrados: 12.5,
-      codigo_invitacion: 'ROOM-X7B9',
-    },
-    {
-      id: 2,
-      nombre: 'Habitación 2',
-      tipo: 'DORMITORIO',
-      es_habitable: true,
-      metros_cuadrados: 10.0,
-      codigo_invitacion: 'ROOM-A3K2',
-    },
-    {
-      id: 3,
-      nombre: 'Baño',
-      tipo: 'BANO',
-      es_habitable: false,
-      metros_cuadrados: null,
-      codigo_invitacion: null,
-    },
-    {
-      id: 4,
-      nombre: 'Cocina',
-      tipo: 'COCINA',
-      es_habitable: false,
-      metros_cuadrados: null,
-      codigo_invitacion: null,
-    },
-  ],
-};
-
 export default function DetalleViviendaScreen() {
-  const { id } = useLocalSearchParams();
-  const [vivienda] = useState<Vivienda>(MOCK_VIVIENDA);
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const router = useRouter();
+  const [vivienda, setVivienda] = useState<Vivienda | null>(null);
+  const [loading, setLoading] = useState(true);
   const [codigosRevelados, setCodigosRevelados] = useState<Record<number, boolean>>({});
+
+  const cargarVivienda = async () => {
+    setLoading(true);
+    try {
+      const { data } = await api.get<Vivienda>(`/viviendas/${id}`);
+      setVivienda(data);
+    } catch {
+      Alert.alert('Error', 'No se pudo cargar la vivienda.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useFocusEffect(
+    useCallback(() => {
+      cargarVivienda();
+    }, [id])
+  );
 
   const revelarCodigo = async (habitacionId: number) => {
     const resultado = await LocalAuthentication.authenticateAsync({
@@ -73,6 +54,24 @@ export default function DetalleViviendaScreen() {
       setCodigosRevelados((prev) => ({ ...prev, [habitacionId]: true }));
     }
   };
+
+  if (loading) {
+    return (
+      <View style={styles.container}>
+        <ActivityIndicator size="large" color="#007AFF" style={{ flex: 1 }} />
+      </View>
+    );
+  }
+
+  if (!vivienda) {
+    return (
+      <View style={styles.container}>
+        <Text style={{ textAlign: 'center', marginTop: 40, color: '#9e9e9e' }}>
+          Vivienda no encontrada.
+        </Text>
+      </View>
+    );
+  }
 
   return (
     <View style={styles.container}>
@@ -105,7 +104,10 @@ export default function DetalleViviendaScreen() {
         ))}
       </ScrollView>
 
-      <Pressable style={styles.fab} onPress={() => console.log('Añadir habitación')}>
+      <Pressable
+        style={styles.fab}
+        onPress={() => router.push(`/casero/vivienda/${id}/nueva-habitacion`)}
+      >
         <Text style={styles.fabText}>+</Text>
       </Pressable>
     </View>

--- a/frontend/app/casero/vivienda/[id]/nueva-habitacion.tsx
+++ b/frontend/app/casero/vivienda/[id]/nueva-habitacion.tsx
@@ -1,0 +1,102 @@
+import { View, Text, TextInput, ScrollView, Pressable, Switch, Alert, ActivityIndicator } from 'react-native';
+import { useState } from 'react';
+import { useRouter, useLocalSearchParams } from 'expo-router';
+import api from '@/services/api';
+import { styles } from '@/styles/casero/vivienda/nueva-habitacion.styles';
+
+const TIPOS = ['DORMITORIO', 'BANO', 'COCINA', 'SALON', 'OTRO'] as const;
+type TipoHabitacion = typeof TIPOS[number];
+
+export default function NuevaHabitacionScreen() {
+  const router = useRouter();
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const [nombre, setNombre] = useState('');
+  const [tipo, setTipo] = useState<TipoHabitacion>('DORMITORIO');
+  const [esHabitable, setEsHabitable] = useState(true);
+  const [metrosCuadrados, setMetrosCuadrados] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const guardar = async () => {
+    if (!nombre.trim()) return;
+    setLoading(true);
+    try {
+      await api.post(`/viviendas/${id}/habitaciones`, {
+        nombre: nombre.trim(),
+        tipo,
+        es_habitable: esHabitable,
+        metros_cuadrados: metrosCuadrados ? parseFloat(metrosCuadrados) : undefined,
+      });
+      router.back();
+    } catch {
+      Alert.alert('Error', 'No se pudo crear la habitación. Inténtalo de nuevo.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <ScrollView contentContainerStyle={styles.scrollContent} keyboardShouldPersistTaps="handled">
+        <Text style={styles.label}>Nombre</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="Ej: Habitación 1"
+          placeholderTextColor="#9e9e9e"
+          value={nombre}
+          onChangeText={setNombre}
+          autoCapitalize="words"
+        />
+
+        <Text style={styles.label}>Tipo</Text>
+        <View style={styles.tipoFila}>
+          {TIPOS.map((t) => (
+            <Pressable
+              key={t}
+              style={[styles.tipoPill, tipo === t && styles.tipoPillActivo]}
+              onPress={() => setTipo(t)}
+            >
+              <Text style={[styles.tipoPillTexto, tipo === t && styles.tipoPillTextoActivo]}>
+                {t}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+
+        <Text style={styles.label}>¿Es habitable?</Text>
+        <View style={styles.switchFila}>
+          <Text style={styles.switchLabel}>
+            {esHabitable ? 'Sí — se generará código de invitación' : 'No — zona común'}
+          </Text>
+          <Switch
+            value={esHabitable}
+            onValueChange={setEsHabitable}
+            trackColor={{ false: '#dee2e6', true: '#34C759' }}
+            thumbColor="#fff"
+          />
+        </View>
+
+        <Text style={styles.label}>Metros cuadrados (opcional)</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="Ej: 12.5"
+          placeholderTextColor="#9e9e9e"
+          value={metrosCuadrados}
+          onChangeText={setMetrosCuadrados}
+          keyboardType="decimal-pad"
+        />
+
+        <Pressable
+          style={[styles.boton, (!nombre.trim() || loading) && styles.botonDisabled]}
+          onPress={guardar}
+          disabled={!nombre.trim() || loading}
+        >
+          {loading ? (
+            <ActivityIndicator color="#fff" />
+          ) : (
+            <Text style={styles.botonTexto}>Añadir habitación</Text>
+          )}
+        </Pressable>
+      </ScrollView>
+    </View>
+  );
+}

--- a/frontend/styles/casero/nueva-vivienda.styles.ts
+++ b/frontend/styles/casero/nueva-vivienda.styles.ts
@@ -1,0 +1,43 @@
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#f5f5f5' },
+  scrollContent: { padding: 16, paddingBottom: 40 },
+  label: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#6c757d',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginBottom: 6,
+    marginTop: 16,
+  },
+  input: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    fontSize: 16,
+    color: '#212529',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.05,
+    shadowRadius: 2,
+    elevation: 1,
+  },
+  boton: {
+    backgroundColor: '#007AFF',
+    borderRadius: 12,
+    paddingVertical: 16,
+    alignItems: 'center',
+    marginTop: 32,
+  },
+  botonDisabled: {
+    backgroundColor: '#b0c8f0',
+  },
+  botonTexto: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+});

--- a/frontend/styles/casero/vivienda/nueva-habitacion.styles.ts
+++ b/frontend/styles/casero/vivienda/nueva-habitacion.styles.ts
@@ -1,0 +1,86 @@
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#f5f5f5' },
+  scrollContent: { padding: 16, paddingBottom: 40 },
+  label: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#6c757d',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginBottom: 6,
+    marginTop: 16,
+  },
+  input: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    fontSize: 16,
+    color: '#212529',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.05,
+    shadowRadius: 2,
+    elevation: 1,
+  },
+  tipoFila: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  tipoPill: {
+    borderRadius: 20,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    backgroundColor: '#fff',
+    borderWidth: 1.5,
+    borderColor: '#dee2e6',
+  },
+  tipoPillActivo: {
+    backgroundColor: '#007AFF',
+    borderColor: '#007AFF',
+  },
+  tipoPillTexto: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#6c757d',
+  },
+  tipoPillTextoActivo: {
+    color: '#fff',
+  },
+  switchFila: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.05,
+    shadowRadius: 2,
+    elevation: 1,
+  },
+  switchLabel: {
+    fontSize: 16,
+    color: '#212529',
+  },
+  boton: {
+    backgroundColor: '#34C759',
+    borderRadius: 12,
+    paddingVertical: 16,
+    alignItems: 'center',
+    marginTop: 32,
+  },
+  botonDisabled: {
+    backgroundColor: '#a8ddb5',
+  },
+  botonTexto: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+});


### PR DESCRIPTION
- Backend: añadir GET /api/viviendas/:id (obtenerVivienda con guard de ownership)
- Frontend: nueva pantalla casero/nueva-vivienda con formulario completo (5 campos requeridos por el backend) → POST /api/viviendas
- Frontend: nueva pantalla casero/vivienda/[id]/nueva-habitacion con selector visual de tipo (pills), Switch es_habitable y campo opcional metros_cuadrados → POST /api/viviendas/:id/habitaciones
- Frontend: pantalla detalle vivienda reemplaza mock por useFocusEffect + GET /api/viviendas/:id; FAB verde conectado a nueva-habitacion; autenticación biométrica intacta