### PR TITLE
feat: conectar canjear código del inquilino con POST /api/inquilino/u…

### DIFF
--- a/docs/changelog/epica-6-issue-52-frontend-inquilino-canjear-codigo.md
+++ b/docs/changelog/epica-6-issue-52-frontend-inquilino-canjear-codigo.md
@@ -1,0 +1,48 @@
+# Épica 6 — Issue #52: Inquilino canjea código conectando con endpoint real
+
+## Qué se hizo
+
+- Pantalla `app/inquilino/inicio.tsx` conectada a `POST /api/inquilino/unirse`
+- Estado `loading` para deshabilitar el botón y mostrar `ActivityIndicator` durante la petición
+- Estado `datosCasa` para almacenar `alias_nombre` de la vivienda y `nombre` de la habitación devueltos por el backend, sustituyendo los textos mockeados del dashboard
+- Botón deshabilitado también cuando el sufijo está vacío
+- Gestión de errores: los mensajes de error del backend (`error.response.data.error`) se muestran en un `Alert.alert` — cubre código inválido y habitación ya ocupada
+- Estilo `botonCanjearDisabled` añadido a `inicio.styles.ts`
+
+## Archivos modificados
+
+| Acción | Archivo |
+|---|---|
+| Modificado | `frontend/app/inquilino/inicio.tsx` |
+| Modificado | `frontend/styles/inquilino/inicio.styles.ts` |
+
+## Respuesta del backend
+
+`POST /api/inquilino/unirse` devuelve:
+```json
+{
+  "mensaje": "Te has unido a la habitación correctamente.",
+  "habitacion": {
+    "id": 1,
+    "nombre": "Habitación 1",
+    "vivienda": {
+      "alias_nombre": "Piso Centro",
+      ...
+    }
+  }
+}
+```
+
+Errores posibles (clave `error`):
+- `404` — `"Código de invitación inválido."`
+- `400` — `"Esta habitación ya está ocupada."`
+- `403` — `"Solo los inquilinos pueden unirse a una habitación."`
+
+## Decisiones técnicas
+
+| Decisión | Motivo |
+|---|---|
+| Botón deshabilitado con sufijo vacío | Evita peticiones innecesarias con código incompleto |
+| `err.response?.data?.error` para el mensaje | El backend usa la clave `error` en todos los errores, no `message` ni `mensaje` |
+| `datosCasa` como estado local | Suficiente para este issue; persistencia real se abordará cuando se implemente la carga del perfil del inquilino al arrancar |
+| `?? 'Mi vivienda'` como fallback en el dashboard | Guarda contra el edge case de `datosCasa` null si el estado se resetea |

--- a/frontend/app/inquilino/inicio.tsx
+++ b/frontend/app/inquilino/inicio.tsx
@@ -1,6 +1,7 @@
-import { View, Text, TextInput, FlatList, Pressable, ScrollView } from 'react-native';
+import { View, Text, TextInput, FlatList, Pressable, ScrollView, Alert, ActivityIndicator } from 'react-native';
 import { useState } from 'react';
 import { useRouter } from 'expo-router';
+import api from '@/services/api';
 import { styles, COLORES_PRIORIDAD, ETIQUETAS_ESTADO } from '@/styles/inquilino/inicio.styles';
 
 type Prioridad = 'VERDE' | 'AMARILLO' | 'ROJO';
@@ -13,6 +14,11 @@ type Incidencia = {
   prioridad: Prioridad;
   estado: Estado;
   fecha_creacion: string;
+};
+
+type DatosCasa = {
+  nombreVivienda: string;
+  nombreHabitacion: string;
 };
 
 const MOCK_INCIDENCIAS: Incidencia[] = [
@@ -46,6 +52,27 @@ export default function InquilinoInicioScreen() {
   const router = useRouter();
   const [tieneCasa, setTieneCasa] = useState(false);
   const [sufijo, setSufijo] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [datosCasa, setDatosCasa] = useState<DatosCasa | null>(null);
+
+  const handleCanjearCodigo = async () => {
+    setLoading(true);
+    try {
+      const { data } = await api.post('/inquilino/unirse', {
+        codigo_invitacion: `ROOM-${sufijo}`,
+      });
+      setDatosCasa({
+        nombreVivienda: data.habitacion.vivienda.alias_nombre,
+        nombreHabitacion: data.habitacion.nombre,
+      });
+      setTieneCasa(true);
+    } catch (err: any) {
+      const mensaje = err.response?.data?.error ?? 'No se pudo canjear el código. Inténtalo de nuevo.';
+      Alert.alert('Error', mensaje);
+    } finally {
+      setLoading(false);
+    }
+  };
 
   if (!tieneCasa) {
     return (
@@ -67,8 +94,16 @@ export default function InquilinoInicioScreen() {
             maxLength={6}
           />
         </View>
-        <Pressable style={styles.botonCanjear} onPress={() => setTieneCasa(true)}>
-          <Text style={styles.botonCanjearTexto}>Canjear Código</Text>
+        <Pressable
+          style={[styles.botonCanjear, (!sufijo.trim() || loading) && styles.botonCanjearDisabled]}
+          onPress={handleCanjearCodigo}
+          disabled={!sufijo.trim() || loading}
+        >
+          {loading ? (
+            <ActivityIndicator color="#fff" />
+          ) : (
+            <Text style={styles.botonCanjearTexto}>Canjear Código</Text>
+          )}
         </Pressable>
       </View>
     );
@@ -77,8 +112,8 @@ export default function InquilinoInicioScreen() {
   return (
     <View style={styles.dashboardContainer}>
       <ScrollView contentContainerStyle={styles.dashboardContent}>
-        <Text style={styles.bienvenida}>Piso Madrid</Text>
-        <Text style={styles.subtituloDashboard}>Habitación Principal</Text>
+        <Text style={styles.bienvenida}>{datosCasa?.nombreVivienda ?? 'Mi vivienda'}</Text>
+        <Text style={styles.subtituloDashboard}>{datosCasa?.nombreHabitacion ?? 'Mi habitación'}</Text>
 
         <Text style={styles.seccionTitulo}>Incidencias</Text>
 

--- a/frontend/styles/inquilino/inicio.styles.ts
+++ b/frontend/styles/inquilino/inicio.styles.ts
@@ -74,6 +74,9 @@ export const styles = StyleSheet.create({
     fontSize: 17,
     fontWeight: '700',
   },
+  botonCanjearDisabled: {
+    backgroundColor: '#b0c8f0',
+  },
 
   // — Dashboard (con casa) —
   dashboardContainer: {


### PR DESCRIPTION
…nirse

- Añadir handleCanjearCodigo con try/catch/finally y estado loading
- Mostrar ActivityIndicator en el botón durante la petición
- Guardar alias_nombre de vivienda y nombre de habitación en datosCasa para sustituir textos mock del dashboard
- Mostrar error del backend (código inválido, habitación ocupada) via Alert
- Deshabilitar botón con sufijo vacío o mientras carga