### PR TITLE
feat: autocompletado de direcciones con Mapbox Geocoding + ajustes Do…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,6 @@ JWT_SECRET=cambia_este_secreto
 
 # IP de tu máquina en la red Wi-Fi local (ipconfig → IPv4 del adaptador Wi-Fi)
 HOST_IP=192.168.1.X
+
+# Mapbox Geocoding — obtén tu token en https://account.mapbox.com
+EXPO_PUBLIC_MAPBOX_TOKEN=pk.ey...

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,9 +33,11 @@ services:
     build: ./frontend
     ports:
       - "8081:8081"
+    command: npx expo start --host lan --clear
     environment:
       EXPO_PUBLIC_API_URL: http://${HOST_IP}:3001/api
       REACT_NATIVE_PACKAGER_HOSTNAME: ${HOST_IP}
+      EXPO_PUBLIC_MAPBOX_TOKEN: ${EXPO_PUBLIC_MAPBOX_TOKEN}
     depends_on:
       - backend
     volumes:

--- a/docs/changelog/epica-5-issue-72-nominatim-autocompletado.md
+++ b/docs/changelog/epica-5-issue-72-nominatim-autocompletado.md
@@ -1,0 +1,50 @@
+# Épica 5 — Issue #72: Autocompletado de direcciones (Mapbox Geocoding)
+
+## Historial de decisiones
+
+| Iteración | API | Motivo del cambio |
+|---|---|---|
+| v1 | Nominatim (OpenStreetMap) | Rendimiento insuficiente — descartada |
+| v2 (actual) | Mapbox Geocoding API | Mayor precisión y velocidad |
+
+## Qué se hizo (v2 — Mapbox)
+
+- Integración de la API de Mapbox Geocoding en el formulario de nueva vivienda
+- Buscador con TextInput + botón "Buscar" que hace `fetch` a `api.mapbox.com/geocoding/v5/mapbox.places`
+- Búsqueda limitada a España (`country=es`) en español (`language=es`)
+- Lista de resultados con `feature.place_name`; al tocar uno rellena `direccion`, `ciudad`, `provincia` y `codigo_postal`
+- Los campos siguen siendo editables manualmente
+- Token leído de `EXPO_PUBLIC_MAPBOX_TOKEN` — Alert si no está configurado
+- Sin cambios en el backend — schema y controlador ya tenían los 5 campos
+
+## Archivos modificados
+
+| Acción | Archivo |
+|---|---|
+| Modificado | `frontend/app/casero/nueva-vivienda.tsx` |
+| Modificado | `.env` (añadida `EXPO_PUBLIC_MAPBOX_TOKEN`) |
+| Modificado | `.env.example` (añadida `EXPO_PUBLIC_MAPBOX_TOKEN`) |
+
+## Mapeo de campos Mapbox → Formulario
+
+| Campo formulario | Fuente en `feature` |
+|---|---|
+| `direccion` | `feature.text` + `feature.address` |
+| `ciudad` | `feature.context[].text` donde `id` empieza por `place` |
+| `provincia` | `feature.context[].text` donde `id` empieza por `region` |
+| `codigo_postal` | `feature.context[].text` donde `id` empieza por `postcode` |
+
+## Configuración necesaria
+
+1. Crear cuenta en [account.mapbox.com](https://account.mapbox.com)
+2. Obtener un token público (scope: `styles:read` + `geocoding:read`)
+3. Añadir en `.env`: `EXPO_PUBLIC_MAPBOX_TOKEN=pk.ey...`
+
+## Decisiones técnicas
+
+| Decisión | Motivo |
+|---|---|
+| `fetch` nativo en lugar de `api` Axios | Mapbox es externo — no debe pasar por el interceptor JWT |
+| `country=es` en la query | Limitar resultados a España para mayor precisión en el contexto del proyecto |
+| `EXPO_PUBLIC_` prefix | Expo requiere este prefijo para exponer variables de entorno al bundle del cliente |
+| Alert si falta el token | Feedback claro al desarrollador en lugar de error de red silencioso |

--- a/frontend/app/casero/nueva-vivienda.tsx
+++ b/frontend/app/casero/nueva-vivienda.tsx
@@ -4,8 +4,23 @@ import { useRouter } from 'expo-router';
 import api from '@/services/api';
 import { styles } from '@/styles/casero/nueva-vivienda.styles';
 
+type MapboxFeature = {
+  id: string;
+  place_name: string;
+  text: string;
+  address?: string;
+  context?: { id: string; text: string }[];
+};
+
 export default function NuevaViviendaScreen() {
   const router = useRouter();
+
+  // Buscador Mapbox
+  const [queryBusqueda, setQueryBusqueda] = useState('');
+  const [resultadosBusqueda, setResultadosBusqueda] = useState<MapboxFeature[]>([]);
+  const [buscandoDireccion, setBuscandoDireccion] = useState(false);
+
+  // Campos del formulario
   const [aliasNombre, setAliasNombre] = useState('');
   const [direccion, setDireccion] = useState('');
   const [codigoPostal, setCodigoPostal] = useState('');
@@ -14,6 +29,41 @@ export default function NuevaViviendaScreen() {
   const [loading, setLoading] = useState(false);
 
   const puedeGuardar = aliasNombre.trim() && direccion.trim() && codigoPostal.trim() && ciudad.trim() && provincia.trim();
+
+  const buscarDireccion = async () => {
+    if (!queryBusqueda.trim()) return;
+    const token = process.env.EXPO_PUBLIC_MAPBOX_TOKEN;
+    if (!token) {
+      Alert.alert('Configuración', 'Falta EXPO_PUBLIC_MAPBOX_TOKEN en las variables de entorno.');
+      return;
+    }
+    setBuscandoDireccion(true);
+    try {
+      const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(queryBusqueda)}.json?access_token=${token}&language=es&country=es`;
+      const respuesta = await fetch(url);
+      const datos = await respuesta.json();
+      setResultadosBusqueda(datos.features ?? []);
+    } catch {
+      Alert.alert('Error', 'No se pudo conectar con el buscador de direcciones.');
+    } finally {
+      setBuscandoDireccion(false);
+    }
+  };
+
+  const seleccionarDireccion = (feature: MapboxFeature) => {
+    const calle = feature.text ?? '';
+    const numero = feature.address ?? '';
+    setDireccion(numero ? `${calle} ${numero}`.trim() : calle);
+
+    for (const ctx of feature.context ?? []) {
+      if (ctx.id.startsWith('place')) setCiudad(ctx.text);
+      else if (ctx.id.startsWith('region')) setProvincia(ctx.text.replace(/^Provincia de /i, ''));
+      else if (ctx.id.startsWith('postcode')) setCodigoPostal(ctx.text);
+    }
+
+    setResultadosBusqueda([]);
+    setQueryBusqueda('');
+  };
 
   const guardar = async () => {
     if (!puedeGuardar) return;
@@ -37,6 +87,53 @@ export default function NuevaViviendaScreen() {
   return (
     <View style={styles.container}>
       <ScrollView contentContainerStyle={styles.scrollContent} keyboardShouldPersistTaps="handled">
+
+        {/* — Buscador Mapbox — */}
+        <Text style={styles.label}>Buscar dirección</Text>
+        <View style={styles.buscadorFila}>
+          <TextInput
+            style={styles.buscadorInput}
+            placeholder="Ej: Calle Mayor 10, Madrid"
+            placeholderTextColor="#9e9e9e"
+            value={queryBusqueda}
+            onChangeText={setQueryBusqueda}
+            autoCapitalize="none"
+            autoCorrect={false}
+            onSubmitEditing={buscarDireccion}
+            returnKeyType="search"
+          />
+          <Pressable
+            style={[styles.buscadorBoton, buscandoDireccion && styles.buscadorBotonDisabled]}
+            onPress={buscarDireccion}
+            disabled={buscandoDireccion}
+          >
+            {buscandoDireccion ? (
+              <ActivityIndicator color="#fff" size="small" />
+            ) : (
+              <Text style={styles.buscadorBotonTexto}>Buscar</Text>
+            )}
+          </Pressable>
+        </View>
+
+        {resultadosBusqueda.length > 0 && (
+          <View style={styles.resultadosContainer}>
+            {resultadosBusqueda.map((feature) => (
+              <Pressable
+                key={feature.id}
+                style={styles.resultadoItem}
+                onPress={() => seleccionarDireccion(feature)}
+              >
+                <Text style={styles.resultadoTexto} numberOfLines={2}>
+                  {feature.place_name}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+        )}
+
+        {/* — Campos manuales — */}
+        <Text style={styles.labelSeccion}>Revisa o edita los datos</Text>
+
         <Text style={styles.label}>Nombre / Alias</Text>
         <TextInput
           style={styles.input}

--- a/frontend/styles/casero/nueva-vivienda.styles.ts
+++ b/frontend/styles/casero/nueva-vivienda.styles.ts
@@ -3,6 +3,7 @@ import { StyleSheet } from 'react-native';
 export const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: '#f5f5f5' },
   scrollContent: { padding: 16, paddingBottom: 40 },
+
   label: {
     fontSize: 13,
     fontWeight: '600',
@@ -11,6 +12,15 @@ export const styles = StyleSheet.create({
     letterSpacing: 0.5,
     marginBottom: 6,
     marginTop: 16,
+  },
+  labelSeccion: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#9e9e9e',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginTop: 24,
+    marginBottom: 4,
   },
   input: {
     backgroundColor: '#fff',
@@ -25,6 +35,70 @@ export const styles = StyleSheet.create({
     shadowRadius: 2,
     elevation: 1,
   },
+
+  // — Buscador Nominatim —
+  buscadorFila: {
+    flexDirection: 'row',
+    gap: 8,
+    alignItems: 'center',
+  },
+  buscadorInput: {
+    flex: 1,
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    fontSize: 16,
+    color: '#212529',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.05,
+    shadowRadius: 2,
+    elevation: 1,
+  },
+  buscadorBoton: {
+    backgroundColor: '#007AFF',
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    justifyContent: 'center',
+    alignItems: 'center',
+    minWidth: 72,
+  },
+  buscadorBotonDisabled: {
+    backgroundColor: '#b0c8f0',
+  },
+  buscadorBotonTexto: {
+    color: '#fff',
+    fontSize: 15,
+    fontWeight: '700',
+  },
+
+  // — Lista de resultados —
+  resultadosContainer: {
+    marginTop: 6,
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    overflow: 'hidden',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.08,
+    shadowRadius: 4,
+    elevation: 3,
+  },
+  resultadoItem: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#f0f0f0',
+  },
+  resultadoTexto: {
+    fontSize: 14,
+    color: '#212529',
+    lineHeight: 20,
+  },
+
+  // — Botón guardar —
   boton: {
     backgroundColor: '#007AFF',
     borderRadius: 12,


### PR DESCRIPTION
…cker

- nueva-vivienda: buscador con fetch a mapbox.places, extracción de ciudad/provincia/CP desde feature.context, token desde EXPO_PUBLIC_MAPBOX_TOKEN
- docker-compose: puertos host cambiados (backend 3001, db 5433) para coexistir con otros proyectos
- docker-compose: EXPO_PUBLIC_MAPBOX_TOKEN inyectado al contenedor frontend; --clear en Metro para evitar caché de env vars
- frontend/.env: creado con EXPO_PUBLIC_API_URL y EXPO_PUBLIC_MAPBOX_TOKEN (cubierto por .gitignore)
- .env.example: documentada la variable EXPO_PUBLIC_MAPBOX_TOKEN