### PR TITLE
feat: copiar y compartir códigos de invitación con expo-clipboard y S…

### DIFF
--- a/docs/changelog/epica-5-issue-74-clipboard-share-codigos.md
+++ b/docs/changelog/epica-5-issue-74-clipboard-share-codigos.md
@@ -1,0 +1,37 @@
+# Épica 5 — Issue #74: Copiar y compartir códigos de invitación
+
+## Qué se hizo
+
+- Instalada la librería `expo-clipboard` para acceso al portapapeles nativo
+- Pantalla de detalle de vivienda (`app/casero/vivienda/[id].tsx`) actualizada con dos nuevas acciones sobre los códigos revelados:
+  - **Mantener pulsado** (`onLongPress`) sobre el código → copia al portapapeles + `Alert` de confirmación
+  - **Botón "Compartir"** → abre el sheet nativo de compartir de iOS/Android con el mensaje de invitación
+
+## Archivos modificados
+
+| Acción | Archivo |
+|---|---|
+| Modificado | `frontend/app/casero/vivienda/[id].tsx` |
+| Modificado | `frontend/styles/casero/vivienda/detalle.styles.ts` |
+
+## UX del código revelado
+
+```
+┌─────────────────────────────────────┐
+│ Código de invitación                │
+│ ┌───────────────────┐ ┌──────────┐  │
+│ │ ROOM-X7B9         │ │Compartir │  │
+│ │ Mantén pulsado... │ └──────────┘  │
+│ └───────────────────┘               │
+└─────────────────────────────────────┘
+```
+
+## Decisiones técnicas
+
+| Decisión | Motivo |
+|---|---|
+| `onLongPress` para copiar | Gesto estándar en mobile para copiar texto; no ocupa espacio visual extra |
+| `Share.share` nativo de react-native | No requiere dependencia extra; usa el sheet de sistema de iOS/Android |
+| Hint "Mantén pulsado para copiar" | Descubribilidad — el gesto long press no es obvio sin indicación |
+| Botón verde para compartir | Verde (`#34C759`) coherente con el FAB de añadir habitación; diferencia la acción de las de navegación (azul) |
+| `codigoReveladoFila` con `flexDirection: row` | Código y botón en la misma línea sin romper el layout del `codigoContainer` existente |

--- a/frontend/app/casero/vivienda/[id].tsx
+++ b/frontend/app/casero/vivienda/[id].tsx
@@ -1,7 +1,8 @@
-import { View, Text, ScrollView, Pressable, ActivityIndicator, Alert } from 'react-native';
+import { View, Text, ScrollView, Pressable, ActivityIndicator, Alert, Share } from 'react-native';
 import { useState, useCallback } from 'react';
 import { useLocalSearchParams, useRouter, useFocusEffect } from 'expo-router';
 import * as LocalAuthentication from 'expo-local-authentication';
+import * as Clipboard from 'expo-clipboard';
 import api from '@/services/api';
 import { styles } from '@/styles/casero/vivienda/detalle.styles';
 
@@ -55,6 +56,17 @@ export default function DetalleViviendaScreen() {
     }
   };
 
+  const copiarCodigo = async (codigo: string) => {
+    await Clipboard.setStringAsync(codigo);
+    Alert.alert('¡Copiado!', 'El código de invitación se ha guardado en el portapapeles.');
+  };
+
+  const compartirCodigo = async (codigo: string) => {
+    await Share.share({
+      message: `¡Únete a tu nueva habitación en Roomies! Tu código de invitación es: ${codigo}`,
+    });
+  };
+
   if (loading) {
     return (
       <View style={styles.container}>
@@ -66,9 +78,7 @@ export default function DetalleViviendaScreen() {
   if (!vivienda) {
     return (
       <View style={styles.container}>
-        <Text style={{ textAlign: 'center', marginTop: 40, color: '#9e9e9e' }}>
-          Vivienda no encontrada.
-        </Text>
+        <Text style={styles.errorTexto}>Vivienda no encontrada.</Text>
       </View>
     );
   }
@@ -89,7 +99,21 @@ export default function DetalleViviendaScreen() {
               <View style={styles.codigoContainer}>
                 <Text style={styles.codigoLabel}>Código de invitación</Text>
                 {codigosRevelados[habitacion.id] ? (
-                  <Text style={styles.codigo}>{habitacion.codigo_invitacion}</Text>
+                  <View style={styles.codigoReveladoFila}>
+                    <Pressable
+                      style={styles.codigoReveladoTextoArea}
+                      onLongPress={() => copiarCodigo(habitacion.codigo_invitacion!)}
+                    >
+                      <Text style={styles.codigo}>{habitacion.codigo_invitacion}</Text>
+                      <Text style={styles.codigoHint}>Mantén pulsado para copiar</Text>
+                    </Pressable>
+                    <Pressable
+                      style={styles.compartirBoton}
+                      onPress={() => compartirCodigo(habitacion.codigo_invitacion!)}
+                    >
+                      <Text style={styles.compartirBotonTexto}>Compartir</Text>
+                    </Pressable>
+                  </View>
                 ) : (
                   <Pressable onPress={() => revelarCodigo(habitacion.id)}>
                     <Text style={styles.codigoOculto}>••••••••</Text>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@react-navigation/native": "^7.1.8",
         "axios": "^1.14.0",
         "expo": "~54.0.33",
+        "expo-clipboard": "^55.0.9",
         "expo-constants": "~18.0.13",
         "expo-font": "~14.0.11",
         "expo-haptics": "~15.0.8",
@@ -6080,6 +6081,17 @@
         "@expo/image-utils": "^0.8.8",
         "expo-constants": "~18.0.12"
       },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-clipboard": {
+      "version": "55.0.9",
+      "resolved": "https://registry.npmjs.org/expo-clipboard/-/expo-clipboard-55.0.9.tgz",
+      "integrity": "sha512-WJ9ougE8fEDu3/RV5Vz3gE5aNgnj1C0WByXCz3WUj8y/06bJyaIUDMq8FDLv3n0AO3guiErmkUunsD0EzSDUUw==",
+      "license": "MIT",
       "peerDependencies": {
         "expo": "*",
         "react": "*",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "@react-navigation/native": "^7.1.8",
     "axios": "^1.14.0",
     "expo": "~54.0.33",
+    "expo-clipboard": "^55.0.9",
     "expo-constants": "~18.0.13",
     "expo-font": "~14.0.11",
     "expo-haptics": "~15.0.8",

--- a/frontend/styles/casero/vivienda/detalle.styles.ts
+++ b/frontend/styles/casero/vivienda/detalle.styles.ts
@@ -38,6 +38,31 @@ export const styles = StyleSheet.create({
     color: '#212529',
   },
   zonaComun: { fontSize: 13, color: '#9e9e9e', fontStyle: 'italic' },
+  errorTexto: { textAlign: 'center', marginTop: 40, color: '#9e9e9e' },
+  codigoReveladoFila: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  codigoReveladoTextoArea: {
+    flex: 1,
+  },
+  codigoHint: {
+    fontSize: 10,
+    color: '#9e9e9e',
+    marginTop: 2,
+  },
+  compartirBoton: {
+    backgroundColor: '#34C759',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  compartirBotonTexto: {
+    color: '#fff',
+    fontSize: 12,
+    fontWeight: '700',
+  },
   codigoOculto: {
     fontSize: 22,
     letterSpacing: 4,


### PR DESCRIPTION
…hare nativo

- Long press sobre código revelado copia al portapapeles y muestra Alert de confirmación
- Botón "Compartir" abre sheet nativo de iOS/Android con mensaje de invitación
- Hint visual "Mantén pulsado para copiar" bajo el código