### PR TITLE
feat: pantalla de perfil con datos reales y cierre de sesión

### DIFF
--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -34,6 +34,18 @@ export const register: express.RequestHandler = async (req, res) => {
   res.status(201).json(usuarioSinPassword);
 };
 
+export const obtenerMiPerfil: express.RequestHandler = async (req, res) => {
+  const usuario = await prisma.usuario.findUnique({
+    where: { id: req.usuario!.id },
+    select: { id: true, nombre: true, apellidos: true, email: true, rol: true, telefono: true },
+  });
+  if (!usuario) {
+    res.status(404).json({ error: 'Usuario no encontrado.' });
+    return;
+  }
+  res.status(200).json(usuario);
+};
+
 export const login: express.RequestHandler = async (req, res) => {
   const { email, password } = req.body as { email: string; password: string };
 

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -1,13 +1,11 @@
 import express from 'express';
-import { register, login } from '../controllers/auth.controller';
+import { register, login, obtenerMiPerfil } from '../controllers/auth.controller';
 import { verificarToken } from '../middlewares/auth.middleware';
 
 const router = express.Router();
 
 router.post('/register', register);
 router.post('/login', login);
-router.get('/me', verificarToken, (req, res) => {
-  res.status(200).json(req.usuario);
-});
+router.get('/me', verificarToken, obtenerMiPerfil);
 
 export default router;

--- a/docs/changelog/epica-5-issue-75-perfil-logout.md
+++ b/docs/changelog/epica-5-issue-75-perfil-logout.md
@@ -1,0 +1,32 @@
+# Épica 5 — Issue #75: Pantalla de Perfil y Cierre de Sesión
+
+## Qué se hizo
+
+- Nuevo handler `obtenerMiPerfil` en el backend que consulta la BD y devuelve nombre, apellidos, email, rol y teléfono (sin password_hash)
+- `GET /auth/me` actualizado para usar `obtenerMiPerfil` en lugar del inline handler que solo devolvía `{ id, rol }` del JWT
+- Nueva pantalla `app/perfil.tsx` con avatar (inicial del nombre), badge de rol (azul/verde), tarjetas de datos y botón "Cerrar Sesión"
+- Logout llama a `eliminarToken()` y hace `router.replace('/')` (sin posibilidad de volver atrás)
+- Icono `person-circle-outline` (Ionicons) en la esquina superior derecha de `casero/viviendas.tsx` y en el dashboard de `inquilino/inicio.tsx`
+
+## Archivos modificados / creados
+
+| Acción | Archivo |
+|---|---|
+| Modificado | `backend/src/controllers/auth.controller.ts` |
+| Modificado | `backend/src/routes/auth.routes.ts` |
+| Creado | `frontend/app/perfil.tsx` |
+| Creado | `frontend/styles/perfil.styles.ts` |
+| Modificado | `frontend/app/casero/viviendas.tsx` |
+| Modificado | `frontend/styles/casero/viviendas.styles.ts` |
+| Modificado | `frontend/app/inquilino/inicio.tsx` |
+| Modificado | `frontend/styles/inquilino/inicio.styles.ts` |
+
+## Decisiones técnicas
+
+| Decisión | Motivo |
+|---|---|
+| `router.replace('/')` en logout | Elimina la pantalla de perfil del stack — el usuario no puede volver atrás con el botón de retroceso tras cerrar sesión |
+| Avatar con inicial del nombre | No requiere librerías de imágenes ni uploads; identifica visualmente al usuario |
+| Badge azul CASERO / verde INQUILINO | Colores coherentes con el resto del sistema (FAB azul = casero, FAB verde = acciones de habitación) |
+| Icono en posición absoluta (zIndex: 10) | No altera el layout de la FlatList ni del ScrollView existentes |
+| Icono solo en dashboard del inquilino (no en onboarding) | En onboarding el usuario aún no tiene sesión activa efectiva; el perfil no es relevante en ese estado |

--- a/frontend/app/casero/viviendas.tsx
+++ b/frontend/app/casero/viviendas.tsx
@@ -1,6 +1,7 @@
 import { View, Text, FlatList, Pressable, ActivityIndicator, Alert } from 'react-native';
 import { useState, useCallback } from 'react';
 import { useRouter, useFocusEffect } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
 import { styles } from '@/styles/casero/viviendas.styles';
 import api from '@/services/api';
 
@@ -45,6 +46,9 @@ export default function ViviendasScreen() {
 
   return (
     <View style={styles.container}>
+      <Pressable style={styles.iconoPerfil} onPress={() => router.push('/perfil')}>
+        <Ionicons name="person-circle-outline" size={32} color="#007AFF" />
+      </Pressable>
       <FlatList
         data={viviendas}
         keyExtractor={(item) => item.id.toString()}

--- a/frontend/app/inquilino/inicio.tsx
+++ b/frontend/app/inquilino/inicio.tsx
@@ -1,6 +1,7 @@
 import { View, Text, TextInput, FlatList, Pressable, ScrollView, Alert, ActivityIndicator } from 'react-native';
 import { useState, useCallback } from 'react';
 import { useRouter, useFocusEffect } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
 import api from '@/services/api';
 import { styles, COLORES_PRIORIDAD, ETIQUETAS_ESTADO } from '@/styles/inquilino/inicio.styles';
 
@@ -112,6 +113,9 @@ export default function InquilinoInicioScreen() {
 
   return (
     <View style={styles.dashboardContainer}>
+      <Pressable style={styles.iconoPerfil} onPress={() => router.push('/perfil')}>
+        <Ionicons name="person-circle-outline" size={32} color="#007AFF" />
+      </Pressable>
       <ScrollView contentContainerStyle={styles.dashboardContent}>
         <Text style={styles.bienvenida}>{datosCasa?.nombreVivienda ?? 'Mi vivienda'}</Text>
         <Text style={styles.subtituloDashboard}>{datosCasa?.nombreHabitacion ?? 'Mi habitación'}</Text>

--- a/frontend/app/perfil.tsx
+++ b/frontend/app/perfil.tsx
@@ -1,0 +1,96 @@
+import { View, Text, ScrollView, Pressable, ActivityIndicator, Alert } from 'react-native';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'expo-router';
+import api from '@/services/api';
+import { eliminarToken } from '@/services/auth.service';
+import { styles } from '@/styles/perfil.styles';
+
+type Perfil = {
+  id: number;
+  nombre: string;
+  apellidos: string;
+  email: string;
+  rol: 'CASERO' | 'INQUILINO';
+  telefono: string | null;
+};
+
+export default function PerfilScreen() {
+  const router = useRouter();
+  const [perfil, setPerfil] = useState<Perfil | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const cargar = async () => {
+      try {
+        const { data } = await api.get<Perfil>('/auth/me');
+        setPerfil(data);
+      } catch {
+        Alert.alert('Error', 'No se pudo cargar el perfil.');
+      } finally {
+        setLoading(false);
+      }
+    };
+    cargar();
+  }, []);
+
+  const cerrarSesion = async () => {
+    await eliminarToken();
+    router.replace('/');
+  };
+
+  if (loading) {
+    return (
+      <View style={styles.loaderContainer}>
+        <ActivityIndicator size="large" color="#007AFF" />
+      </View>
+    );
+  }
+
+  if (!perfil) {
+    return (
+      <View style={styles.loaderContainer}>
+        <Text>No se pudo cargar el perfil.</Text>
+      </View>
+    );
+  }
+
+  const inicial = perfil.nombre.charAt(0).toUpperCase();
+  const esCasero = perfil.rol === 'CASERO';
+
+  return (
+    <View style={styles.container}>
+      <ScrollView contentContainerStyle={styles.scrollContent}>
+        <View style={styles.avatar}>
+          <Text style={styles.avatarTexto}>{inicial}</Text>
+        </View>
+
+        <Text style={styles.nombreCompleto}>{perfil.nombre} {perfil.apellidos}</Text>
+
+        <View style={[styles.badge, esCasero ? styles.badgeCasero : styles.badgeInquilino]}>
+          <Text style={styles.badgeTexto}>{esCasero ? 'Casero' : 'Inquilino'}</Text>
+        </View>
+
+        <View style={styles.tarjeta}>
+          <Text style={styles.tarjetaLabel}>Email</Text>
+          <Text style={styles.tarjetaValor}>{perfil.email}</Text>
+        </View>
+
+        {perfil.telefono ? (
+          <View style={styles.tarjeta}>
+            <Text style={styles.tarjetaLabel}>Teléfono</Text>
+            <Text style={styles.tarjetaValor}>{perfil.telefono}</Text>
+          </View>
+        ) : null}
+
+        <View style={styles.tarjeta}>
+          <Text style={styles.tarjetaLabel}>Rol</Text>
+          <Text style={styles.tarjetaValor}>{esCasero ? 'Propietario / Casero' : 'Inquilino'}</Text>
+        </View>
+
+        <Pressable style={styles.botonLogout} onPress={cerrarSesion}>
+          <Text style={styles.botonLogoutTexto}>Cerrar Sesión</Text>
+        </Pressable>
+      </ScrollView>
+    </View>
+  );
+}

--- a/frontend/styles/casero/viviendas.styles.ts
+++ b/frontend/styles/casero/viviendas.styles.ts
@@ -37,4 +37,10 @@ export const styles = StyleSheet.create({
     elevation: 8,
   },
   fabText: { color: '#fff', fontSize: 32, lineHeight: 36, fontWeight: '300' },
+  iconoPerfil: {
+    position: 'absolute',
+    top: 16,
+    right: 16,
+    zIndex: 10,
+  },
 });

--- a/frontend/styles/inquilino/inicio.styles.ts
+++ b/frontend/styles/inquilino/inicio.styles.ts
@@ -166,6 +166,14 @@ export const styles = StyleSheet.create({
     color: '#c7c7cc',
   },
 
+  // — Icono perfil —
+  iconoPerfil: {
+    position: 'absolute',
+    top: 16,
+    right: 16,
+    zIndex: 10,
+  },
+
   // — FAB —
   fab: {
     position: 'absolute',

--- a/frontend/styles/perfil.styles.ts
+++ b/frontend/styles/perfil.styles.ts
@@ -1,0 +1,94 @@
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#f5f5f5' },
+  loaderContainer: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  scrollContent: { padding: 24, paddingBottom: 48, alignItems: 'center' },
+
+  // — Avatar —
+  avatar: {
+    width: 88,
+    height: 88,
+    borderRadius: 44,
+    backgroundColor: '#007AFF',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: 12,
+    shadowColor: '#007AFF',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.3,
+    shadowRadius: 8,
+    elevation: 6,
+  },
+  avatarTexto: {
+    color: '#fff',
+    fontSize: 36,
+    fontWeight: '700',
+  },
+  nombreCompleto: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: '#212529',
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+
+  // — Badge de rol —
+  badge: {
+    borderRadius: 20,
+    paddingHorizontal: 16,
+    paddingVertical: 6,
+    marginBottom: 28,
+  },
+  badgeCasero: { backgroundColor: '#007AFF' },
+  badgeInquilino: { backgroundColor: '#34C759' },
+  badgeTexto: { color: '#fff', fontSize: 13, fontWeight: '700' },
+
+  // — Tarjetas de datos —
+  tarjeta: {
+    width: '100%',
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    marginBottom: 10,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.05,
+    shadowRadius: 2,
+    elevation: 1,
+  },
+  tarjetaLabel: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: '#9e9e9e',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginBottom: 4,
+  },
+  tarjetaValor: {
+    fontSize: 16,
+    color: '#212529',
+    fontWeight: '500',
+  },
+
+  // — Botón logout —
+  botonLogout: {
+    width: '100%',
+    backgroundColor: '#FF3B30',
+    borderRadius: 12,
+    paddingVertical: 16,
+    alignItems: 'center',
+    marginTop: 28,
+    shadowColor: '#FF3B30',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.25,
+    shadowRadius: 6,
+    elevation: 4,
+  },
+  botonLogoutTexto: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+});


### PR DESCRIPTION
- Backend: obtenerMiPerfil consulta la BD en GET /auth/me (antes devolvía solo id/rol del JWT)
- Frontend: nueva pantalla /perfil con avatar, badge de rol (azul/verde), tarjetas y botón "Cerrar Sesión"
- Logout llama a eliminarToken() + router.replace('/') sin posibilidad de volver atrás
- Icono person-circle-outline (Ionicons) en viviendas del casero y dashboard del inquilino