### PR TITLE
Add mensualidades engine and recurring expense cron jobs

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -77,6 +77,7 @@ model Usuario {
   turnos_limpieza    TurnoLimpieza[]
   asignaciones_fijas AsignacionLimpiezaFija[]
   gastos_pagados     Gasto[]
+  gastos_recurrentes_pagados GastoRecurrente[]
   deudas_a_pagar     Deuda[]                  @relation("DeudorDeuda")
   deudas_a_cobrar    Deuda[]                  @relation("AcreedorDeuda")
 }
@@ -95,6 +96,7 @@ model Vivienda {
   anuncios         Anuncio[]
   zonas_limpieza   ZonaLimpieza[]
   gastos           Gasto[]
+  gastos_recurrentes GastoRecurrente[]
   items_inventario ItemInventario[]
 }
 
@@ -151,6 +153,18 @@ model Gasto {
   vivienda_id    Int
   vivienda       Vivienda @relation(fields: [vivienda_id], references: [id])
   deudas         Deuda[]
+}
+
+model GastoRecurrente {
+  id          Int      @id @default(autoincrement())
+  concepto    String
+  importe     Float
+  dia_del_mes Int
+  vivienda_id Int
+  vivienda    Vivienda @relation(fields: [vivienda_id], references: [id])
+  pagador_id  Int
+  pagador     Usuario  @relation(fields: [pagador_id], references: [id])
+  activo      Boolean  @default(true)
 }
 
 model Deuda {

--- a/backend/src/controllers/gasto-recurrente.controller.ts
+++ b/backend/src/controllers/gasto-recurrente.controller.ts
@@ -1,0 +1,85 @@
+import express from 'express';
+import { prisma } from '../lib/prisma';
+import { usuarioPerteneceAVivienda } from '../services/gasto.service';
+
+const obtenerParamNumerico = (valor: string | string[] | undefined) => {
+  const normalizado = Array.isArray(valor) ? valor[0] : valor;
+
+  if (!normalizado) {
+    return NaN;
+  }
+
+  return parseInt(normalizado, 10);
+};
+
+export const listarGastosRecurrentes: express.RequestHandler = async (req, res) => {
+  const viviendaId = obtenerParamNumerico(req.params.viviendaId);
+  const usuarioId = req.usuario!.id;
+
+  if (!Number.isInteger(viviendaId) || viviendaId <= 0) {
+    res.status(400).json({ error: 'viviendaId inválido.' });
+    return;
+  }
+
+  const pertenece = await usuarioPerteneceAVivienda(viviendaId, usuarioId);
+  if (!pertenece) {
+    res.status(403).json({ error: 'No perteneces a esta vivienda.' });
+    return;
+  }
+
+  const gastosRecurrentes = await prisma.gastoRecurrente.findMany({
+    where: { vivienda_id: viviendaId },
+    orderBy: [{ activo: 'desc' }, { dia_del_mes: 'asc' }, { id: 'desc' }],
+    include: {
+      pagador: { select: { id: true, nombre: true, apellidos: true } },
+    },
+  });
+
+  res.status(200).json(gastosRecurrentes);
+};
+
+export const crearGastoRecurrente: express.RequestHandler = async (req, res) => {
+  const viviendaId = obtenerParamNumerico(req.params.viviendaId);
+  const pagadorId = req.usuario!.id;
+  const { concepto, importe, dia_del_mes } = req.body as {
+    concepto: string;
+    importe: number;
+    dia_del_mes: number;
+  };
+
+  if (!Number.isInteger(viviendaId) || viviendaId <= 0) {
+    res.status(400).json({ error: 'viviendaId inválido.' });
+    return;
+  }
+
+  if (!concepto?.trim() || typeof importe !== 'number' || importe <= 0) {
+    res.status(400).json({ error: 'concepto e importe (> 0) son obligatorios.' });
+    return;
+  }
+
+  if (!Number.isInteger(dia_del_mes) || dia_del_mes < 1 || dia_del_mes > 31) {
+    res.status(400).json({ error: 'dia_del_mes debe ser un entero entre 1 y 31.' });
+    return;
+  }
+
+  const pertenece = await usuarioPerteneceAVivienda(viviendaId, pagadorId);
+  if (!pertenece) {
+    res.status(403).json({ error: 'No perteneces a esta vivienda.' });
+    return;
+  }
+
+  const gastoRecurrente = await prisma.gastoRecurrente.create({
+    data: {
+      concepto: concepto.trim(),
+      importe,
+      dia_del_mes,
+      vivienda_id: viviendaId,
+      pagador_id: pagadorId,
+    },
+    include: {
+      pagador: { select: { id: true, nombre: true, apellidos: true } },
+    },
+  });
+
+  res.status(201).json(gastoRecurrente);
+};

--- a/backend/src/controllers/gasto.controller.ts
+++ b/backend/src/controllers/gasto.controller.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import { prisma } from '../lib/prisma';
+import { crearGastoDividido, usuarioPerteneceAVivienda } from '../services/gasto.service';
 
 const obtenerParamNumerico = (valor: string | string[] | undefined) => {
   const normalizado = Array.isArray(valor) ? valor[0] : valor;
@@ -20,9 +21,7 @@ export const listarGastos: express.RequestHandler = async (req, res) => {
     return;
   }
 
-  const pertenece = await prisma.habitacion.findFirst({
-    where: { vivienda_id: viviendaId, inquilino_id: usuarioId },
-  });
+  const pertenece = await usuarioPerteneceAVivienda(viviendaId, usuarioId);
 
   if (!pertenece) {
     res.status(403).json({ error: 'No perteneces a esta vivienda.' });
@@ -50,9 +49,7 @@ export const listarDeudas: express.RequestHandler = async (req, res) => {
     return;
   }
 
-  const pertenece = await prisma.habitacion.findFirst({
-    where: { vivienda_id: viviendaId, inquilino_id: usuarioId },
-  });
+  const pertenece = await usuarioPerteneceAVivienda(viviendaId, usuarioId);
 
   if (!pertenece) {
     res.status(403).json({ error: 'No perteneces a esta vivienda.' });
@@ -90,9 +87,7 @@ export const saldarDeuda: express.RequestHandler = async (req, res) => {
     return;
   }
 
-  const pertenece = await prisma.habitacion.findFirst({
-    where: { vivienda_id: viviendaId, inquilino_id: usuarioId },
-  });
+  const pertenece = await usuarioPerteneceAVivienda(viviendaId, usuarioId);
 
   if (!pertenece) {
     res.status(403).json({ error: 'No perteneces a esta vivienda.' });
@@ -155,71 +150,25 @@ export const crearGasto: express.RequestHandler = async (req, res) => {
   }
 
   // Verificar que el pagador pertenece a la vivienda (es inquilino de alguna habitación)
-  const habitacionPagador = await prisma.habitacion.findFirst({
-    where: { vivienda_id: viviendaId, inquilino_id: pagadorId },
-  });
+  const habitacionPagador = await usuarioPerteneceAVivienda(viviendaId, pagadorId);
 
   if (!habitacionPagador) {
     res.status(403).json({ error: 'No perteneces a esta vivienda.' });
     return;
   }
 
-  // Obtener todos los inquilinos activos de la vivienda
-  const habitaciones = await prisma.habitacion.findMany({
-    where: {
-      vivienda_id: viviendaId,
-      inquilino_id: { not: null },
-      es_habitable: true,
-    },
-    select: {
-      inquilino_id: true,
-    },
-  });
+  try {
+    const gasto = await crearGastoDividido({
+      concepto,
+      importe,
+      viviendaId,
+      pagadorId,
+      implicadosIds,
+    });
 
-  const inquilinosActivosIds = habitaciones.map((h) => h.inquilino_id!);
-  const inquilinosActivosSet = new Set(inquilinosActivosIds);
-  const implicadosNormalizados = Array.isArray(implicadosIds)
-    ? [...new Set(implicadosIds)]
-    : [];
-
-  if (implicadosNormalizados.length > 0) {
-    const hayInvalidos = implicadosNormalizados.some((id) => !inquilinosActivosSet.has(id));
-    if (hayInvalidos) {
-      res.status(400).json({ error: 'Todos los implicados deben pertenecer a la vivienda.' });
-      return;
-    }
+    res.status(201).json(gasto);
+  } catch (error) {
+    const mensaje = error instanceof Error ? error.message : 'No se pudo registrar el gasto.';
+    res.status(400).json({ error: mensaje });
   }
-
-  const participantesIds =
-    implicadosNormalizados.length > 0 ? implicadosNormalizados : inquilinosActivosIds;
-
-  const totalParticipantes = participantesIds.length;
-  if (totalParticipantes === 0) {
-    res.status(400).json({ error: 'No hay inquilinos activos para repartir este gasto.' });
-    return;
-  }
-
-  const deudoresIds = participantesIds.filter((id) => id !== pagadorId);
-  const importePorPersona = parseFloat((importe / totalParticipantes).toFixed(2));
-
-  const [gasto] = await prisma.$transaction([
-    prisma.gasto.create({
-      data: {
-        concepto,
-        importe,
-        pagador_id: pagadorId,
-        vivienda_id: viviendaId,
-        deudas: {
-          create: deudoresIds.map((deudorId) => ({
-            deudor_id: deudorId,
-            acreedor_id: pagadorId,
-            importe: importePorPersona,
-          })),
-        },
-      },
-      include: { deudas: true },
-    }),
-  ]);
-
-  res.status(201).json(gasto);
 };

--- a/backend/src/cron/mensualidades.cron.ts
+++ b/backend/src/cron/mensualidades.cron.ts
@@ -1,0 +1,57 @@
+import cron from 'node-cron';
+import { prisma } from '../lib/prisma';
+import { crearGastoDividido } from '../services/gasto.service';
+
+let cronMensualidadesIniciado = false;
+
+export const procesarMensualidadesDelDia = async () => {
+  const diaActual = new Date().getDate();
+
+  const gastosRecurrentes = await prisma.gastoRecurrente.findMany({
+    where: {
+      activo: true,
+      dia_del_mes: diaActual,
+    },
+  });
+
+  if (gastosRecurrentes.length === 0) {
+    console.log(`[cron] No hay mensualidades pendientes para el día ${diaActual}.`);
+    return;
+  }
+
+  console.log(`[cron] Procesando ${gastosRecurrentes.length} mensualidad(es) del día ${diaActual}.`);
+
+  for (const gastoRecurrente of gastosRecurrentes) {
+    try {
+      await crearGastoDividido({
+        concepto: gastoRecurrente.concepto,
+        importe: gastoRecurrente.importe,
+        viviendaId: gastoRecurrente.vivienda_id,
+        pagadorId: gastoRecurrente.pagador_id,
+      });
+
+      console.log(
+        `[cron] Mensualidad ${gastoRecurrente.id} convertida en gasto para vivienda ${gastoRecurrente.vivienda_id}.`,
+      );
+    } catch (error) {
+      console.error(
+        `[cron] Error procesando mensualidad ${gastoRecurrente.id}:`,
+        error,
+      );
+    }
+  }
+};
+
+export const iniciarCronMensualidades = () => {
+  if (cronMensualidadesIniciado) {
+    return;
+  }
+
+  cron.schedule('0 2 * * *', async () => {
+    console.log('[cron] Ejecutando motor de mensualidades...');
+    await procesarMensualidadesDelDia();
+  });
+
+  cronMensualidadesIniciado = true;
+  console.log('[cron] Motor de mensualidades programado para las 02:00.');
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -8,9 +8,11 @@ import incidenciaRoutes from './routes/incidencia.routes';
 import anuncioRoutes from './routes/anuncio.routes';
 import limpiezaRoutes from './routes/limpieza.routes';
 import gastoRoutes from './routes/gasto.routes';
+import gastoRecurrenteRoutes from './routes/gasto-recurrente.routes';
 import userRoutes from './routes/user.routes';
 import inventarioRoutes from './routes/inventario.routes';
 import './services/cron.service';
+import { iniciarCronMensualidades } from './cron/mensualidades.cron';
 
 const app = express();
 const PORT = 3000;
@@ -29,8 +31,11 @@ app.use('/api/incidencias', incidenciaRoutes);
 app.use('/api/anuncios', anuncioRoutes);
 app.use('/api/viviendas', limpiezaRoutes);
 app.use('/api/viviendas', gastoRoutes);
+app.use('/api/viviendas', gastoRecurrenteRoutes);
 app.use('/api', inventarioRoutes);
 app.use('/api/users', userRoutes);
+
+iniciarCronMensualidades();
 
 app.listen(PORT, () => {
   console.log(`Server running on http://localhost:${PORT}`);

--- a/backend/src/routes/gasto-recurrente.routes.ts
+++ b/backend/src/routes/gasto-recurrente.routes.ts
@@ -1,0 +1,13 @@
+import express from 'express';
+import { verificarToken } from '../middlewares/auth.middleware';
+import {
+  crearGastoRecurrente,
+  listarGastosRecurrentes,
+} from '../controllers/gasto-recurrente.controller';
+
+const router = express.Router();
+
+router.get('/:viviendaId/gastos-recurrentes', verificarToken, listarGastosRecurrentes);
+router.post('/:viviendaId/gastos-recurrentes', verificarToken, crearGastoRecurrente);
+
+export default router;

--- a/backend/src/services/gasto.service.ts
+++ b/backend/src/services/gasto.service.ts
@@ -1,0 +1,84 @@
+import { prisma } from '../lib/prisma';
+
+type CrearGastoDivididoInput = {
+  concepto: string;
+  importe: number;
+  viviendaId: number;
+  pagadorId: number;
+  implicadosIds?: number[];
+};
+
+export const usuarioPerteneceAVivienda = async (viviendaId: number, usuarioId: number) => {
+  return prisma.habitacion.findFirst({
+    where: { vivienda_id: viviendaId, inquilino_id: usuarioId },
+    select: { id: true },
+  });
+};
+
+export const obtenerInquilinosActivosIds = async (viviendaId: number) => {
+  const habitaciones = await prisma.habitacion.findMany({
+    where: {
+      vivienda_id: viviendaId,
+      inquilino_id: { not: null },
+      es_habitable: true,
+      inquilino: { estado_presencia: 'ACTIVO' },
+    },
+    select: {
+      inquilino_id: true,
+    },
+  });
+
+  return habitaciones.map((habitacion) => habitacion.inquilino_id!);
+};
+
+export const crearGastoDividido = async ({
+  concepto,
+  importe,
+  viviendaId,
+  pagadorId,
+  implicadosIds,
+}: CrearGastoDivididoInput) => {
+  const inquilinosActivosIds = await obtenerInquilinosActivosIds(viviendaId);
+  const inquilinosActivosSet = new Set(inquilinosActivosIds);
+  const implicadosNormalizados = Array.isArray(implicadosIds)
+    ? [...new Set(implicadosIds)]
+    : [];
+
+  if (implicadosNormalizados.length > 0) {
+    const hayInvalidos = implicadosNormalizados.some((id) => !inquilinosActivosSet.has(id));
+    if (hayInvalidos) {
+      throw new Error('Todos los implicados deben pertenecer a la vivienda.');
+    }
+  }
+
+  if (!inquilinosActivosSet.has(pagadorId)) {
+    throw new Error('El pagador debe pertenecer a la vivienda como inquilino activo.');
+  }
+
+  const participantesIds =
+    implicadosNormalizados.length > 0 ? implicadosNormalizados : inquilinosActivosIds;
+
+  if (participantesIds.length === 0) {
+    throw new Error('No hay inquilinos activos para repartir este gasto.');
+  }
+
+  const deudoresIds = participantesIds.filter((id) => id !== pagadorId);
+  const importePorPersona = parseFloat((importe / participantesIds.length).toFixed(2));
+
+  return prisma.gasto.create({
+    data: {
+      concepto,
+      importe,
+      pagador_id: pagadorId,
+      vivienda_id: viviendaId,
+      deudas: {
+        create: deudoresIds.map((deudorId) => ({
+          deudor_id: deudorId,
+          acreedor_id: pagadorId,
+          importe: importePorPersona,
+        })),
+      },
+    },
+    include: { deudas: true },
+  });
+};

--- a/docs/changelog/epica-12-issue-195-mensualidades-cronjobs.md
+++ b/docs/changelog/epica-12-issue-195-mensualidades-cronjobs.md
@@ -1,0 +1,21 @@
+# Issue #195 — Motor de mensualidades y cronjobs
+
+**Fecha:** 2026-04-10
+**Epica:** 12
+
+## Cambios tecnicos
+
+- `backend/prisma/schema.prisma`: se anade el modelo `GastoRecurrente` con sus claves foraneas a `Vivienda` y `Usuario`, y se crean las relaciones inversas en `Usuario` y `Vivienda`.
+- `backend/src/services/gasto.service.ts`: se extrae la logica reutilizable para validar pertenencia a vivienda, obtener inquilinos activos y crear gastos con reparto equitativo de deudas.
+- `backend/src/controllers/gasto.controller.ts`: el alta de gastos puntuales pasa a reutilizar el nuevo servicio compartido.
+- `backend/src/controllers/gasto-recurrente.controller.ts`: se crean los endpoints para listar y registrar gastos recurrentes por vivienda.
+- `backend/src/routes/gasto-recurrente.routes.ts`: se registran las rutas `GET /:viviendaId/gastos-recurrentes` y `POST /:viviendaId/gastos-recurrentes`.
+- `backend/src/cron/mensualidades.cron.ts`: se crea el cron diario de las 02:00 que busca mensualidades activas del dia y las transforma en registros normales de `Gasto`.
+- `backend/src/index.ts`: se inicializa el nuevo cron de mensualidades y se monta el router de gastos recurrentes.
+- `frontend/app/inquilino/(tabs)/gastos.tsx`: se anade la carga de mensualidades activas, una seccion visible de "Gastos Fijos / Mensualidades" y un modal para crear nuevas suscripciones.
+- `frontend/styles/inquilino/gastos.styles.ts`: se incorporan estilos para la nueva seccion, tarjetas de mensualidades y banner informativo del modal.
+
+## Resultado tecnico observable
+
+- El backend puede persistir suscripciones mensuales y convertirlas automaticamente en gastos repartidos entre inquilinos activos cuando coincide el dia del mes.
+- La app de inquilino puede consultar mensualidades activas y crear nuevas sin salir de la pestaña de gastos.

--- a/frontend/app/inquilino/(tabs)/gastos.tsx
+++ b/frontend/app/inquilino/(tabs)/gastos.tsx
@@ -18,8 +18,6 @@ import { useFocusEffect } from 'expo-router';
 import api from '@/services/api';
 import { styles } from '@/styles/inquilino/gastos.styles';
 
-// ── Tipos ─────────────────────────────────────────────────────────────────────
-
 type UsuarioBasico = { id: number; nombre: string; apellidos: string | null };
 
 type HabitacionVivienda = {
@@ -51,7 +49,15 @@ type Gasto = {
   deudas: Omit<Deuda, 'deudor' | 'acreedor' | 'gasto'>[];
 };
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
+type GastoRecurrente = {
+  id: number;
+  concepto: string;
+  importe: number;
+  dia_del_mes: number;
+  activo: boolean;
+  pagador_id: number;
+  pagador: UsuarioBasico;
+};
 
 const AvatarInitials = ({
   nombre,
@@ -88,18 +94,16 @@ const formatFecha = (iso: string) =>
 const formatImporte = (n: number) =>
   n.toLocaleString('es-ES', { style: 'currency', currency: 'EUR' });
 
-// ─────────────────────────────────────────────────────────────────────────────
-
 export default function GastosInquilinoTab() {
   const [viviendaId, setViviendaId] = useState<number | null>(null);
   const [miId, setMiId] = useState<number | null>(null);
   const [companerosPiso, setCompanerosPiso] = useState<UsuarioBasico[]>([]);
   const [gastos, setGastos] = useState<Gasto[]>([]);
   const [deudas, setDeudas] = useState<Deuda[]>([]);
+  const [gastosRecurrentes, setGastosRecurrentes] = useState<GastoRecurrente[]>([]);
   const [loading, setLoading] = useState(true);
   const [saldando, setSaldando] = useState<number | null>(null);
 
-  // Modal
   const [modalVisible, setModalVisible] = useState(false);
   const [concepto, setConcepto] = useState('');
   const [importe, setImporte] = useState('');
@@ -108,18 +112,31 @@ export default function GastosInquilinoTab() {
   const [importeFocused, setImporteFocused] = useState(false);
   const [implicadosSeleccionados, setImplicadosSeleccionados] = useState<number[]>([]);
 
-  // ── Carga de datos ────────────────────────────────────────────────────────
+  const [mensualidadModalVisible, setMensualidadModalVisible] = useState(false);
+  const [conceptoMensualidad, setConceptoMensualidad] = useState('');
+  const [importeMensualidad, setImporteMensualidad] = useState('');
+  const [diaMensualidad, setDiaMensualidad] = useState('');
+  const [guardandoMensualidad, setGuardandoMensualidad] = useState(false);
+  const [conceptoMensualidadFocused, setConceptoMensualidadFocused] = useState(false);
+  const [importeMensualidadFocused, setImporteMensualidadFocused] = useState(false);
+  const [diaMensualidadFocused, setDiaMensualidadFocused] = useState(false);
 
   const cargarTodo = useCallback(async (vId: number) => {
     try {
-      const [{ data: gastosData }, { data: deudasData }] = await Promise.all([
-        api.get<Gasto[]>(`/viviendas/${vId}/gastos`),
-        api.get<Deuda[]>(`/viviendas/${vId}/deudas`),
-      ]);
+      const [{ data: gastosData }, { data: deudasData }, { data: recurrentesData }] =
+        await Promise.all([
+          api.get<Gasto[]>(`/viviendas/${vId}/gastos`),
+          api.get<Deuda[]>(`/viviendas/${vId}/deudas`),
+          api.get<GastoRecurrente[]>(`/viviendas/${vId}/gastos-recurrentes`),
+        ]);
+
       setGastos(gastosData);
       setDeudas(deudasData);
+      setGastosRecurrentes(recurrentesData);
     } catch {
-      // Feed vacío — se muestra empty state
+      setGastos([]);
+      setDeudas([]);
+      setGastosRecurrentes([]);
     }
   }, []);
 
@@ -132,70 +149,83 @@ export default function GastosInquilinoTab() {
         try {
           const { data: viviendaData } = await api.get<{
             miHabitacionId: number;
-            vivienda: any;
+            vivienda: {
+              id: number;
+              habitaciones: HabitacionVivienda[];
+            };
           }>('/inquilino/vivienda');
 
-          const vId: number = viviendaData.vivienda.id;
+          const vId = viviendaData.vivienda.id;
           const miHab = viviendaData.vivienda.habitaciones.find(
-            (h: any) => h.id === viviendaData.miHabitacionId
+            (habitacion) => habitacion.id === viviendaData.miHabitacionId,
           );
-          const uId: number = miHab?.inquilino?.id ?? 0;
-          const participantes = (viviendaData.vivienda.habitaciones as HabitacionVivienda[])
-            .filter((h) => h.tipo === 'DORMITORIO' && h.inquilino !== null)
-            .map((h) => h.inquilino!);
+          const uId = miHab?.inquilino?.id ?? 0;
+          const participantes = viviendaData.vivienda.habitaciones
+            .filter((habitacion) => habitacion.tipo === 'DORMITORIO' && habitacion.inquilino !== null)
+            .map((habitacion) => habitacion.inquilino!);
 
           if (!activo) return;
+
           setViviendaId(vId);
           setMiId(uId);
           setCompanerosPiso(participantes);
           setImplicadosSeleccionados(participantes.map((inquilino) => inquilino.id));
           await cargarTodo(vId);
         } catch {
-          // Sin vivienda
+          if (!activo) return;
+          setViviendaId(null);
+          setMiId(null);
+          setCompanerosPiso([]);
+          setImplicadosSeleccionados([]);
+          setGastos([]);
+          setDeudas([]);
+          setGastosRecurrentes([]);
         } finally {
           if (activo) setLoading(false);
         }
       };
 
       inicializar();
-      return () => { activo = false; };
-    }, [cargarTodo])
+      return () => {
+        activo = false;
+      };
+    }, [cargarTodo]),
   );
-
-  // ── Balance desde deudas PENDIENTE ───────────────────────────────────────
 
   const calcularBalance = (): number => {
     if (!miId) return 0;
-    let bal = 0;
-    for (const d of deudas) {
-      if (d.estado === 'PAGADA') continue;
-      if (d.acreedor_id === miId) bal += d.importe;
-      if (d.deudor_id === miId)   bal -= d.importe;
+
+    let balance = 0;
+    for (const deuda of deudas) {
+      if (deuda.estado === 'PAGADA') continue;
+      if (deuda.acreedor_id === miId) balance += deuda.importe;
+      if (deuda.deudor_id === miId) balance -= deuda.importe;
     }
-    return bal;
+
+    return balance;
   };
 
-  const deudoasPendientes = deudas.filter((d) => d.estado === 'PENDIENTE');
-
-  // ── Saldar deuda ──────────────────────────────────────────────────────────
+  const deudasPendientes = deudas.filter((deuda) => deuda.estado === 'PENDIENTE');
+  const mensualidadesActivas = gastosRecurrentes.filter((gasto) => gasto.activo);
 
   const handleSaldar = (deuda: Deuda) => {
     Alert.alert(
-      '¿Confirmar pago?',
-      `¿Has hecho ya el Bizum o transferencia de ${formatImporte(deuda.importe)} a ${deuda.acreedor.nombre}?`,
+      'Confirmar pago',
+      `Has hecho ya el Bizum o transferencia de ${formatImporte(deuda.importe)} a ${deuda.acreedor.nombre}?`,
       [
-        { text: 'Aún no', style: 'cancel' },
+        { text: 'Aun no', style: 'cancel' },
         {
-          text: 'Sí, ya lo hice',
+          text: 'Si, ya lo hice',
           onPress: async () => {
             if (!viviendaId) return;
+
             setSaldando(deuda.id);
             try {
               await api.patch(`/viviendas/${viviendaId}/deudas/${deuda.id}/saldar`);
               await cargarTodo(viviendaId);
               Toast.show({
                 type: 'success',
-                text1: '¡Deuda saldada!',
+                text1: 'Deuda saldada',
                 text2: `${formatImporte(deuda.importe)} marcados como pagados.`,
               });
             } catch (err: any) {
@@ -208,23 +238,24 @@ export default function GastosInquilinoTab() {
             }
           },
         },
-      ]
+      ],
     );
   };
 
-  // ── Guardar nuevo gasto ───────────────────────────────────────────────────
-
   const handleGuardar = async () => {
     if (!concepto.trim() || !importe.trim() || !viviendaId) return;
+
     if (implicadosSeleccionados.length === 0) {
       Toast.show({ type: 'error', text1: 'Selecciona al menos un participante para el gasto.' });
       return;
     }
+
     const importeNum = parseFloat(importe.replace(',', '.'));
     if (isNaN(importeNum) || importeNum <= 0) {
-      Toast.show({ type: 'error', text1: 'Introduce un importe válido mayor que 0.' });
+      Toast.show({ type: 'error', text1: 'Introduce un importe valido mayor que 0.' });
       return;
     }
+
     setGuardando(true);
     try {
       await api.post(`/viviendas/${viviendaId}/gastos`, {
@@ -236,7 +267,7 @@ export default function GastosInquilinoTab() {
       cerrarModal();
       Toast.show({
         type: 'success',
-        text1: '¡Gasto registrado!',
+        text1: 'Gasto registrado',
         text2: `${concepto.trim()} · ${formatImporte(importeNum)}`,
       });
     } catch (err: any) {
@@ -265,8 +296,64 @@ export default function GastosInquilinoTab() {
     setImplicadosSeleccionados((actuales) =>
       actuales.includes(inquilinoId)
         ? actuales.filter((id) => id !== inquilinoId)
-        : [...actuales, inquilinoId]
+        : [...actuales, inquilinoId],
     );
+  };
+
+  const cerrarModalMensualidad = () => {
+    setMensualidadModalVisible(false);
+    setConceptoMensualidad('');
+    setImporteMensualidad('');
+    setDiaMensualidad('');
+  };
+
+  const abrirModalMensualidad = () => {
+    setMensualidadModalVisible(true);
+  };
+
+  const handleGuardarMensualidad = async () => {
+    if (!viviendaId) return;
+
+    const importeNum = parseFloat(importeMensualidad.replace(',', '.'));
+    const diaNum = parseInt(diaMensualidad, 10);
+
+    if (!conceptoMensualidad.trim()) {
+      Toast.show({ type: 'error', text1: 'Indica un concepto para la mensualidad.' });
+      return;
+    }
+
+    if (isNaN(importeNum) || importeNum <= 0) {
+      Toast.show({ type: 'error', text1: 'Introduce un importe valido mayor que 0.' });
+      return;
+    }
+
+    if (!Number.isInteger(diaNum) || diaNum < 1 || diaNum > 31) {
+      Toast.show({ type: 'error', text1: 'El dia del mes debe estar entre 1 y 31.' });
+      return;
+    }
+
+    setGuardandoMensualidad(true);
+    try {
+      await api.post(`/viviendas/${viviendaId}/gastos-recurrentes`, {
+        concepto: conceptoMensualidad.trim(),
+        importe: importeNum,
+        dia_del_mes: diaNum,
+      });
+      await cargarTodo(viviendaId);
+      cerrarModalMensualidad();
+      Toast.show({
+        type: 'success',
+        text1: 'Mensualidad creada',
+        text2: `${conceptoMensualidad.trim()} · ${formatImporte(importeNum)} · Dia ${diaNum}`,
+      });
+    } catch (err: any) {
+      Toast.show({
+        type: 'error',
+        text1: err.response?.data?.error ?? 'No se pudo crear la mensualidad.',
+      });
+    } finally {
+      setGuardandoMensualidad(false);
+    }
   };
 
   const puedeGuardar =
@@ -274,7 +361,10 @@ export default function GastosInquilinoTab() {
     importe.trim().length > 0 &&
     implicadosSeleccionados.length > 0;
 
-  // ── Loading ───────────────────────────────────────────────────────────────
+  const puedeGuardarMensualidad =
+    conceptoMensualidad.trim().length > 0 &&
+    importeMensualidad.trim().length > 0 &&
+    diaMensualidad.trim().length > 0;
 
   if (loading) {
     return <ActivityIndicator style={{ flex: 1 }} size="large" color={Theme.colors.primary} />;
@@ -282,22 +372,19 @@ export default function GastosInquilinoTab() {
 
   const balance = calcularBalance();
   const debeMas = balance < 0;
-  const heroColor      = debeMas ? Theme.colors.danger : Theme.colors.success;
+  const heroColor = debeMas ? Theme.colors.danger : Theme.colors.success;
   const heroBackground = balance === 0 ? Theme.colors.surface2 : Theme.colors.surface;
-  const heroBadgeBackground = balance === 0
-    ? Theme.colors.surface2
-    : debeMas
-    ? Theme.colors.dangerLight
-    : Theme.colors.successLight;
-  const heroLabel      = debeMas ? 'Debes al grupo' : balance === 0 ? 'Estás al día' : 'Te deben';
-
-  // ── Render ────────────────────────────────────────────────────────────────
+  const heroBadgeBackground =
+    balance === 0
+      ? Theme.colors.surface2
+      : debeMas
+        ? Theme.colors.dangerLight
+        : Theme.colors.successLight;
+  const heroLabel = debeMas ? 'Debes al grupo' : balance === 0 ? 'Estas al dia' : 'Te deben';
 
   return (
     <View style={styles.container}>
       <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
-
-        {/* ── Cabecera ── */}
         <View style={styles.header}>
           <Text style={styles.headerEtiqueta}>Gastos comunes</Text>
           <Text style={styles.headerTitulo}>Balance del piso</Text>
@@ -306,51 +393,53 @@ export default function GastosInquilinoTab() {
           </Text>
         </View>
 
-        {/* ── Hero Card Balance ── */}
-        <View style={[styles.heroCard, { backgroundColor: heroBackground }]}> 
+        <View style={[styles.heroCard, { backgroundColor: heroBackground }]}>
           <View style={[styles.heroEtiquetaBadge, { backgroundColor: heroBadgeBackground }]}>
-            <Text style={[styles.heroEtiqueta, { color: heroColor }]}>
-              {heroLabel.toUpperCase()}
-            </Text>
+            <Text style={[styles.heroEtiqueta, { color: heroColor }]}>{heroLabel.toUpperCase()}</Text>
           </View>
           <Text style={[styles.heroImporte, { color: heroColor }]}>
             {formatImporte(Math.abs(balance))}
           </Text>
           <Text style={styles.heroDescripcion}>
             {debeMas
-              ? 'Tienes deudas pendientes con tus compañeros'
+              ? 'Tienes deudas pendientes con tus companeros'
               : balance === 0
-              ? 'No tienes deudas pendientes'
-              : 'Tus compañeros te deben dinero'}
+                ? 'No tienes deudas pendientes'
+                : 'Tus companeros te deben dinero'}
           </Text>
         </View>
 
-        {/* ── Sección Deudas Pendientes ── */}
-        {deudoasPendientes.length > 0 && (
+        {deudasPendientes.length > 0 && (
           <>
             <Text style={styles.seccionTitulo}>Deudas pendientes</Text>
-            {deudoasPendientes.map((d) => {
-              const yoDebo = d.deudor_id === miId;
-              const companero = yoDebo ? d.acreedor : d.deudor;
+            {deudasPendientes.map((deuda) => {
+              const yoDebo = deuda.deudor_id === miId;
+              const companero = yoDebo ? deuda.acreedor : deuda.deudor;
               const amountColor = yoDebo ? Theme.colors.danger : Theme.colors.success;
-              const statusBackground = yoDebo ? Theme.colors.dangerLight : Theme.colors.successLight;
+              const statusBackground = yoDebo
+                ? Theme.colors.dangerLight
+                : Theme.colors.successLight;
               const statusText = yoDebo ? Theme.colors.danger : Theme.colors.success;
 
               return (
-                <View key={d.id} style={styles.deudaCard}>
-                  <AvatarInitials nombre={companero.nombre} apellidos={companero.apellidos} size={52} />
+                <View key={deuda.id} style={styles.deudaCard}>
+                  <AvatarInitials
+                    nombre={companero.nombre}
+                    apellidos={companero.apellidos}
+                    size={52}
+                  />
                   <View style={styles.deudaInfo}>
                     <Text style={styles.deudaNombre} numberOfLines={1}>
                       {companero.nombre}
                       {companero.apellidos ? ` ${companero.apellidos}` : ''}
                     </Text>
                     <Text style={styles.deudaConcepto} numberOfLines={2}>
-                      {d.gasto.concepto}
+                      {deuda.gasto.concepto}
                     </Text>
                   </View>
                   <View style={styles.deudaMeta}>
                     <Text style={[styles.deudaImporte, { color: amountColor }]}>
-                      {formatImporte(d.importe)}
+                      {formatImporte(deuda.importe)}
                     </Text>
 
                     {yoDebo ? (
@@ -359,14 +448,14 @@ export default function GastosInquilinoTab() {
                           styles.botonSaldar,
                           { backgroundColor: statusBackground },
                           pressed && styles.botonSaldarPressed,
-                          saldando === d.id && { opacity: 0.6 },
+                          saldando === deuda.id && { opacity: 0.6 },
                         ]}
-                        onPress={() => handleSaldar(d)}
-                        disabled={saldando === d.id}
-                        accessibilityLabel={`Saldar deuda de ${formatImporte(d.importe)} con ${companero.nombre}`}
+                        onPress={() => handleSaldar(deuda)}
+                        disabled={saldando === deuda.id}
+                        accessibilityLabel={`Saldar deuda de ${formatImporte(deuda.importe)} con ${companero.nombre}`}
                         accessibilityRole="button"
                       >
-                        {saldando === d.id ? (
+                        {saldando === deuda.id ? (
                           <ActivityIndicator size="small" color={statusText} />
                         ) : (
                           <Text style={[styles.botonSaldarTexto, { color: statusText }]}>Saldar</Text>
@@ -375,7 +464,9 @@ export default function GastosInquilinoTab() {
                     ) : (
                       <View style={[styles.badgeEsperando, { backgroundColor: statusBackground }]}>
                         <Ionicons name="time-outline" size={13} color={statusText} />
-                        <Text style={[styles.badgeEsperandoTexto, { color: statusText }]}>Esperando</Text>
+                        <Text style={[styles.badgeEsperandoTexto, { color: statusText }]}>
+                          Esperando
+                        </Text>
                       </View>
                     )}
                   </View>
@@ -385,30 +476,80 @@ export default function GastosInquilinoTab() {
           </>
         )}
 
-        {/* ── Feed de movimientos ── */}
+        <View style={styles.seccionHeaderRow}>
+          <View style={styles.seccionHeaderTextos}>
+            <Text style={styles.seccionTitulo}>Gastos Fijos / Mensualidades</Text>
+            <Text style={styles.seccionDescripcion}>
+              Suscripciones activas que el backend genera automaticamente cada mes.
+            </Text>
+          </View>
+          <Pressable
+            style={({ pressed }) => [styles.botonSecundario, pressed && styles.botonPressed]}
+            onPress={abrirModalMensualidad}
+            accessibilityLabel="Crear nuevo gasto fijo o mensualidad"
+            accessibilityRole="button"
+          >
+            <Ionicons name="repeat-outline" size={16} color={Theme.colors.primary} />
+            <Text style={styles.botonSecundarioTexto}>Nueva</Text>
+          </Pressable>
+        </View>
+
+        {mensualidadesActivas.length === 0 ? (
+          <View style={styles.mensualidadEmptyCard}>
+            <View style={styles.mensualidadEmptyIcon}>
+              <Ionicons name="calendar-outline" size={22} color={Theme.colors.primary} />
+            </View>
+            <View style={styles.mensualidadEmptyTextos}>
+              <Text style={styles.mensualidadEmptyTitulo}>Aun no hay mensualidades activas</Text>
+              <Text style={styles.mensualidadEmptySubtitulo}>
+                Crea alquiler, internet o suministros para que el cron los convierta en gastos
+                normales.
+              </Text>
+            </View>
+          </View>
+        ) : (
+          mensualidadesActivas.map((gasto) => (
+            <View key={gasto.id} style={styles.mensualidadCard}>
+              <View style={styles.mensualidadIcono}>
+                <Ionicons name="repeat" size={18} color={Theme.colors.primary} />
+              </View>
+              <View style={styles.mensualidadInfo}>
+                <Text style={styles.mensualidadConcepto}>{gasto.concepto}</Text>
+                <Text style={styles.mensualidadMeta}>
+                  {formatImporte(gasto.importe)} · Dia {gasto.dia_del_mes}
+                </Text>
+              </View>
+              <View style={styles.mensualidadBadge}>
+                <Text style={styles.mensualidadBadgeTexto}>Activa</Text>
+              </View>
+            </View>
+          ))
+        )}
+
         {gastos.length === 0 ? (
           <View style={styles.emptyContainer}>
             <View style={styles.emptyIconBox}>
               <Ionicons name="wallet-outline" size={40} color={Theme.colors.primary} />
             </View>
-            <Text style={styles.emptyTitulo}>Sin gastos todavía</Text>
+            <Text style={styles.emptyTitulo}>Sin gastos todavia</Text>
             <Text style={styles.emptySubtitulo}>
-              Cuando alguien pague algo por la casa, aparecerá aquí para que todos contribuyan su parte.
+              Cuando alguien pague algo por la casa, aparecera aqui para que todos contribuyan su
+              parte.
             </Text>
           </View>
         ) : (
           <>
             <Text style={styles.seccionTitulo}>Movimientos</Text>
-            {gastos.map((g) => (
-              <View key={g.id} style={styles.gastoCard}>
-                <AvatarInitials nombre={g.pagador.nombre} apellidos={g.pagador.apellidos} size={46} />
+            {gastos.map((gasto) => (
+              <View key={gasto.id} style={styles.gastoCard}>
+                <AvatarInitials nombre={gasto.pagador.nombre} apellidos={gasto.pagador.apellidos} size={46} />
                 <View style={styles.gastoInfo}>
-                  <Text style={styles.gastoConcepto}>{g.concepto}</Text>
-                  <Text style={styles.gastoPagador}>Pagado por {g.pagador.nombre}</Text>
-                  <Text style={styles.gastoFecha}>{formatFecha(g.fecha_creacion)}</Text>
+                  <Text style={styles.gastoConcepto}>{gasto.concepto}</Text>
+                  <Text style={styles.gastoPagador}>Pagado por {gasto.pagador.nombre}</Text>
+                  <Text style={styles.gastoFecha}>{formatFecha(gasto.fecha_creacion)}</Text>
                 </View>
                 <View style={styles.gastoImporteBox}>
-                  <Text style={styles.gastoImporte}>{formatImporte(g.importe)}</Text>
+                  <Text style={styles.gastoImporte}>{formatImporte(gasto.importe)}</Text>
                   <Text style={styles.gastoImporteSub}>total</Text>
                 </View>
               </View>
@@ -417,17 +558,15 @@ export default function GastosInquilinoTab() {
         )}
       </ScrollView>
 
-      {/* ── FAB ── */}
       <Pressable
         style={({ pressed }) => [styles.fab, pressed && styles.fabPressed]}
         onPress={abrirModal}
-        accessibilityLabel="Añadir nuevo gasto"
+        accessibilityLabel="Anadir nuevo gasto"
         accessibilityRole="button"
       >
         <Ionicons name="add" size={28} color={Theme.colors.surface} />
       </Pressable>
 
-      {/* ── Modal Nuevo Gasto ── */}
       <Modal visible={modalVisible} animationType="slide" transparent onRequestClose={cerrarModal}>
         <KeyboardAvoidingView
           behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
@@ -443,9 +582,12 @@ export default function GastosInquilinoTab() {
               <TextInput
                 style={[
                   styles.input,
-                  conceptoFocused && { borderColor: Theme.colors.primary, backgroundColor: Theme.colors.primaryLight },
+                  conceptoFocused && {
+                    borderColor: Theme.colors.primary,
+                    backgroundColor: Theme.colors.primaryLight,
+                  },
                 ]}
-                placeholder="Ej. Papel higiénico, gas, pizza…"
+                placeholder="Ej. Papel higienico, gas, pizza..."
                 placeholderTextColor={Theme.colors.textMuted}
                 value={concepto}
                 onChangeText={setConcepto}
@@ -461,7 +603,10 @@ export default function GastosInquilinoTab() {
               <TextInput
                 style={[
                   styles.input,
-                  importeFocused && { borderColor: Theme.colors.primary, backgroundColor: Theme.colors.primaryLight },
+                  importeFocused && {
+                    borderColor: Theme.colors.primary,
+                    backgroundColor: Theme.colors.primaryLight,
+                  },
                 ]}
                 placeholder="0,00"
                 placeholderTextColor={Theme.colors.textMuted}
@@ -555,7 +700,116 @@ export default function GastosInquilinoTab() {
           </View>
         </KeyboardAvoidingView>
       </Modal>
+
+      <Modal
+        visible={mensualidadModalVisible}
+        animationType="slide"
+        transparent
+        onRequestClose={cerrarModalMensualidad}
+      >
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+          style={styles.modalOverlay}
+        >
+          <Pressable style={{ flex: 1 }} onPress={cerrarModalMensualidad} />
+          <View style={styles.modalContainer}>
+            <View style={styles.modalHandle} />
+            <Text style={styles.modalTitulo}>Nueva mensualidad</Text>
+
+            <View style={styles.infoBanner}>
+              <Ionicons name="time-outline" size={16} color={Theme.colors.primary} />
+              <Text style={styles.infoBannerTexto}>
+                El backend creara un gasto automatico cada mes a las 02:00 del dia elegido.
+              </Text>
+            </View>
+
+            <View>
+              <Text style={styles.inputLabel}>Concepto</Text>
+              <TextInput
+                style={[
+                  styles.input,
+                  conceptoMensualidadFocused && {
+                    borderColor: Theme.colors.primary,
+                    backgroundColor: Theme.colors.primaryLight,
+                  },
+                ]}
+                placeholder="Ej. Alquiler, internet, luz"
+                placeholderTextColor={Theme.colors.textMuted}
+                value={conceptoMensualidad}
+                onChangeText={setConceptoMensualidad}
+                onFocus={() => setConceptoMensualidadFocused(true)}
+                onBlur={() => setConceptoMensualidadFocused(false)}
+                maxLength={120}
+              />
+            </View>
+
+            <View>
+              <Text style={styles.inputLabel}>Importe (€)</Text>
+              <TextInput
+                style={[
+                  styles.input,
+                  importeMensualidadFocused && {
+                    borderColor: Theme.colors.primary,
+                    backgroundColor: Theme.colors.primaryLight,
+                  },
+                ]}
+                placeholder="800,00"
+                placeholderTextColor={Theme.colors.textMuted}
+                value={importeMensualidad}
+                onChangeText={setImporteMensualidad}
+                onFocus={() => setImporteMensualidadFocused(true)}
+                onBlur={() => setImporteMensualidadFocused(false)}
+                keyboardType="decimal-pad"
+              />
+            </View>
+
+            <View>
+              <Text style={styles.inputLabel}>Dia del mes</Text>
+              <TextInput
+                style={[
+                  styles.input,
+                  diaMensualidadFocused && {
+                    borderColor: Theme.colors.primary,
+                    backgroundColor: Theme.colors.primaryLight,
+                  },
+                ]}
+                placeholder="1"
+                placeholderTextColor={Theme.colors.textMuted}
+                value={diaMensualidad}
+                onChangeText={setDiaMensualidad}
+                onFocus={() => setDiaMensualidadFocused(true)}
+                onBlur={() => setDiaMensualidadFocused(false)}
+                keyboardType="number-pad"
+                maxLength={2}
+              />
+            </View>
+
+            <View style={styles.modalAcciones}>
+              <Pressable
+                style={({ pressed }) => [styles.botonCancelar, pressed && styles.botonPressed]}
+                onPress={cerrarModalMensualidad}
+              >
+                <Text style={styles.botonCancelarTexto}>Cancelar</Text>
+              </Pressable>
+              <Pressable
+                style={({ pressed }) => [
+                  styles.botonGuardar,
+                  !puedeGuardarMensualidad && styles.botonGuardarDisabled,
+                  pressed && !guardandoMensualidad && styles.botonPressed,
+                ]}
+                onPress={handleGuardarMensualidad}
+                disabled={!puedeGuardarMensualidad || guardandoMensualidad}
+              >
+                {guardandoMensualidad ? (
+                  <ActivityIndicator color={Theme.colors.surface} />
+                ) : (
+                  <Text style={styles.botonGuardarTexto}>Crear</Text>
+                )}
+              </Pressable>
+            </View>
+          </View>
+        </KeyboardAvoidingView>
+      </Modal>
     </View>
   );
 }
-

--- a/frontend/styles/inquilino/gastos.styles.ts
+++ b/frontend/styles/inquilino/gastos.styles.ts
@@ -6,10 +6,9 @@ export const styles = StyleSheet.create({
   content: {
     paddingHorizontal: Theme.spacing.lg,
     paddingTop: Theme.spacing.lg,
-    paddingBottom: 100, // espacio para el FAB
+    paddingBottom: 100,
   },
 
-  // — Cabecera —
   header: {
     marginBottom: Theme.spacing.lg,
   },
@@ -35,7 +34,6 @@ export const styles = StyleSheet.create({
     lineHeight: 22,
   },
 
-  // — Hero Card Balance —
   heroCard: {
     borderRadius: Theme.radius.xl,
     padding: Theme.spacing.xl,
@@ -72,15 +70,44 @@ export const styles = StyleSheet.create({
     lineHeight: 21,
   },
 
-  // — Sección —
   seccionTitulo: {
     fontSize: Theme.typography.subtitle,
     fontWeight: '700',
     color: Theme.colors.text,
     marginBottom: Theme.spacing.md,
   },
+  seccionHeaderRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    gap: Theme.spacing.base,
+    marginTop: Theme.spacing.sm,
+    marginBottom: Theme.spacing.md,
+  },
+  seccionHeaderTextos: {
+    flex: 1,
+  },
+  seccionDescripcion: {
+    fontSize: Theme.typography.label,
+    color: Theme.colors.textSecondary,
+    lineHeight: 20,
+  },
+  botonSecundario: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Theme.spacing.xs,
+    backgroundColor: Theme.colors.primaryLight,
+    borderRadius: Theme.radius.full,
+    paddingHorizontal: Theme.spacing.base,
+    paddingVertical: 10,
+    minHeight: 42,
+  },
+  botonSecundarioTexto: {
+    color: Theme.colors.primary,
+    fontSize: Theme.typography.label,
+    fontWeight: '800',
+  },
 
-  // — Tarjetas de Deuda —
   deudaCard: {
     backgroundColor: Theme.colors.surface,
     borderRadius: Theme.radius.lg,
@@ -152,7 +179,86 @@ export const styles = StyleSheet.create({
     fontWeight: '800',
   },
 
-  // — Card de Gasto —
+  mensualidadCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Theme.spacing.base,
+    backgroundColor: Theme.colors.surface,
+    borderRadius: Theme.radius.lg,
+    padding: Theme.spacing.base,
+    marginBottom: Theme.spacing.sm,
+    borderWidth: 1,
+    borderColor: Theme.colors.border,
+    ...Theme.shadows.sm,
+  },
+  mensualidadIcono: {
+    width: 46,
+    height: 46,
+    borderRadius: Theme.radius.md,
+    backgroundColor: Theme.colors.primaryLight,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  mensualidadInfo: {
+    flex: 1,
+    gap: 4,
+  },
+  mensualidadConcepto: {
+    fontSize: Theme.typography.body,
+    fontWeight: '800',
+    color: Theme.colors.text,
+  },
+  mensualidadMeta: {
+    fontSize: Theme.typography.label,
+    color: Theme.colors.textSecondary,
+  },
+  mensualidadBadge: {
+    borderRadius: Theme.radius.full,
+    backgroundColor: Theme.colors.successLight,
+    paddingHorizontal: Theme.spacing.sm,
+    paddingVertical: 8,
+  },
+  mensualidadBadgeTexto: {
+    color: Theme.colors.success,
+    fontSize: Theme.typography.caption,
+    fontWeight: '800',
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+  },
+  mensualidadEmptyCard: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: Theme.spacing.base,
+    backgroundColor: Theme.colors.surface,
+    borderRadius: Theme.radius.lg,
+    padding: Theme.spacing.base,
+    marginBottom: Theme.spacing.xl,
+    borderWidth: 1,
+    borderColor: Theme.colors.border,
+  },
+  mensualidadEmptyIcon: {
+    width: 40,
+    height: 40,
+    borderRadius: Theme.radius.full,
+    backgroundColor: Theme.colors.primaryLight,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  mensualidadEmptyTextos: {
+    flex: 1,
+    gap: 4,
+  },
+  mensualidadEmptyTitulo: {
+    color: Theme.colors.text,
+    fontSize: Theme.typography.body,
+    fontWeight: '700',
+  },
+  mensualidadEmptySubtitulo: {
+    color: Theme.colors.textSecondary,
+    fontSize: Theme.typography.label,
+    lineHeight: 20,
+  },
+
   gastoCard: {
     backgroundColor: Theme.colors.surface,
     borderRadius: Theme.radius.lg,
@@ -205,7 +311,6 @@ export const styles = StyleSheet.create({
     marginTop: 2,
   },
 
-  // — Empty State —
   emptyContainer: {
     alignItems: 'center',
     paddingVertical: Theme.spacing.xxl,
@@ -235,7 +340,6 @@ export const styles = StyleSheet.create({
     lineHeight: 22,
   },
 
-  // — Modal (bottom sheet) —
   modalOverlay: {
     flex: 1,
     backgroundColor: 'rgba(0,0,0,0.45)',
@@ -263,6 +367,21 @@ export const styles = StyleSheet.create({
     fontWeight: '800',
     color: Theme.colors.text,
     letterSpacing: -0.3,
+  },
+  infoBanner: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: Theme.spacing.sm,
+    backgroundColor: Theme.colors.primaryLight,
+    borderRadius: Theme.radius.md,
+    padding: Theme.spacing.base,
+  },
+  infoBannerTexto: {
+    flex: 1,
+    color: Theme.colors.primary,
+    fontSize: Theme.typography.label,
+    lineHeight: 20,
+    fontWeight: '600',
   },
   inputLabel: {
     fontSize: Theme.typography.label,
@@ -373,7 +492,6 @@ export const styles = StyleSheet.create({
     transform: [{ scale: 0.97 }],
   },
 
-  // — FAB —
   fab: {
     position: 'absolute',
     bottom: Theme.spacing.xl,


### PR DESCRIPTION
## Summary
- Add the recurring expense backend flow for monthly charges and automatic cron execution
- Add management endpoints and in-app UI to create and list fixed monthly expenses

**Descripción:**
## Objetivo
Implementar el motor de mensualidades de la Épica 12 para registrar gastos recurrentes por vivienda y generar automáticamente los gastos mensuales repartidos entre inquilinos activos.

## Cambios principales
* Se añade el modelo `GastoRecurrente` en Prisma y se conectan sus relaciones con `Vivienda` y `Usuario`.
* Se extrae la lógica compartida de reparto de gastos a un servicio reutilizable para controladores y cron.
* Se crea el cron diario de mensualidades y se inicializa en el arranque del backend.
* Se añaden los endpoints `GET/POST /viviendas/:viviendaId/gastos-recurrentes`.
* Se amplía la pantalla de gastos del inquilino para listar mensualidades activas y crear nuevas desde un modal.

## UI / UX (Solo si aplica)
* Se añade una sección específica de "Gastos Fijos / Mensualidades" reutilizando `Theme.ts`, superficies redondeadas y soft tints en acciones secundarias e info states.

## Changelog
* `docs/changelog/epica-12-issue-195-mensualidades-cronjobs.md`

## Testing
- `npx prisma generate --schema prisma/schema.prisma`
- `npm run build` en `backend`
- `npm run lint` en `frontend`