### PR TITLE
[Épica 12] Añade justificante de pago en deudas de inquilino

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -177,6 +177,7 @@ model Deuda {
   acreedor    Usuario     @relation("AcreedorDeuda", fields: [acreedor_id], references: [id])
   importe     Float
   estado      EstadoDeuda @default(PENDIENTE)
+  justificante_url String?
 }
 
 model ItemInventario {

--- a/backend/src/config/cloudinary.config.ts
+++ b/backend/src/config/cloudinary.config.ts
@@ -20,30 +20,32 @@ if (cloudinaryEstaConfigurado) {
   });
 }
 
-const storage = cloudinaryEstaConfigurado
-  ? new CloudinaryStorage({
-      cloudinary,
-      params: async () => ({
-        folder: 'roomies-inventario',
-        allowed_formats: ['jpg', 'jpeg', 'png', 'webp'],
-        resource_type: 'image',
-      }),
-    })
-  : multer.memoryStorage();
+const crearUploaderImagen = (folder: string) =>
+  multer({
+    storage: cloudinaryEstaConfigurado
+      ? new CloudinaryStorage({
+          cloudinary,
+          params: async () => ({
+            folder,
+            allowed_formats: ['jpg', 'jpeg', 'png', 'webp'],
+            resource_type: 'image',
+          }),
+        })
+      : multer.memoryStorage(),
+    limits: {
+      fileSize: 8 * 1024 * 1024,
+    },
+    fileFilter: (_req, file, cb) => {
+      if (!file.mimetype.startsWith('image/')) {
+        cb(new Error('Solo se permiten archivos de imagen.'));
+        return;
+      }
 
-export const uploadInventarioFoto = multer({
-  storage,
-  limits: {
-    fileSize: 8 * 1024 * 1024,
-  },
-  fileFilter: (_req, file, cb) => {
-    if (!file.mimetype.startsWith('image/')) {
-      cb(new Error('Solo se permiten archivos de imagen.'));
-      return;
-    }
+      cb(null, true);
+    },
+  });
 
-    cb(null, true);
-  },
-});
+export const uploadInventarioFoto = crearUploaderImagen('roomies-inventario');
+export const uploadJustificanteFoto = crearUploaderImagen('roomies-justificantes');
 
 export { cloudinary };

--- a/backend/src/controllers/deuda.controller.ts
+++ b/backend/src/controllers/deuda.controller.ts
@@ -1,0 +1,78 @@
+import express from 'express';
+import { cloudinaryEstaConfigurado } from '../config/cloudinary.config';
+import { prisma } from '../lib/prisma';
+import { usuarioPerteneceAVivienda } from '../services/gasto.service';
+
+const obtenerParamNumerico = (valor: string | string[] | undefined) => {
+  const normalizado = Array.isArray(valor) ? valor[0] : valor;
+
+  if (!normalizado) {
+    return NaN;
+  }
+
+  return parseInt(normalizado, 10);
+};
+
+export const subirJustificanteDeuda: express.RequestHandler = async (req, res) => {
+  const deudaId = obtenerParamNumerico(req.params.deudaId);
+  const usuarioId = req.usuario!.id;
+
+  if (!cloudinaryEstaConfigurado) {
+    res.status(500).json({ error: 'Cloudinary no está configurado en el servidor.' });
+    return;
+  }
+
+  if (!Number.isInteger(deudaId) || deudaId <= 0) {
+    res.status(400).json({ error: 'deudaId inválido.' });
+    return;
+  }
+
+  if (!req.file) {
+    res.status(400).json({ error: 'Debes adjuntar una imagen.' });
+    return;
+  }
+
+  const deuda = await prisma.deuda.findUnique({
+    where: { id: deudaId },
+    include: {
+      gasto: {
+        select: {
+          vivienda_id: true,
+        },
+      },
+    },
+  });
+
+  if (!deuda) {
+    res.status(404).json({ error: 'Deuda no encontrada.' });
+    return;
+  }
+
+  const pertenece = await usuarioPerteneceAVivienda(deuda.gasto.vivienda_id, usuarioId);
+
+  if (!pertenece) {
+    res.status(403).json({ error: 'No perteneces a la vivienda de esta deuda.' });
+    return;
+  }
+
+  if (deuda.deudor_id !== usuarioId) {
+    res.status(403).json({ error: 'Solo el deudor puede subir el justificante de esta deuda.' });
+    return;
+  }
+
+  const secureUrl = (req.file as Express.Multer.File & { path?: string }).path;
+
+  if (!secureUrl) {
+    res.status(500).json({ error: 'No se pudo obtener la URL del justificante subido.' });
+    return;
+  }
+
+  const deudaActualizada = await prisma.deuda.update({
+    where: { id: deudaId },
+    data: {
+      justificante_url: secureUrl,
+    },
+  });
+
+  res.status(201).json(deudaActualizada);
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -9,6 +9,7 @@ import anuncioRoutes from './routes/anuncio.routes';
 import limpiezaRoutes from './routes/limpieza.routes';
 import gastoRoutes from './routes/gasto.routes';
 import gastoRecurrenteRoutes from './routes/gasto-recurrente.routes';
+import deudaRoutes from './routes/deuda.routes';
 import userRoutes from './routes/user.routes';
 import inventarioRoutes from './routes/inventario.routes';
 import './services/cron.service';
@@ -32,6 +33,7 @@ app.use('/api/anuncios', anuncioRoutes);
 app.use('/api/viviendas', limpiezaRoutes);
 app.use('/api/viviendas', gastoRoutes);
 app.use('/api/viviendas', gastoRecurrenteRoutes);
+app.use('/api', deudaRoutes);
 app.use('/api', inventarioRoutes);
 app.use('/api/users', userRoutes);
 

--- a/backend/src/routes/deuda.routes.ts
+++ b/backend/src/routes/deuda.routes.ts
@@ -1,0 +1,15 @@
+import express from 'express';
+import { uploadJustificanteFoto } from '../config/cloudinary.config';
+import { subirJustificanteDeuda } from '../controllers/deuda.controller';
+import { verificarToken } from '../middlewares/auth.middleware';
+
+const router = express.Router();
+
+router.post(
+  '/deudas/:deudaId/justificante',
+  verificarToken,
+  uploadJustificanteFoto.single('justificante'),
+  subirJustificanteDeuda,
+);
+
+export default router;

--- a/docs/changelog/epica-12-issue-196-justificante-pago.md
+++ b/docs/changelog/epica-12-issue-196-justificante-pago.md
@@ -1,0 +1,17 @@
+# Issue #196 — Justificante de pago en deudas de inquilino
+
+**Fecha:** 2026-04-10
+**Épica:** 12
+
+## Cambios técnicos
+
+- `backend/prisma/schema.prisma`: añadido el campo opcional `justificante_url` al modelo `Deuda` para persistir la URL segura del comprobante.
+- `backend/src/config/cloudinary.config.ts`: extraído un creador de uploaders reutilizable por carpeta y añadido `uploadJustificanteFoto` para subir imágenes a `roomies-justificantes`.
+- `backend/src/controllers/deuda.controller.ts`: creado el controlador `subirJustificanteDeuda` con validación de deuda, pertenencia a vivienda, propiedad del deudor y guardado de `secure_url` en Prisma.
+- `backend/src/routes/deuda.routes.ts`: registrado el endpoint `POST /api/deudas/:deudaId/justificante` con `verificarToken`, `multer` y Cloudinary.
+- `backend/src/index.ts`: montadas las nuevas rutas de deuda bajo `/api`.
+- `frontend/constants/theme.ts`: añadidos tokens `info` e `infoLight` para estados y CTAs de justificante con Soft Tint azul.
+- `frontend/app/inquilino/(tabs)/gastos.tsx`: reemplazado el `Alert` de “Saldar deuda” por un bottom sheet con dos acciones, integración con `expo-image-picker`, subida multipart del justificante y saldado posterior de la deuda.
+- `frontend/app/inquilino/(tabs)/gastos.tsx`: añadido un bloque de deudas pagadas con botón `Ver justificante` que abre la URL remota cuando existe `justificante_url`.
+- `frontend/styles/inquilino/gastos.styles.ts`: incorporados estilos del nuevo sheet de confirmación, CTA secundario/primario y tarjeta de justificantes pagados siguiendo `Theme.radius.lg` y espaciado amplio.
+- Validación técnica: `npx prisma validate --schema prisma/schema.prisma`, `npm run build` en `backend` y `npm run lint` en `frontend` completados; el lint solo reporta warnings previos ajenos a esta issue.

--- a/frontend/app/inquilino/(tabs)/gastos.tsx
+++ b/frontend/app/inquilino/(tabs)/gastos.tsx
@@ -8,9 +8,10 @@ import {
   TextInput,
   KeyboardAvoidingView,
   Platform,
-  Alert,
+  Linking,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import * as ImagePicker from 'expo-image-picker';
 import Toast from 'react-native-toast-message';
 import { Theme } from '@/constants/theme';
 import { useState, useCallback } from 'react';
@@ -34,6 +35,7 @@ type Deuda = {
   acreedor_id: number;
   importe: number;
   estado: 'PENDIENTE' | 'PAGADA';
+  justificante_url: string | null;
   deudor: UsuarioBasico;
   acreedor: UsuarioBasico;
   gasto: { concepto: string };
@@ -103,6 +105,7 @@ export default function GastosInquilinoTab() {
   const [gastosRecurrentes, setGastosRecurrentes] = useState<GastoRecurrente[]>([]);
   const [loading, setLoading] = useState(true);
   const [saldando, setSaldando] = useState<number | null>(null);
+  const [deudaSeleccionada, setDeudaSeleccionada] = useState<Deuda | null>(null);
 
   const [modalVisible, setModalVisible] = useState(false);
   const [concepto, setConcepto] = useState('');
@@ -206,40 +209,125 @@ export default function GastosInquilinoTab() {
   };
 
   const deudasPendientes = deudas.filter((deuda) => deuda.estado === 'PENDIENTE');
+  const deudasPagadasConJustificante = deudas.filter(
+    (deuda) => deuda.estado === 'PAGADA' && !!deuda.justificante_url,
+  );
   const mensualidadesActivas = gastosRecurrentes.filter((gasto) => gasto.activo);
 
-  const handleSaldar = (deuda: Deuda) => {
-    Alert.alert(
-      'Confirmar pago',
-      `Has hecho ya el Bizum o transferencia de ${formatImporte(deuda.importe)} a ${deuda.acreedor.nombre}?`,
-      [
-        { text: 'Aun no', style: 'cancel' },
-        {
-          text: 'Si, ya lo hice',
-          onPress: async () => {
-            if (!viviendaId) return;
+  const abrirModalPago = (deuda: Deuda) => {
+    setDeudaSeleccionada(deuda);
+  };
 
-            setSaldando(deuda.id);
-            try {
-              await api.patch(`/viviendas/${viviendaId}/deudas/${deuda.id}/saldar`);
-              await cargarTodo(viviendaId);
-              Toast.show({
-                type: 'success',
-                text1: 'Deuda saldada',
-                text2: `${formatImporte(deuda.importe)} marcados como pagados.`,
-              });
-            } catch (err: any) {
-              Toast.show({
-                type: 'error',
-                text1: err.response?.data?.error ?? 'No se pudo saldar la deuda.',
-              });
-            } finally {
-              setSaldando(null);
-            }
-          },
-        },
-      ],
+  const cerrarModalPago = () => {
+    if (saldando) return;
+    setDeudaSeleccionada(null);
+  };
+
+  const saldarDeuda = async (deuda: Deuda, mensajeExito: string) => {
+    if (!viviendaId) return;
+
+    setSaldando(deuda.id);
+    try {
+      await api.patch(`/viviendas/${viviendaId}/deudas/${deuda.id}/saldar`);
+      await cargarTodo(viviendaId);
+      setDeudaSeleccionada(null);
+      Toast.show({
+        type: 'success',
+        text1: 'Deuda saldada',
+        text2: mensajeExito,
+      });
+    } catch (err: any) {
+      Toast.show({
+        type: 'error',
+        text1: err.response?.data?.error ?? 'No se pudo saldar la deuda.',
+      });
+    } finally {
+      setSaldando(null);
+    }
+  };
+
+  const subirJustificante = async (deuda: Deuda, asset: ImagePicker.ImagePickerAsset) => {
+    const formData = new FormData();
+
+    if (Platform.OS === 'web' && asset.file) {
+      formData.append('justificante', asset.file);
+    } else {
+      formData.append('justificante', {
+        uri: asset.uri,
+        name: asset.fileName ?? `justificante-deuda-${deuda.id}.jpg`,
+        type: asset.mimeType ?? 'image/jpeg',
+      } as never);
+    }
+
+    await api.post(`/deudas/${deuda.id}/justificante`, formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    });
+  };
+
+  const handleSaldarSinJustificante = async () => {
+    if (!deudaSeleccionada) return;
+
+    await saldarDeuda(
+      deudaSeleccionada,
+      `${formatImporte(deudaSeleccionada.importe)} marcados como pagados.`,
     );
+  };
+
+  const handleSubirJustificanteYSaldar = async () => {
+    if (!deudaSeleccionada || !viviendaId) return;
+
+    if (Platform.OS !== 'web') {
+      const permiso = await ImagePicker.requestMediaLibraryPermissionsAsync();
+      if (!permiso.granted) {
+        Toast.show({
+          type: 'info',
+          text1: 'Permiso necesario',
+          text2: 'Necesitamos acceso a tu galería para adjuntar el justificante.',
+        });
+        return;
+      }
+    }
+
+    const resultado = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ['images'],
+      allowsEditing: true,
+      quality: 0.82,
+    });
+
+    if (resultado.canceled || !resultado.assets[0]) {
+      return;
+    }
+
+    setSaldando(deudaSeleccionada.id);
+    try {
+      await subirJustificante(deudaSeleccionada, resultado.assets[0]);
+      await api.patch(`/viviendas/${viviendaId}/deudas/${deudaSeleccionada.id}/saldar`);
+      await cargarTodo(viviendaId);
+      setDeudaSeleccionada(null);
+      Toast.show({
+        type: 'success',
+        text1: 'Pago registrado',
+        text2: 'Se ha subido el justificante y la deuda ya figura como pagada.',
+      });
+    } catch (err: any) {
+      Toast.show({
+        type: 'error',
+        text1: err.response?.data?.error ?? 'No se pudo subir el justificante y saldar la deuda.',
+      });
+    } finally {
+      setSaldando(null);
+    }
+  };
+
+  const abrirJustificante = async (url: string) => {
+    try {
+      await Linking.openURL(url);
+    } catch {
+      Toast.show({
+        type: 'error',
+        text1: 'No se pudo abrir el justificante.',
+      });
+    }
   };
 
   const handleGuardar = async () => {
@@ -450,7 +538,7 @@ export default function GastosInquilinoTab() {
                           pressed && styles.botonSaldarPressed,
                           saldando === deuda.id && { opacity: 0.6 },
                         ]}
-                        onPress={() => handleSaldar(deuda)}
+                        onPress={() => abrirModalPago(deuda)}
                         disabled={saldando === deuda.id}
                         accessibilityLabel={`Saldar deuda de ${formatImporte(deuda.importe)} con ${companero.nombre}`}
                         accessibilityRole="button"
@@ -470,6 +558,56 @@ export default function GastosInquilinoTab() {
                       </View>
                     )}
                   </View>
+                </View>
+              );
+            })}
+          </>
+        )}
+
+        {deudasPagadasConJustificante.length > 0 && (
+          <>
+            <Text style={styles.seccionTitulo}>Pagadas con justificante</Text>
+            {deudasPagadasConJustificante.map((deuda) => {
+              const yoPague = deuda.deudor_id === miId;
+              const companero = yoPague ? deuda.acreedor : deuda.deudor;
+
+              return (
+                <View key={deuda.id} style={styles.deudaPagadaCard}>
+                  <View style={styles.deudaPagadaHeader}>
+                    <AvatarInitials
+                      nombre={companero.nombre}
+                      apellidos={companero.apellidos}
+                      size={48}
+                    />
+                    <View style={styles.deudaPagadaInfo}>
+                      <Text style={styles.deudaNombre} numberOfLines={1}>
+                        {companero.nombre}
+                        {companero.apellidos ? ` ${companero.apellidos}` : ''}
+                      </Text>
+                      <Text style={styles.deudaConcepto} numberOfLines={2}>
+                        {deuda.gasto.concepto}
+                      </Text>
+                      <Text style={[styles.deudaImporte, { color: Theme.colors.success }]}>
+                        {formatImporte(deuda.importe)}
+                      </Text>
+                    </View>
+                    <View style={styles.deudaPagadaEstado}>
+                      <Text style={styles.deudaPagadaEstadoTexto}>Pagada</Text>
+                    </View>
+                  </View>
+
+                  <Pressable
+                    style={({ pressed }) => [
+                      styles.botonJustificante,
+                      pressed && styles.botonPressed,
+                    ]}
+                    onPress={() => abrirJustificante(deuda.justificante_url!)}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Ver justificante de ${deuda.gasto.concepto}`}
+                  >
+                    <Ionicons name="image-outline" size={16} color={Theme.colors.info} />
+                    <Text style={styles.botonJustificanteTexto}>Ver justificante</Text>
+                  </Pressable>
                 </View>
               );
             })}
@@ -566,6 +704,117 @@ export default function GastosInquilinoTab() {
       >
         <Ionicons name="add" size={28} color={Theme.colors.surface} />
       </Pressable>
+
+      <Modal
+        visible={!!deudaSeleccionada}
+        animationType="slide"
+        transparent
+        onRequestClose={cerrarModalPago}
+      >
+        <View style={styles.modalOverlay}>
+          <Pressable style={{ flex: 1 }} onPress={cerrarModalPago} />
+          <View style={styles.pagoSheet}>
+            <View style={styles.modalHandle} />
+            <View style={styles.pagoSheetHero}>
+              <View style={styles.pagoSheetIcon}>
+                <Ionicons name="wallet-outline" size={22} color={Theme.colors.success} />
+              </View>
+              <View style={styles.pagoSheetHeroTextos}>
+                <Text style={styles.pagoSheetTitulo}>Confirmar pago</Text>
+                <Text style={styles.pagoSheetSubtitulo}>
+                  {deudaSeleccionada
+                    ? `¿Ya has enviado ${formatImporte(deudaSeleccionada.importe)} a ${deudaSeleccionada.acreedor.nombre}?`
+                    : ''}
+                </Text>
+                {deudaSeleccionada && (
+                  <Text style={styles.pagoSheetAmount}>
+                    {deudaSeleccionada.gasto.concepto} ·{' '}
+                    {formatImporte(deudaSeleccionada.importe)}
+                  </Text>
+                )}
+              </View>
+            </View>
+
+            <Pressable
+              style={({ pressed }) => [
+                styles.pagoSheetOption,
+                styles.pagoSheetOptionSecundaria,
+                pressed && !saldando && styles.botonPressed,
+                !!saldando && { opacity: 0.7 },
+              ]}
+              onPress={handleSaldarSinJustificante}
+              disabled={!!saldando}
+            >
+              <View style={styles.pagoSheetOptionHeader}>
+                <View style={styles.pagoSheetOptionHeaderLeft}>
+                  <View
+                    style={[styles.pagoSheetOptionIcon, styles.pagoSheetOptionIconSecundaria]}
+                  >
+                    <Ionicons
+                      name="checkmark-circle-outline"
+                      size={20}
+                      color={Theme.colors.textMedium}
+                    />
+                  </View>
+                  <Text style={styles.pagoSheetOptionTitle}>Saldar sin justificante</Text>
+                </View>
+                {deudaSeleccionada && saldando === deudaSeleccionada.id ? (
+                  <ActivityIndicator color={Theme.colors.textMedium} />
+                ) : (
+                  <Ionicons name="chevron-forward" size={18} color={Theme.colors.textSecondary} />
+                )}
+              </View>
+              <Text style={styles.pagoSheetOptionDescription}>
+                Marca la deuda como pagada inmediatamente y cierra este pendiente.
+              </Text>
+            </Pressable>
+
+            <Pressable
+              style={({ pressed }) => [
+                styles.pagoSheetOption,
+                styles.pagoSheetOptionPrimaria,
+                pressed && !saldando && styles.botonPressed,
+                !!saldando && { opacity: 0.7 },
+              ]}
+              onPress={handleSubirJustificanteYSaldar}
+              disabled={!!saldando}
+            >
+              <View style={styles.pagoSheetOptionHeader}>
+                <View style={styles.pagoSheetOptionHeaderLeft}>
+                  <View
+                    style={[styles.pagoSheetOptionIcon, styles.pagoSheetOptionIconPrimaria]}
+                  >
+                    <Ionicons name="image-outline" size={20} color={Theme.colors.primary} />
+                  </View>
+                  <Text style={styles.pagoSheetOptionTitle}>Subir captura y saldar</Text>
+                </View>
+                {deudaSeleccionada && saldando === deudaSeleccionada.id ? (
+                  <ActivityIndicator color={Theme.colors.primary} />
+                ) : (
+                  <Ionicons name="chevron-forward" size={18} color={Theme.colors.primary} />
+                )}
+              </View>
+              <Text style={styles.pagoSheetOptionDescription}>
+                Adjunta una captura de Bizum o transferencia, la guardamos y después marcamos la
+                deuda como pagada.
+              </Text>
+            </Pressable>
+
+            <View style={styles.pagoSheetFooter}>
+              <Pressable
+                style={({ pressed }) => [
+                  styles.pagoSheetCancel,
+                  pressed && !saldando && styles.botonPressed,
+                ]}
+                onPress={cerrarModalPago}
+                disabled={!!saldando}
+              >
+                <Text style={styles.pagoSheetCancelText}>Cancelar</Text>
+              </Pressable>
+            </View>
+          </View>
+        </View>
+      </Modal>
 
       <Modal visible={modalVisible} animationType="slide" transparent onRequestClose={cerrarModal}>
         <KeyboardAvoidingView

--- a/frontend/constants/theme.ts
+++ b/frontend/constants/theme.ts
@@ -8,6 +8,8 @@ export const Theme = {
     success:          '#06D6A0',  // Teal-verde vibrante
     successLight:     '#E8FBF5',
     successDisabled:  '#A3E8DA',
+    info:             '#4F8CFF',
+    infoLight:        '#EDF4FF',
     danger:           '#FF4757',
     dangerLight:      '#FFF0F2',
     warning:          '#FFA726',

--- a/frontend/styles/inquilino/gastos.styles.ts
+++ b/frontend/styles/inquilino/gastos.styles.ts
@@ -178,6 +178,54 @@ export const styles = StyleSheet.create({
     fontSize: Theme.typography.caption,
     fontWeight: '800',
   },
+  botonJustificante: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Theme.spacing.xs,
+    alignSelf: 'flex-start',
+    backgroundColor: Theme.colors.infoLight,
+    borderRadius: Theme.radius.full,
+    paddingVertical: 10,
+    paddingHorizontal: Theme.spacing.base,
+  },
+  botonJustificanteTexto: {
+    color: Theme.colors.info,
+    fontSize: Theme.typography.label,
+    fontWeight: '800',
+  },
+  deudaPagadaCard: {
+    backgroundColor: Theme.colors.surface,
+    borderRadius: Theme.radius.lg,
+    padding: Theme.spacing.base,
+    marginBottom: Theme.spacing.sm,
+    gap: Theme.spacing.md,
+    borderWidth: 1,
+    borderColor: Theme.colors.border,
+    ...Theme.shadows.sm,
+  },
+  deudaPagadaHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Theme.spacing.md,
+  },
+  deudaPagadaInfo: {
+    flex: 1,
+    gap: 4,
+  },
+  deudaPagadaEstado: {
+    alignSelf: 'flex-start',
+    borderRadius: Theme.radius.full,
+    backgroundColor: Theme.colors.successLight,
+    paddingHorizontal: Theme.spacing.sm,
+    paddingVertical: 8,
+  },
+  deudaPagadaEstadoTexto: {
+    color: Theme.colors.success,
+    fontSize: Theme.typography.caption,
+    fontWeight: '800',
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+  },
 
   mensualidadCard: {
     flexDirection: 'row',
@@ -490,6 +538,115 @@ export const styles = StyleSheet.create({
   botonPressed: {
     opacity: 0.75,
     transform: [{ scale: 0.97 }],
+  },
+  pagoSheet: {
+    backgroundColor: Theme.colors.surface,
+    borderTopLeftRadius: Theme.radius.xl,
+    borderTopRightRadius: Theme.radius.xl,
+    paddingHorizontal: Theme.spacing.lg,
+    paddingTop: Theme.spacing.xl,
+    paddingBottom: Theme.spacing.xl,
+    gap: Theme.spacing.base,
+  },
+  pagoSheetHero: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: Theme.spacing.base,
+    backgroundColor: Theme.colors.surface2,
+    borderRadius: Theme.radius.lg,
+    padding: Theme.spacing.lg,
+  },
+  pagoSheetIcon: {
+    width: 52,
+    height: 52,
+    borderRadius: Theme.radius.lg,
+    backgroundColor: Theme.colors.successLight,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  pagoSheetHeroTextos: {
+    flex: 1,
+    gap: Theme.spacing.xs,
+  },
+  pagoSheetTitulo: {
+    fontSize: Theme.typography.title,
+    fontWeight: '800',
+    color: Theme.colors.text,
+    letterSpacing: -0.3,
+  },
+  pagoSheetSubtitulo: {
+    fontSize: Theme.typography.body,
+    color: Theme.colors.textSecondary,
+    lineHeight: 22,
+  },
+  pagoSheetAmount: {
+    fontSize: Theme.typography.subtitle,
+    fontWeight: '900',
+    color: Theme.colors.success,
+  },
+  pagoSheetOption: {
+    borderRadius: Theme.radius.lg,
+    padding: Theme.spacing.lg,
+    gap: Theme.spacing.sm,
+    borderWidth: 1,
+  },
+  pagoSheetOptionSecundaria: {
+    backgroundColor: Theme.colors.surface2,
+    borderColor: Theme.colors.border,
+  },
+  pagoSheetOptionPrimaria: {
+    backgroundColor: Theme.colors.primaryLight,
+    borderColor: Theme.colors.primary + '24',
+  },
+  pagoSheetOptionHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: Theme.spacing.base,
+  },
+  pagoSheetOptionHeaderLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Theme.spacing.sm,
+    flex: 1,
+  },
+  pagoSheetOptionIcon: {
+    width: 42,
+    height: 42,
+    borderRadius: Theme.radius.full,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  pagoSheetOptionIconSecundaria: {
+    backgroundColor: Theme.colors.surface,
+  },
+  pagoSheetOptionIconPrimaria: {
+    backgroundColor: Theme.colors.primary + '18',
+  },
+  pagoSheetOptionTitle: {
+    fontSize: Theme.typography.body,
+    fontWeight: '800',
+    color: Theme.colors.text,
+  },
+  pagoSheetOptionDescription: {
+    fontSize: Theme.typography.label,
+    color: Theme.colors.textSecondary,
+    lineHeight: 20,
+  },
+  pagoSheetFooter: {
+    marginTop: Theme.spacing.xs,
+  },
+  pagoSheetCancel: {
+    borderRadius: Theme.radius.lg,
+    paddingVertical: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: Theme.colors.surface2,
+  },
+  pagoSheetCancelText: {
+    color: Theme.colors.textMedium,
+    fontSize: Theme.typography.body,
+    fontWeight: '700',
   },
 
   fab: {


### PR DESCRIPTION
## Objetivo
Incorporar la subida de justificantes en el flujo de saldado de deudas del inquilino, persistiendo la URL del comprobante en backend y mostrando su acceso posterior en la app.

## Cambios principales
* Backend: añade `justificante_url` al modelo `Deuda` y crea `POST /api/deudas/:deudaId/justificante` con subida de imagen a Cloudinary en `roomies-justificantes`.
* Backend: reutiliza la configuración de `multer`/Cloudinary mediante un uploader parametrizable por carpeta y registra las nuevas rutas de deuda.
* Frontend: sustituye el `Alert` de "Saldar deuda" por un modal/bottom sheet con dos acciones: saldar sin justificante o subir captura y saldar.
* Frontend: integra `expo-image-picker`, subida multipart del justificante y saldado posterior de la deuda.
* Frontend: muestra "Ver justificante" en deudas pagadas que tengan `justificante_url`.

## UI / UX
* Se añade un sheet de confirmación con esquinas amplias usando `Theme.radius.lg`/`xl`, padding generoso y jerarquía clara entre acción secundaria y primaria.
* Se incorporan soft tints azules mediante nuevos tokens `info` e `infoLight` en `Theme.ts` para el acceso a justificantes.

## Changelog
* `docs/changelog/epica-12-issue-196-justificante-pago.md`

## Summary
* Añade soporte completo de justificante de pago para deudas de inquilino en backend y frontend.
* Mantiene el flujo existente de saldado y agrega una vía con comprobante adjunto.

## Testing
* `npx prisma validate --schema prisma/schema.prisma`
* `npm run build` en `backend`
* `npm run lint` en `frontend`
* `npx tsc --noEmit` en `frontend`