### PR TITLE
[Épica 12] Añade dashboard de cobros del casero

### DIFF
--- a/backend/src/controllers/cobros.controller.ts
+++ b/backend/src/controllers/cobros.controller.ts
@@ -1,0 +1,117 @@
+import express from 'express';
+import { prisma } from '../lib/prisma';
+
+const obtenerParamNumerico = (valor: string | string[] | undefined) => {
+  const normalizado = Array.isArray(valor) ? valor[0] : valor;
+
+  if (!normalizado) {
+    return NaN;
+  }
+
+  return parseInt(normalizado, 10);
+};
+
+export const listarCobrosVivienda: express.RequestHandler = async (req, res) => {
+  const viviendaId = obtenerParamNumerico(req.params.viviendaId);
+  const usuarioId = req.usuario!.id;
+
+  if (!Number.isInteger(viviendaId) || viviendaId <= 0) {
+    res.status(400).json({ error: 'viviendaId inválido.' });
+    return;
+  }
+
+  const vivienda = await prisma.vivienda.findUnique({
+    where: { id: viviendaId },
+    select: {
+      id: true,
+      alias_nombre: true,
+      direccion: true,
+      casero_id: true,
+    },
+  });
+
+  if (!vivienda) {
+    res.status(404).json({ error: 'Vivienda no encontrada.' });
+    return;
+  }
+
+  if (vivienda.casero_id !== usuarioId) {
+    res.status(403).json({ error: 'No tienes acceso a los cobros de esta vivienda.' });
+    return;
+  }
+
+  const ahora = new Date();
+  const inicioMes = new Date(ahora.getFullYear(), ahora.getMonth(), 1);
+  const inicioMesSiguiente = new Date(ahora.getFullYear(), ahora.getMonth() + 1, 1);
+
+  const deudas = await prisma.deuda.findMany({
+    where: {
+      acreedor_id: usuarioId,
+      gasto: {
+        vivienda_id: viviendaId,
+        fecha_creacion: {
+          gte: inicioMes,
+          lt: inicioMesSiguiente,
+        },
+      },
+    },
+    include: {
+      deudor: {
+        select: {
+          id: true,
+          nombre: true,
+          apellidos: true,
+        },
+      },
+      gasto: {
+        select: {
+          id: true,
+          concepto: true,
+          fecha_creacion: true,
+        },
+      },
+    },
+    orderBy: [
+      { estado: 'asc' },
+      { id: 'desc' },
+    ],
+  });
+
+  const totalPagadoMes = deudas
+    .filter((deuda) => deuda.estado === 'PAGADA')
+    .reduce((acumulado, deuda) => acumulado + deuda.importe, 0);
+
+  const totalPendiente = deudas
+    .filter((deuda) => deuda.estado === 'PENDIENTE')
+    .reduce((acumulado, deuda) => acumulado + deuda.importe, 0);
+
+  res.status(200).json({
+    vivienda: {
+      id: vivienda.id,
+      alias_nombre: vivienda.alias_nombre,
+      direccion: vivienda.direccion,
+    },
+    periodo: {
+      inicio: inicioMes.toISOString(),
+      fin: inicioMesSiguiente.toISOString(),
+    },
+    resumen: {
+      total_pagado_mes: totalPagadoMes,
+      total_pendiente: totalPendiente,
+      total_deudas: deudas.length,
+    },
+    deudas: deudas.map((deuda) => ({
+      id: deuda.id,
+      importe: deuda.importe,
+      estado: deuda.estado,
+      justificante_url: deuda.justificante_url,
+      gasto: deuda.gasto,
+      deudor: {
+        id: deuda.deudor.id,
+        nombre: deuda.deudor.nombre,
+        apellidos: deuda.deudor.apellidos,
+        avatar: null,
+      },
+    })),
+  });
+};

--- a/backend/src/routes/gasto.routes.ts
+++ b/backend/src/routes/gasto.routes.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import { listarCobrosVivienda } from '../controllers/cobros.controller';
 import { verificarToken } from '../middlewares/auth.middleware';
 import { listarGastos, crearGasto, listarDeudas, saldarDeuda } from '../controllers/gasto.controller';
 
@@ -7,6 +8,7 @@ const router = express.Router();
 router.get('/:viviendaId/gastos', verificarToken, listarGastos);
 router.post('/:viviendaId/gastos', verificarToken, crearGasto);
 router.get('/:viviendaId/deudas', verificarToken, listarDeudas);
+router.get('/:viviendaId/cobros', verificarToken, listarCobrosVivienda);
 router.patch('/:viviendaId/deudas/:deudaId/saldar', verificarToken, saldarDeuda);
 
 export default router;

--- a/docs/changelog/epica-12-issue-197-casero-dashboard-cobros.md
+++ b/docs/changelog/epica-12-issue-197-casero-dashboard-cobros.md
@@ -1,0 +1,17 @@
+# Issue #197 — Dashboard de cobros para casero
+
+**Fecha:** 2026-04-10
+**Épica:** 12
+
+## Cambios técnicos
+
+- `backend/src/controllers/cobros.controller.ts`: creado el endpoint de resumen financiero del casero para una vivienda, filtrando deudas del mes actual donde el casero es acreedor y devolviendo totales pagado/pendiente junto al detalle de deudor, concepto y `justificante_url`.
+- `backend/src/routes/gasto.routes.ts`: registrada la ruta `GET /:viviendaId/cobros` bajo `/api/viviendas` con autenticación.
+- `frontend/app/casero/(tabs)/_layout.tsx`: añadida la nueva tab `Cobros` al dashboard del casero.
+- `frontend/app/casero/(tabs)/cobros.tsx`: implementada la pantalla principal de cobros con selector de vivienda, hero card de resumen mensual, listas agrupadas por estado y modal de visualización del justificante.
+- `frontend/styles/casero/cobros.styles.ts`: definidos estilos del dashboard con superficies blancas, `Theme.shadows.sm`, radios amplios, badges Soft Tint y modal de imagen.
+
+## Resultado técnico observable
+
+- El casero puede consultar por vivienda cuánto tiene ingresado y cuánto sigue pendiente en el mes actual desde un endpoint dedicado.
+- La app muestra un dashboard visual de cobros con tarjetas por recibo y permite abrir el justificante subido por el inquilino sin salir de la pestaña.

--- a/frontend/app/casero/(tabs)/_layout.tsx
+++ b/frontend/app/casero/(tabs)/_layout.tsx
@@ -34,6 +34,15 @@ export default function CaseroTabsLayout() {
         }}
       />
       <Tabs.Screen
+        name="cobros"
+        options={{
+          title: 'Cobros',
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="wallet-outline" size={size} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
         name="inventario"
         options={{
           title: 'Inventario',

--- a/frontend/app/casero/(tabs)/cobros.tsx
+++ b/frontend/app/casero/(tabs)/cobros.tsx
@@ -1,0 +1,398 @@
+import { useCallback, useMemo, useState } from 'react';
+import { Modal, Pressable, ScrollView, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { Image } from 'expo-image';
+import { useFocusEffect, useRouter } from 'expo-router';
+import Toast from 'react-native-toast-message';
+import { CustomButton } from '@/components/common/CustomButton';
+import { LoadingScreen } from '@/components/common/LoadingScreen';
+import { Theme } from '@/constants/theme';
+import api from '@/services/api';
+import {
+  ESTADO_BADGE_BG,
+  ESTADO_BADGE_BORDER,
+  ESTADO_BADGE_TEXT,
+  styles,
+} from '@/styles/casero/cobros.styles';
+
+type Vivienda = {
+  id: number;
+  alias_nombre: string;
+  direccion: string;
+};
+
+type DeudaCobro = {
+  id: number;
+  importe: number;
+  estado: 'PENDIENTE' | 'PAGADA';
+  justificante_url: string | null;
+  gasto: {
+    id: number;
+    concepto: string;
+    fecha_creacion: string;
+  };
+  deudor: {
+    id: number;
+    nombre: string;
+    apellidos: string | null;
+    avatar: string | null;
+  };
+};
+
+type CobrosResponse = {
+  vivienda: Vivienda;
+  periodo: {
+    inicio: string;
+    fin: string;
+  };
+  resumen: {
+    total_pagado_mes: number;
+    total_pendiente: number;
+    total_deudas: number;
+  };
+  deudas: DeudaCobro[];
+};
+
+const formatearImporte = (importe: number) =>
+  importe.toLocaleString('es-ES', { style: 'currency', currency: 'EUR' });
+
+const formatearFecha = (fechaIso: string) =>
+  new Date(fechaIso).toLocaleDateString('es-ES', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
+
+const obtenerIniciales = (nombre: string, apellidos: string | null) =>
+  `${nombre[0] ?? ''}${apellidos?.[0] ?? ''}`.toUpperCase();
+
+export default function CaseroCobrosScreen() {
+  const router = useRouter();
+  const [viviendas, setViviendas] = useState<Vivienda[]>([]);
+  const [viviendaSeleccionadaId, setViviendaSeleccionadaId] = useState<number | null>(null);
+  const [resumen, setResumen] = useState<CobrosResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadingCobros, setLoadingCobros] = useState(false);
+  const [justificanteSeleccionado, setJustificanteSeleccionado] = useState<DeudaCobro | null>(null);
+
+  const deudasPendientes = useMemo(
+    () => resumen?.deudas.filter((deuda) => deuda.estado === 'PENDIENTE') ?? [],
+    [resumen],
+  );
+  const deudasPagadas = useMemo(
+    () => resumen?.deudas.filter((deuda) => deuda.estado === 'PAGADA') ?? [],
+    [resumen],
+  );
+
+  const cargarCobros = useCallback(async (viviendaId: number) => {
+    setLoadingCobros(true);
+    try {
+      const { data } = await api.get<CobrosResponse>(`/viviendas/${viviendaId}/cobros`);
+      setResumen(data);
+    } catch (error: any) {
+      setResumen(null);
+      Toast.show({
+        type: 'error',
+        text1: error.response?.data?.error ?? 'No se pudo cargar el dashboard de cobros.',
+      });
+    } finally {
+      setLoadingCobros(false);
+    }
+  }, []);
+
+  const cargarContexto = useCallback(async () => {
+    setLoading(true);
+    try {
+      const { data } = await api.get<Vivienda[]>('/viviendas');
+      setViviendas(data);
+
+      if (data.length === 0) {
+        setViviendaSeleccionadaId(null);
+        setResumen(null);
+        return;
+      }
+
+      const viviendaInicial =
+        data.find((vivienda) => vivienda.id === viviendaSeleccionadaId) ?? data[0];
+
+      setViviendaSeleccionadaId(viviendaInicial.id);
+      await cargarCobros(viviendaInicial.id);
+    } catch {
+      setViviendas([]);
+      setViviendaSeleccionadaId(null);
+      setResumen(null);
+      Toast.show({ type: 'error', text1: 'No se pudieron cargar tus viviendas.' });
+    } finally {
+      setLoading(false);
+    }
+  }, [cargarCobros, viviendaSeleccionadaId]);
+
+  useFocusEffect(
+    useCallback(() => {
+      cargarContexto();
+    }, [cargarContexto]),
+  );
+
+  const cambiarVivienda = async (viviendaId: number) => {
+    setViviendaSeleccionadaId(viviendaId);
+    await cargarCobros(viviendaId);
+  };
+
+  if (loading) {
+    return <LoadingScreen />;
+  }
+
+  if (!viviendas.length) {
+    return (
+      <View style={styles.container}>
+        <View style={styles.emptyContainer}>
+          <View style={styles.emptyIconBox}>
+            <Ionicons name="home-outline" size={44} color={Theme.colors.primary} />
+          </View>
+          <Text style={styles.emptyTitle}>Primero añade una vivienda</Text>
+          <Text style={styles.emptySubtitle}>
+            El dashboard de cobros aparecerá aquí en cuanto tengas una propiedad creada.
+          </Text>
+          <CustomButton
+            label="Crear vivienda"
+            onPress={() => router.push('/casero/nueva-vivienda')}
+            style={styles.emptyAction}
+          />
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+        <View style={styles.header}>
+          <Text style={styles.headerEyebrow}>Dashboard financiero</Text>
+          <Text style={styles.headerTitle}>Cobros del mes</Text>
+          <Text style={styles.headerSubtitle}>
+            Controla qué recibos ya han entrado y qué importes siguen pendientes de cobro.
+          </Text>
+        </View>
+
+        {viviendas.length > 1 && (
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.viviendaSelectorContent}
+            style={styles.viviendaSelector}
+          >
+            {viviendas.map((vivienda) => {
+              const activa = vivienda.id === viviendaSeleccionadaId;
+              return (
+                <Pressable
+                  key={vivienda.id}
+                  style={[styles.viviendaChip, activa && styles.viviendaChipActive]}
+                  onPress={() => cambiarVivienda(vivienda.id)}
+                >
+                  <Text
+                    style={[
+                      styles.viviendaChipText,
+                      activa && styles.viviendaChipTextActive,
+                    ]}
+                  >
+                    {vivienda.alias_nombre}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </ScrollView>
+        )}
+
+        {resumen && (
+          <View style={styles.heroCard}>
+            <View style={styles.heroTop}>
+              <Text style={styles.heroLabel}>Vivienda activa</Text>
+              <Text style={styles.heroTitle}>{resumen.vivienda.alias_nombre}</Text>
+              <Text style={styles.heroAddress}>{resumen.vivienda.direccion}</Text>
+            </View>
+
+            <View style={styles.heroAmounts}>
+              <View style={[styles.heroAmountCard, styles.heroAmountCardPaid]}>
+                <Text style={[styles.heroAmountLabel, styles.heroAmountLabelPaid]}>
+                  Ingresado
+                </Text>
+                <Text style={styles.heroAmountValue}>
+                  {formatearImporte(resumen.resumen.total_pagado_mes)}
+                </Text>
+                <Text style={styles.heroAmountHelp}>Recibos marcados como pagados este mes</Text>
+              </View>
+
+              <View style={[styles.heroAmountCard, styles.heroAmountCardPending]}>
+                <Text style={[styles.heroAmountLabel, styles.heroAmountLabelPending]}>
+                  Pendiente
+                </Text>
+                <Text style={styles.heroAmountValue}>
+                  {formatearImporte(resumen.resumen.total_pendiente)}
+                </Text>
+                <Text style={styles.heroAmountHelp}>Importe aún abierto por cobrar</Text>
+              </View>
+            </View>
+          </View>
+        )}
+
+        <View style={styles.section}>
+          <View style={styles.sectionHeader}>
+            <Text style={styles.sectionTitle}>Pendientes de cobro</Text>
+            <Text style={styles.sectionSubtitle}>
+              Recibos del mes actual que todavía no han sido marcados como pagados.
+            </Text>
+          </View>
+
+          {loadingCobros ? (
+            <LoadingScreen />
+          ) : deudasPendientes.length === 0 ? (
+            <View style={styles.emptyContainer}>
+              <View style={styles.emptyIconBox}>
+                <Ionicons name="checkmark-done-outline" size={40} color={Theme.colors.success} />
+              </View>
+              <Text style={styles.emptyTitle}>Nada pendiente por ahora</Text>
+              <Text style={styles.emptySubtitle}>
+                Cuando haya importes abiertos para esta vivienda aparecerán aquí agrupados.
+              </Text>
+            </View>
+          ) : (
+            <View style={styles.debtList}>
+              {deudasPendientes.map((deuda) => (
+                <DeudaCard key={deuda.id} deuda={deuda} onVerJustificante={setJustificanteSeleccionado} />
+              ))}
+            </View>
+          )}
+        </View>
+
+        <View style={styles.section}>
+          <View style={styles.sectionHeader}>
+            <Text style={styles.sectionTitle}>Cobrados</Text>
+            <Text style={styles.sectionSubtitle}>
+              Pagos ya registrados, con acceso rápido al justificante cuando existe.
+            </Text>
+          </View>
+
+          {deudasPagadas.length === 0 ? (
+            <View style={styles.emptyContainer}>
+              <View style={styles.emptyIconBox}>
+                <Ionicons name="wallet-outline" size={40} color={Theme.colors.primary} />
+              </View>
+              <Text style={styles.emptyTitle}>Todavía no hay cobros cerrados</Text>
+              <Text style={styles.emptySubtitle}>
+                En cuanto un inquilino marque una deuda como pagada la verás aquí.
+              </Text>
+            </View>
+          ) : (
+            <View style={styles.debtList}>
+              {deudasPagadas.map((deuda) => (
+                <DeudaCard key={deuda.id} deuda={deuda} onVerJustificante={setJustificanteSeleccionado} />
+              ))}
+            </View>
+          )}
+        </View>
+      </ScrollView>
+
+      <Modal
+        visible={!!justificanteSeleccionado}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setJustificanteSeleccionado(null)}
+      >
+        <View style={styles.modalOverlay}>
+          <Pressable style={{ flex: 1 }} onPress={() => setJustificanteSeleccionado(null)} />
+          <View style={styles.modalSheet}>
+            <View style={styles.modalHandle} />
+            <Text style={styles.modalTitle}>Justificante</Text>
+            <Text style={styles.modalSubtitle}>
+              {justificanteSeleccionado
+                ? `${nombreCompleto(justificanteSeleccionado.deudor.nombre, justificanteSeleccionado.deudor.apellidos)} · ${justificanteSeleccionado.gasto.concepto}`
+                : ''}
+            </Text>
+
+            {justificanteSeleccionado?.justificante_url && (
+              <View style={styles.modalImageWrap}>
+                <Image
+                  source={{ uri: justificanteSeleccionado.justificante_url }}
+                  contentFit="contain"
+                  style={styles.modalImage}
+                />
+              </View>
+            )}
+
+            <View style={styles.modalActions}>
+              <CustomButton
+                label="Cerrar"
+                variant="secondary"
+                onPress={() => setJustificanteSeleccionado(null)}
+                style={styles.modalAction}
+              />
+            </View>
+          </View>
+        </View>
+      </Modal>
+    </View>
+  );
+}
+
+function DeudaCard({
+  deuda,
+  onVerJustificante,
+}: {
+  deuda: DeudaCobro;
+  onVerJustificante: (deuda: DeudaCobro) => void;
+}) {
+  return (
+    <View style={styles.debtCard}>
+      <View style={styles.debtRow}>
+        <View style={styles.avatar}>
+          <Text style={styles.avatarText}>
+            {obtenerIniciales(deuda.deudor.nombre, deuda.deudor.apellidos)}
+          </Text>
+        </View>
+
+        <View style={styles.debtBody}>
+          <Text style={styles.debtName} numberOfLines={1}>
+            {nombreCompleto(deuda.deudor.nombre, deuda.deudor.apellidos)}
+          </Text>
+          <Text style={styles.debtConcept} numberOfLines={2}>
+            {deuda.gasto.concepto}
+          </Text>
+          <Text style={styles.debtDate}>{formatearFecha(deuda.gasto.fecha_creacion)}</Text>
+        </View>
+
+        <View style={styles.debtMeta}>
+          <Text style={styles.debtAmount}>{formatearImporte(deuda.importe)}</Text>
+          <View
+            style={[
+              styles.statusBadge,
+              {
+                backgroundColor: ESTADO_BADGE_BG[deuda.estado],
+                borderColor: ESTADO_BADGE_BORDER[deuda.estado],
+              },
+            ]}
+          >
+            <Text
+              style={[
+                styles.statusBadgeText,
+                { color: ESTADO_BADGE_TEXT[deuda.estado] },
+              ]}
+            >
+              {deuda.estado}
+            </Text>
+          </View>
+        </View>
+      </View>
+
+      {deuda.estado === 'PAGADA' && deuda.justificante_url && (
+        <Pressable style={styles.receiptLink} onPress={() => onVerJustificante(deuda)}>
+          <Ionicons name="image-outline" size={15} color={Theme.colors.info} />
+          <Text style={styles.receiptLinkText}>Ver justificante</Text>
+        </Pressable>
+      )}
+    </View>
+  );
+}
+
+function nombreCompleto(nombre: string, apellidos: string | null) {
+  return apellidos ? `${nombre} ${apellidos}` : nombre;
+}

--- a/frontend/styles/casero/cobros.styles.ts
+++ b/frontend/styles/casero/cobros.styles.ts
@@ -1,0 +1,328 @@
+import { StyleSheet } from 'react-native';
+import { Theme } from '@/constants/theme';
+
+export const ESTADO_BADGE_BG = {
+  PENDIENTE: `${Theme.colors.warning}16`,
+  PAGADA: `${Theme.colors.success}18`,
+} as const;
+
+export const ESTADO_BADGE_TEXT = {
+  PENDIENTE: Theme.colors.warning,
+  PAGADA: Theme.colors.success,
+} as const;
+
+export const ESTADO_BADGE_BORDER = {
+  PENDIENTE: `${Theme.colors.warning}32`,
+  PAGADA: `${Theme.colors.success}30`,
+} as const;
+
+export const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Theme.colors.background,
+  },
+  content: {
+    paddingHorizontal: Theme.spacing.lg,
+    paddingTop: Theme.spacing.lg,
+    paddingBottom: 120,
+  },
+  header: {
+    marginBottom: Theme.spacing.lg,
+    gap: Theme.spacing.sm,
+  },
+  headerEyebrow: {
+    fontSize: Theme.typography.caption,
+    fontWeight: '800',
+    color: Theme.colors.textTertiary,
+    letterSpacing: 1.2,
+    textTransform: 'uppercase',
+  },
+  headerTitle: {
+    fontSize: Theme.typography.hero,
+    fontWeight: '800',
+    color: Theme.colors.text,
+    letterSpacing: -0.8,
+  },
+  headerSubtitle: {
+    fontSize: Theme.typography.body,
+    color: Theme.colors.textSecondary,
+    lineHeight: 22,
+  },
+  viviendaSelector: {
+    marginBottom: Theme.spacing.lg,
+  },
+  viviendaSelectorContent: {
+    gap: Theme.spacing.sm,
+    paddingRight: Theme.spacing.sm,
+  },
+  viviendaChip: {
+    paddingHorizontal: Theme.spacing.base,
+    paddingVertical: Theme.spacing.sm,
+    borderRadius: Theme.radius.full,
+    backgroundColor: Theme.colors.surface,
+    borderWidth: 1.5,
+    borderColor: Theme.colors.border,
+  },
+  viviendaChipActive: {
+    backgroundColor: Theme.colors.primaryLight,
+    borderColor: Theme.colors.primary,
+  },
+  viviendaChipText: {
+    fontSize: Theme.typography.label,
+    fontWeight: '700',
+    color: Theme.colors.textSecondary,
+  },
+  viviendaChipTextActive: {
+    color: Theme.colors.primary,
+  },
+  heroCard: {
+    backgroundColor: Theme.colors.surface,
+    borderRadius: Theme.radius.xl,
+    padding: Theme.spacing.lg,
+    marginBottom: Theme.spacing.xl,
+    gap: Theme.spacing.lg,
+    ...Theme.shadows.sm,
+  },
+  heroTop: {
+    gap: Theme.spacing.xs,
+  },
+  heroLabel: {
+    fontSize: Theme.typography.caption,
+    fontWeight: '800',
+    color: Theme.colors.textTertiary,
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+  },
+  heroTitle: {
+    fontSize: Theme.typography.heading,
+    fontWeight: '800',
+    color: Theme.colors.text,
+    letterSpacing: -0.4,
+  },
+  heroAddress: {
+    fontSize: Theme.typography.label,
+    color: Theme.colors.textSecondary,
+    lineHeight: 20,
+  },
+  heroAmounts: {
+    flexDirection: 'row',
+    gap: Theme.spacing.base,
+  },
+  heroAmountCard: {
+    flex: 1,
+    borderRadius: Theme.radius.lg,
+    padding: Theme.spacing.base,
+    gap: Theme.spacing.xs,
+  },
+  heroAmountCardPaid: {
+    backgroundColor: `${Theme.colors.success}12`,
+  },
+  heroAmountCardPending: {
+    backgroundColor: `${Theme.colors.warning}14`,
+  },
+  heroAmountLabel: {
+    fontSize: Theme.typography.caption,
+    fontWeight: '800',
+    letterSpacing: 0.8,
+    textTransform: 'uppercase',
+  },
+  heroAmountLabelPaid: {
+    color: Theme.colors.success,
+  },
+  heroAmountLabelPending: {
+    color: Theme.colors.warning,
+  },
+  heroAmountValue: {
+    fontSize: Theme.typography.heading,
+    fontWeight: '800',
+    color: Theme.colors.text,
+    letterSpacing: -0.5,
+  },
+  heroAmountHelp: {
+    fontSize: Theme.typography.caption,
+    color: Theme.colors.textSecondary,
+    lineHeight: 18,
+  },
+  section: {
+    marginBottom: Theme.spacing.xl,
+  },
+  sectionHeader: {
+    marginBottom: Theme.spacing.base,
+    gap: Theme.spacing.xs,
+  },
+  sectionTitle: {
+    fontSize: Theme.typography.subtitle,
+    fontWeight: '800',
+    color: Theme.colors.text,
+  },
+  sectionSubtitle: {
+    fontSize: Theme.typography.label,
+    color: Theme.colors.textSecondary,
+  },
+  debtList: {
+    gap: Theme.spacing.base,
+  },
+  debtCard: {
+    backgroundColor: Theme.colors.surface,
+    borderRadius: Theme.radius.lg,
+    padding: Theme.spacing.base,
+    ...Theme.shadows.sm,
+  },
+  debtRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Theme.spacing.base,
+  },
+  avatar: {
+    width: 56,
+    height: 56,
+    borderRadius: Theme.radius.full,
+    backgroundColor: `${Theme.colors.primary}14`,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+  avatarText: {
+    fontSize: Theme.typography.subtitle,
+    fontWeight: '800',
+    color: Theme.colors.primary,
+  },
+  debtBody: {
+    flex: 1,
+    gap: Theme.spacing.xs,
+  },
+  debtName: {
+    fontSize: Theme.typography.body,
+    fontWeight: '800',
+    color: Theme.colors.text,
+  },
+  debtConcept: {
+    fontSize: Theme.typography.label,
+    color: Theme.colors.textSecondary,
+    lineHeight: 20,
+  },
+  debtDate: {
+    fontSize: Theme.typography.caption,
+    color: Theme.colors.textTertiary,
+  },
+  debtMeta: {
+    alignItems: 'flex-end',
+    gap: Theme.spacing.sm,
+  },
+  debtAmount: {
+    fontSize: Theme.typography.subtitle,
+    fontWeight: '800',
+    color: Theme.colors.text,
+  },
+  statusBadge: {
+    paddingHorizontal: Theme.spacing.md,
+    paddingVertical: Theme.spacing.sm,
+    borderRadius: Theme.radius.full,
+    borderWidth: 1,
+  },
+  statusBadgeText: {
+    fontSize: Theme.typography.caption,
+    fontWeight: '800',
+  },
+  receiptLink: {
+    marginTop: Theme.spacing.base,
+    alignSelf: 'flex-start',
+    backgroundColor: `${Theme.colors.info}12`,
+    borderRadius: Theme.radius.full,
+    paddingHorizontal: Theme.spacing.md,
+    paddingVertical: Theme.spacing.sm,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Theme.spacing.xs,
+  },
+  receiptLinkText: {
+    fontSize: Theme.typography.caption,
+    fontWeight: '800',
+    color: Theme.colors.info,
+  },
+  emptyContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: Theme.spacing.xxl,
+    paddingHorizontal: Theme.spacing.xl,
+  },
+  emptyIconBox: {
+    width: 92,
+    height: 92,
+    borderRadius: Theme.radius.xl,
+    backgroundColor: `${Theme.colors.primary}12`,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: Theme.spacing.lg,
+  },
+  emptyTitle: {
+    fontSize: Theme.typography.heading,
+    fontWeight: '800',
+    color: Theme.colors.text,
+    textAlign: 'center',
+  },
+  emptySubtitle: {
+    marginTop: Theme.spacing.sm,
+    fontSize: Theme.typography.body,
+    color: Theme.colors.textSecondary,
+    textAlign: 'center',
+    lineHeight: 24,
+  },
+  emptyAction: {
+    width: '100%',
+    marginTop: Theme.spacing.xl,
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    justifyContent: 'flex-end',
+  },
+  modalSheet: {
+    backgroundColor: Theme.colors.background,
+    borderTopLeftRadius: Theme.radius.xl,
+    borderTopRightRadius: Theme.radius.xl,
+    paddingHorizontal: Theme.spacing.lg,
+    paddingTop: Theme.spacing.md,
+    paddingBottom: Theme.spacing.xl,
+  },
+  modalHandle: {
+    width: 44,
+    height: 4,
+    borderRadius: Theme.radius.full,
+    backgroundColor: Theme.colors.textMuted,
+    alignSelf: 'center',
+    marginBottom: Theme.spacing.base,
+  },
+  modalTitle: {
+    fontSize: Theme.typography.heading,
+    fontWeight: '800',
+    color: Theme.colors.text,
+    marginBottom: Theme.spacing.xs,
+  },
+  modalSubtitle: {
+    fontSize: Theme.typography.label,
+    color: Theme.colors.textSecondary,
+    lineHeight: 20,
+    marginBottom: Theme.spacing.lg,
+  },
+  modalImageWrap: {
+    width: '100%',
+    height: 320,
+    borderRadius: Theme.radius.xl,
+    overflow: 'hidden',
+    backgroundColor: Theme.colors.surface2,
+    marginBottom: Theme.spacing.lg,
+  },
+  modalImage: {
+    width: '100%',
+    height: '100%',
+    backgroundColor: Theme.colors.surface2,
+  },
+  modalActions: {
+    flexDirection: 'row',
+    gap: Theme.spacing.sm,
+  },
+  modalAction: {
+    flex: 1,
+  },
+});


### PR DESCRIPTION
## Summary

## Objetivo
Añadir el dashboard de cobros del casero con soporte backend y frontend para consultar importes pagados y pendientes del mes, revisar el detalle por inquilino y abrir justificantes de pago.

## Cambios principales
* Se crea el endpoint `GET /viviendas/:viviendaId/cobros` y su lógica de resumen financiero para vivienda del casero.
* Se conectan las rutas de cobros, justificantes, gastos recurrentes e inventario junto con utilidades compartidas de gastos.
* Se añade la nueva pestaña `Cobros` del casero con hero card, agrupación por estado y modal para visualizar justificantes.
* Se actualizan flujos relacionados de gastos, inventario y documentación técnica para reflejar los nuevos endpoints y pantallas.

## UI / UX
* Se incorporan tarjetas con fondo claro, `Theme.shadows.sm`, `Theme.radius.lg` y padding generoso.
* Se usan badges Soft Tint para estados de cobro y tokens de `frontend/constants/theme.ts` para colores semánticos.

## Changelog
* `docs/changelog/epica-12-issue-197-casero-dashboard-cobros.md`

## Testing
* `npm run build` en `backend`
* `npm run lint` en `frontend`
* `npx tsc --noEmit` en `frontend`