### PR TITLE
[Épica 12] Añade sistema automático de cobro por push

### DIFF
--- a/backend/src/controllers/user.controller.ts
+++ b/backend/src/controllers/user.controller.ts
@@ -2,11 +2,18 @@ import express from 'express';
 import { prisma } from '../lib/prisma';
 
 export const actualizarPushToken: express.RequestHandler = async (req, res) => {
-  const { token } = req.body as { token: string };
+  const { token } = req.body as { token?: unknown };
+
+  if (token !== null && (typeof token !== 'string' || token.trim().length === 0)) {
+    res.status(400).json({ error: 'Debes enviar un token valido.' });
+    return;
+  }
+
+  const tokenNormalizado = typeof token === 'string' ? token.trim() : null;
 
   await prisma.usuario.update({
     where: { id: req.usuario!.id },
-    data: { expo_push_token: token ?? null },
+    data: { expo_push_token: tokenNormalizado },
   });
 
   res.status(200).json({ mensaje: 'Push token actualizado.' });

--- a/backend/src/cron/recordatorios.cron.ts
+++ b/backend/src/cron/recordatorios.cron.ts
@@ -1,0 +1,88 @@
+import cron from 'node-cron';
+import { EstadoDeuda } from '../generated/prisma/client';
+import { prisma } from '../lib/prisma';
+import { enviarNotificacion } from '../services/push.service';
+
+let cronRecordatoriosMorososIniciado = false;
+
+const formatearImporte = (importe: number) => {
+  const importeNormalizado = Number.isInteger(importe)
+    ? importe.toString()
+    : importe.toFixed(2).replace('.', ',');
+
+  return `${importeNormalizado}€`;
+};
+
+const formatearNombre = (nombre: string, apellidos?: string | null) =>
+  [nombre, apellidos].filter(Boolean).join(' ');
+
+export const enviarRecordatoriosMorosos = async () => {
+  const deudasPendientes = await prisma.deuda.findMany({
+    where: {
+      estado: EstadoDeuda.PENDIENTE,
+      deudor: {
+        expo_push_token: {
+          not: null,
+        },
+      },
+    },
+    select: {
+      id: true,
+      importe: true,
+      deudor: {
+        select: {
+          expo_push_token: true,
+        },
+      },
+      acreedor: {
+        select: {
+          id: true,
+          nombre: true,
+          apellidos: true,
+        },
+      },
+    },
+  });
+
+  if (deudasPendientes.length === 0) {
+    console.log('[cron] No hay deudas pendientes con push token registrado.');
+    return;
+  }
+
+  console.log(`[cron] Enviando ${deudasPendientes.length} recordatorio(s) de deuda pendiente.`);
+
+  for (const deuda of deudasPendientes) {
+    const token = deuda.deudor.expo_push_token;
+
+    if (!token) {
+      continue;
+    }
+
+    const nombreAcreedor = formatearNombre(deuda.acreedor.nombre, deuda.acreedor.apellidos);
+    const mensaje = `Tienes un pago de ${formatearImporte(deuda.importe)} con ${nombreAcreedor} pendiente de realizar`;
+
+    try {
+      await enviarNotificacion(token, 'Pago pendiente', mensaje, {
+        deudaId: deuda.id,
+        acreedorId: deuda.acreedor.id,
+        tipo: 'recordatorio_deuda_pendiente',
+      });
+    } catch (error) {
+      console.error(`[cron] Error enviando recordatorio de la deuda ${deuda.id}:`, error);
+    }
+  }
+};
+
+export const iniciarCronRecordatoriosMorosos = () => {
+  if (cronRecordatoriosMorososIniciado) {
+    return;
+  }
+
+  cron.schedule('0 12 5 * *', async () => {
+    console.log('[cron] Ejecutando recordatorio mensual de pagos pendientes...');
+    await enviarRecordatoriosMorosos();
+  });
+
+  cronRecordatoriosMorososIniciado = true;
+  console.log('[cron] Recordatorio mensual de pagos pendientes programado para el dia 5 de cada mes a las 12:00.');
+};

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -14,6 +14,7 @@ import userRoutes from './routes/user.routes';
 import inventarioRoutes from './routes/inventario.routes';
 import './services/cron.service';
 import { iniciarCronMensualidades } from './cron/mensualidades.cron';
+import { iniciarCronRecordatoriosMorosos } from './cron/recordatorios.cron';
 
 const app = express();
 const PORT = 3000;
@@ -35,9 +36,11 @@ app.use('/api/viviendas', gastoRoutes);
 app.use('/api/viviendas', gastoRecurrenteRoutes);
 app.use('/api', deudaRoutes);
 app.use('/api', inventarioRoutes);
+app.use('/api/usuarios', userRoutes);
 app.use('/api/users', userRoutes);
 
 iniciarCronMensualidades();
+iniciarCronRecordatoriosMorosos();
 
 app.listen(PORT, () => {
   console.log(`Server running on http://localhost:${PORT}`);

--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -4,6 +4,7 @@ import { verificarToken } from '../middlewares/auth.middleware';
 
 const router = express.Router();
 
+router.patch('/me/push-token', verificarToken, actualizarPushToken);
 router.put('/push-token', verificarToken, actualizarPushToken);
 
 export default router;

--- a/backend/src/services/notification.service.ts
+++ b/backend/src/services/notification.service.ts
@@ -1,7 +1,5 @@
-import { Expo, ExpoPushMessage } from 'expo-server-sdk';
 import { prisma } from '../lib/prisma';
-
-const expo = new Expo();
+import { enviarNotificaciones } from './push.service';
 
 export async function enviarNotificacionPush(
   userIds: number[],
@@ -14,31 +12,9 @@ export async function enviarNotificacionPush(
     select: { expo_push_token: true },
   });
 
-  const mensajes: ExpoPushMessage[] = usuarios
-    .map((u) => u.expo_push_token)
-    .filter((token): token is string => !!token && Expo.isExpoPushToken(token))
-    .map((token) => ({
-      to: token,
-      title: titulo,
-      body: cuerpo,
-      data: data ?? {},
-      sound: 'default' as const,
-    }));
+  const tokens = usuarios
+    .map((usuario) => usuario.expo_push_token)
+    .filter((token): token is string => Boolean(token));
 
-  if (mensajes.length === 0) return;
-
-  const chunks = expo.chunkPushNotifications(mensajes);
-
-  for (const chunk of chunks) {
-    try {
-      const tickets = await expo.sendPushNotificationsAsync(chunk);
-      for (const ticket of tickets) {
-        if (ticket.status === 'error') {
-          console.error('[push] Error en ticket:', ticket.message);
-        }
-      }
-    } catch (err) {
-      console.error('[push] Error enviando chunk:', err);
-    }
-  }
+  await enviarNotificaciones(tokens, titulo, cuerpo, data);
 }

--- a/backend/src/services/push.service.ts
+++ b/backend/src/services/push.service.ts
@@ -1,0 +1,66 @@
+import { Expo, type ExpoPushMessage } from 'expo-server-sdk';
+
+const expo = new Expo();
+
+const enviarMensajes = async (mensajes: ExpoPushMessage[]) => {
+  if (mensajes.length === 0) {
+    return;
+  }
+
+  const chunks = expo.chunkPushNotifications(mensajes);
+
+  for (const chunk of chunks) {
+    try {
+      const tickets = await expo.sendPushNotificationsAsync(chunk);
+
+      for (const ticket of tickets) {
+        if (ticket.status === 'error') {
+          console.error('[push] Error en ticket:', ticket.message);
+        }
+      }
+    } catch (error) {
+      console.error('[push] Error enviando chunk:', error);
+    }
+  }
+};
+
+export async function enviarNotificacion(
+  token: string,
+  titulo: string,
+  mensaje: string,
+  data?: Record<string, unknown>,
+): Promise<void> {
+  if (!Expo.isExpoPushToken(token)) {
+    console.warn(`[push] Token Expo invalido ignorado: ${token}`);
+    return;
+  }
+
+  await enviarMensajes([
+    {
+      to: token,
+      title: titulo,
+      body: mensaje,
+      data: data ?? {},
+      sound: 'default',
+    },
+  ]);
+}
+
+export async function enviarNotificaciones(
+  tokens: string[],
+  titulo: string,
+  mensaje: string,
+  data?: Record<string, unknown>,
+): Promise<void> {
+  const mensajes = tokens
+    .filter((token) => Expo.isExpoPushToken(token))
+    .map<ExpoPushMessage>((token) => ({
+      to: token,
+      title: titulo,
+      body: mensaje,
+      data: data ?? {},
+      sound: 'default',
+    }));
+
+  await enviarMensajes(mensajes);
+}

--- a/docs/changelog/epica-12-issue-198-sistema-push.md
+++ b/docs/changelog/epica-12-issue-198-sistema-push.md
@@ -1,0 +1,25 @@
+# Issue #198 - Sistema automatico de cobro por push
+
+**Fecha:** 2026-04-10
+**Epica:** 12
+
+## Cambios tecnicos
+
+- `backend/src/services/push.service.ts`: nuevo servicio compartido para validar tokens Expo y enviar notificaciones individuales o por lotes con `expo-server-sdk`.
+- `backend/src/services/notification.service.ts`: refactor para reutilizar `push.service.ts` y mantener el envio push existente basado en usuarios.
+- `backend/src/controllers/user.controller.ts`: validacion del body y guardado del `expo_push_token` del usuario autenticado.
+- `backend/src/routes/user.routes.ts`: nuevo endpoint principal `PATCH /me/push-token` y alias legado `PUT /push-token`.
+- `backend/src/cron/recordatorios.cron.ts`: nuevo cron mensual `0 12 5 * *` que se ejecuta el dia 5 a las 12:00, recorre deudas `PENDIENTE` con token registrado y envia el recordatorio de pago al deudor.
+- `backend/src/index.ts`: registro de `/api/usuarios` e inicializacion explicita del cron de recordatorios junto al de mensualidades.
+- `frontend/utils/notifications.ts`: sincronizacion del Expo Push Token al nuevo endpoint, comprobacion de sesion antes del envio y resolucion del `projectId` desde `EAS`.
+- `frontend/app/_layout.tsx`: `useEffect` de arranque para sincronizar el token cuando existe sesion persistida y mantener el handler de foreground activo via import.
+- `frontend/app/index.tsx`: sincronizacion push tras login manual y login con Google.
+- `frontend/app/registro.tsx`: sincronizacion push tras registro manual y acceso con Google.
+- `frontend/app/rol.tsx`: sincronizacion push tras persistir el token cuando un alta nueva confirma el rol.
+- `frontend/app.json`: alta del plugin `expo-notifications` para que la configuracion nativa acompane al flujo de push.
+
+## Resultado tecnico observable
+
+- La app solicita permisos push en dispositivo fisico, obtiene el Expo Push Token y lo registra en backend para la sesion autenticada.
+- El backend expone `PATCH /api/usuarios/me/push-token` para guardar el token del usuario autenticado.
+- El dia 5 de cada mes a las 12:00 se envian recordatorios push a los deudores con pagos pendientes y token Expo disponible.

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -42,7 +42,8 @@
         }
       ],
       "expo-secure-store",
-      "expo-local-authentication"
+      "expo-local-authentication",
+      "expo-notifications"
     ],
     "experiments": {
       "typedRoutes": true

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -6,6 +6,7 @@ import { obtenerToken, eliminarToken } from '@/services/auth.service';
 import api from '@/services/api';
 import { Theme } from '@/constants/theme';
 import { toastConfig } from '@/constants/toastConfig';
+import { syncPushToken } from '@/utils/notifications';
 
 export default function RootLayout() {
   const router = useRouter();
@@ -17,6 +18,7 @@ export default function RootLayout() {
         const token = await obtenerToken();
         if (token) {
           const { data } = await api.get<{ rol: string }>('/auth/me');
+          void syncPushToken();
           const destino = data.rol === 'CASERO' ? '/casero/viviendas' : '/inquilino/inicio';
           router.replace(destino);
         }
@@ -28,7 +30,7 @@ export default function RootLayout() {
     };
 
     verificarSesion();
-  }, []);
+  }, [router]);
 
   return (
     <>

--- a/frontend/app/index.tsx
+++ b/frontend/app/index.tsx
@@ -1,6 +1,6 @@
 import { View, Text, Pressable } from 'react-native';
 import Toast from 'react-native-toast-message';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'expo-router';
 import { AntDesign } from '@expo/vector-icons';
 import * as Google from 'expo-auth-session/providers/google';
@@ -36,21 +36,12 @@ export default function LoginScreen() {
     scopes: ['openid', 'email', 'profile'],
   });
 
-  useEffect(() => {
-    if (googleResponse?.type === 'success') {
-      const idToken =
-        googleResponse.authentication?.idToken ??
-        (googleResponse.params as Record<string, string>)?.['id_token'];
-      if (idToken) handleGoogleLogin(idToken);
-    }
-  }, [googleResponse]);
-
-  const irAlDashboard = (rol: string) => {
+  const irAlDashboard = useCallback((rol: string) => {
     const destino = rol === 'CASERO' ? '/casero/viviendas' : '/inquilino/inicio';
     router.replace(destino);
-  };
+  }, [router]);
 
-  const handleGoogleLogin = async (idToken: string) => {
+  const handleGoogleLogin = useCallback(async (idToken: string) => {
     setLoading(true);
     try {
       const { data } = await api.post<{ token: string; usuario: { rol: string }; esNuevo: boolean }>(
@@ -58,7 +49,7 @@ export default function LoginScreen() {
         { idToken }
       );
       await guardarToken(data.token);
-      syncPushToken();
+      void syncPushToken();
       if (data.esNuevo) {
         router.replace('/rol');
       } else {
@@ -69,7 +60,16 @@ export default function LoginScreen() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [irAlDashboard, router]);
+
+  useEffect(() => {
+    if (googleResponse?.type === 'success') {
+      const idToken =
+        googleResponse.authentication?.idToken ??
+        (googleResponse.params as Record<string, string>)?.['id_token'];
+      if (idToken) void handleGoogleLogin(idToken);
+    }
+  }, [googleResponse, handleGoogleLogin]);
 
   const handleLogin = async () => {
     setLoading(true);
@@ -79,7 +79,7 @@ export default function LoginScreen() {
         { email, password }
       );
       await guardarToken(data.token);
-      syncPushToken();
+      void syncPushToken();
       irAlDashboard(data.usuario.rol);
     } catch (err: any) {
       const mensaje = err.response?.data?.error ?? 'Credenciales inválidas o sin conexión al servidor.';

--- a/frontend/app/registro.tsx
+++ b/frontend/app/registro.tsx
@@ -1,6 +1,6 @@
 import { View, Text, Pressable, ScrollView } from 'react-native';
 import Toast from 'react-native-toast-message';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'expo-router';
 import { AntDesign } from '@expo/vector-icons';
 import * as Google from 'expo-auth-session/providers/google';
@@ -38,16 +38,7 @@ export default function RegistroScreen() {
     scopes: ['openid', 'email', 'profile'],
   });
 
-  useEffect(() => {
-    if (googleResponse?.type === 'success') {
-      const idToken =
-        googleResponse.authentication?.idToken ??
-        (googleResponse.params as Record<string, string>)?.['id_token'];
-      if (idToken) handleGoogleLogin(idToken);
-    }
-  }, [googleResponse]);
-
-  const handleGoogleLogin = async (idToken: string) => {
+  const handleGoogleLogin = useCallback(async (idToken: string) => {
     setLoading(true);
     try {
       const { data } = await api.post<{ token: string; usuario: { rol: string }; esNuevo: boolean }>(
@@ -55,6 +46,7 @@ export default function RegistroScreen() {
         { idToken }
       );
       await guardarToken(data.token);
+      void syncPushToken();
       if (data.esNuevo) {
         router.replace('/rol');
       } else {
@@ -66,7 +58,16 @@ export default function RegistroScreen() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [router]);
+
+  useEffect(() => {
+    if (googleResponse?.type === 'success') {
+      const idToken =
+        googleResponse.authentication?.idToken ??
+        (googleResponse.params as Record<string, string>)?.['id_token'];
+      if (idToken) void handleGoogleLogin(idToken);
+    }
+  }, [googleResponse, handleGoogleLogin]);
 
   const handleRegistrar = async () => {
     if (
@@ -109,7 +110,7 @@ export default function RegistroScreen() {
         { nombre, apellidos, documento_identidad, email, telefono, password, rol }
       );
       await guardarToken(data.token);
-      syncPushToken();
+      void syncPushToken();
       const destino = data.usuario.rol === 'CASERO' ? '/casero/viviendas' : '/inquilino/inicio';
       router.replace(destino);
     } catch (err: any) {

--- a/frontend/app/rol.tsx
+++ b/frontend/app/rol.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'expo-router';
 import { styles } from '@/styles/rol.styles';
 import { guardarToken } from '@/services/auth.service';
 import api from '@/services/api';
+import { syncPushToken } from '@/utils/notifications';
 
 type Rol = 'CASERO' | 'INQUILINO';
 
@@ -21,6 +22,7 @@ export default function SeleccionRolScreen() {
         rol: rolSeleccionado,
       });
       await guardarToken(data.token);
+      void syncPushToken();
       const destino = data.usuario.rol === 'CASERO' ? '/casero/viviendas' : '/inquilino/inicio';
       router.replace(destino);
     } catch {

--- a/frontend/utils/notifications.ts
+++ b/frontend/utils/notifications.ts
@@ -3,6 +3,7 @@ import * as Notifications from 'expo-notifications';
 import Constants from 'expo-constants';
 import { Platform } from 'react-native';
 import api from '@/services/api';
+import { obtenerToken } from '@/services/auth.service';
 
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
@@ -39,7 +40,9 @@ export async function registerForPushNotificationsAsync(): Promise<string | null
   }
 
   const projectId =
-    Constants.expoConfig?.extra?.eas?.projectId ?? 'e4004191-4922-49cd-9f17-6cacd52578d1';
+    Constants.easConfig?.projectId ??
+    Constants.expoConfig?.extra?.eas?.projectId ??
+    'e4004191-4922-49cd-9f17-6cacd52578d1';
 
   let token: Awaited<ReturnType<typeof Notifications.getExpoPushTokenAsync>>;
   try {
@@ -62,9 +65,15 @@ export async function registerForPushNotificationsAsync(): Promise<string | null
 
 export async function syncPushToken(): Promise<void> {
   try {
+    const authToken = await obtenerToken();
+
+    if (!authToken) {
+      return;
+    }
+
     const token = await registerForPushNotificationsAsync();
     if (token) {
-      await api.put('/users/push-token', { token });
+      await api.patch('/usuarios/me/push-token', { token });
     }
   } catch (err) {
     console.warn('[push] No se pudo sincronizar el push token:', err);


### PR DESCRIPTION
## Summary
- Implementa el registro del `expo_push_token` del usuario autenticado y centraliza el envío de notificaciones push en backend.
- Añade el cron de recordatorios de deudas pendientes para el día 5 de cada mes a las 12:00.
- Integra en frontend la solicitud de permisos, obtención del token Expo y sincronización con el nuevo endpoint.
- Documenta la funcionalidad en el changelog técnico de la issue.

## Testing
- `npm run build` en `backend`
- `npm run lint` en `frontend` (sin errores; quedaron warnings previos no relacionados con esta PR)

## Objetivo
Esta PR añade la infraestructura necesaria para registrar dispositivos, enviar notificaciones push con Expo y automatizar el recordatorio de deudas pendientes a través de un cron mensual.

## Cambios principales
- Backend: nuevo servicio `backend/src/services/push.service.ts` para validar tokens Expo y enviar notificaciones individuales o en lote.
- Backend: endpoint `PATCH /api/usuarios/me/push-token` para guardar el `expo_push_token` del usuario autenticado.
- Backend: nuevo cron `backend/src/cron/recordatorios.cron.ts` que envía recordatorios a deudores con estado `PENDIENTE` y token registrado.
- Backend: integración del nuevo cron en `backend/src/index.ts` y reutilización del servicio push desde `backend/src/services/notification.service.ts`.
- Frontend: configuración de `expo-notifications` en `frontend/app.json` y sincronización del token desde `frontend/utils/notifications.ts`.
- Frontend: registro del token al arrancar la app y tras login, registro y selección de rol en `_layout.tsx`, `index.tsx`, `registro.tsx` y `rol.tsx`.

## UI / UX
- No aplica: no hay cambios visuales relevantes; el impacto es funcional en permisos y recepción de notificaciones.

## Changelog
- `docs/changelog/epica-12-issue-198-sistema-push.md`