### PR TITLE
Corrige el contexto de vivienda en tabs del casero y completa la épica 12

### DIFF
--- a/docs/changelog/epica-12-issue-sin-numero.md
+++ b/docs/changelog/epica-12-issue-sin-numero.md
@@ -10,7 +10,11 @@
 - `docs/backend/setup.md`: reescrita la guia de despliegue/configuracion para reflejar Cloudinary en inventario y justificantes, los cron de mensualidades/recordatorios y el registro del `expo_push_token`.
 - `docs/frontend/setup.md`: reescrita la guia del frontend con la estructura real de tabs del casero e inquilino, el flujo de cobros/gastos de la epica 12 y la sincronizacion de notificaciones push.
 - `README.md`: limpiado el contenido conflictivo y actualizado el resumen del producto para incluir cobros, mensualidades recurrentes y recordatorios push.
+- `frontend/app/casero/vivienda/[id]/(tabs)/limpieza.tsx`: sustituido `useGlobalSearchParams` por `useLocalSearchParams` para fijar el `id` de la vivienda y evitar recargas con ids de otras rutas abiertas.
+- `frontend/app/casero/vivienda/[id]/(tabs)/incidencias.tsx`: sustituido `useGlobalSearchParams` por `useLocalSearchParams` para mantener el contexto local de la vivienda dentro de la tab anidada.
+- `frontend/app/casero/vivienda/[id]/(tabs)/tablon.tsx`: sustituido `useGlobalSearchParams` por `useLocalSearchParams` para evitar colisiones del parametro `id` al navegar a pantallas como el perfil de inquilino.
 
 ## Resultado tecnico observable
 
 - La documentacion del repo vuelve a describir el comportamiento real de la epica 12 en contexto general, referencia API, setup backend, setup frontend y README.
+- Al entrar en `/casero/inquilino/[id]` desde el detalle de una vivienda, las tabs anidadas del casero ya no intentan recargar datos de limpieza, incidencias o tablon con el id del inquilino.

--- a/frontend/app/casero/vivienda/[id]/(tabs)/incidencias.tsx
+++ b/frontend/app/casero/vivienda/[id]/(tabs)/incidencias.tsx
@@ -4,7 +4,7 @@ import Toast from 'react-native-toast-message';
 import { LoadingScreen } from '@/components/common/LoadingScreen';
 import { Theme } from '@/constants/theme';
 import { useState, useCallback } from 'react';
-import { useGlobalSearchParams, useRouter, useFocusEffect } from 'expo-router';
+import { useLocalSearchParams, useRouter, useFocusEffect } from 'expo-router';
 import api from '@/services/api';
 import {
   styles,
@@ -34,7 +34,7 @@ type Incidencia = {
 const ESTADOS: Estado[] = ['PENDIENTE', 'EN_PROCESO', 'RESUELTA'];
 
 export default function IncidenciasCaseroTab() {
-  const { id } = useGlobalSearchParams<{ id: string }>();
+  const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
   const [incidencias, setIncidencias] = useState<Incidencia[]>([]);
   const [loading, setLoading] = useState(true);

--- a/frontend/app/casero/vivienda/[id]/(tabs)/limpieza.tsx
+++ b/frontend/app/casero/vivienda/[id]/(tabs)/limpieza.tsx
@@ -14,7 +14,7 @@ import { Ionicons } from '@expo/vector-icons';
 import Toast from 'react-native-toast-message';
 import { Theme } from '@/constants/theme';
 import { useState, useEffect } from 'react';
-import { useGlobalSearchParams } from 'expo-router';
+import { useLocalSearchParams } from 'expo-router';
 import api from '@/services/api';
 import { Card } from '@/components/common/Card';
 import { CustomButton } from '@/components/common/CustomButton';
@@ -122,7 +122,7 @@ type Turno = {
 // ─────────────────────────────────────────────────────────────────────────────
 
 export default function LimpiezaCaseroTab() {
-  const { id } = useGlobalSearchParams<{ id: string }>();
+  const { id } = useLocalSearchParams<{ id: string }>();
 
   // — Vista activa —
   const [vistaActual, setVistaActual] = useState<'CONFIG' | 'CALENDARIO'>('CONFIG');

--- a/frontend/app/casero/vivienda/[id]/(tabs)/tablon.tsx
+++ b/frontend/app/casero/vivienda/[id]/(tabs)/tablon.tsx
@@ -14,7 +14,7 @@ import { Ionicons } from '@expo/vector-icons';
 import Toast from 'react-native-toast-message';
 import { Theme } from '@/constants/theme';
 import { useState, useCallback } from 'react';
-import { useGlobalSearchParams, useFocusEffect } from 'expo-router';
+import { useLocalSearchParams, useFocusEffect } from 'expo-router';
 import api from '@/services/api';
 import { styles } from '@/styles/tablon/tablon.styles';
 
@@ -28,7 +28,7 @@ type Anuncio = {
 };
 
 export default function CaseroTablonTab() {
-  const { id } = useGlobalSearchParams<{ id: string }>();
+  const { id } = useLocalSearchParams<{ id: string }>();
   const [anuncios, setAnuncios] = useState<Anuncio[]>([]);
   const [loading, setLoading] = useState(true);
   const [modalVisible, setModalVisible] = useState(false);


### PR DESCRIPTION
## Summary
- Corrige el uso del `id` en las tabs anidadas de vivienda del casero para evitar cargas cruzadas al navegar al perfil de inquilinos
- Completa el flujo de cobros, mensualidades, justificantes y notificaciones push entre backend, frontend y documentación
- Reubica la gestión de mensualidades al contexto correcto de vivienda y refuerza permisos y copy en la UI

## Objetivo
Resolver inconsistencias de navegación y permisos en la gestión de vivienda del casero, cerrar el flujo financiero de la épica 12 y dejar sincronizados backend, frontend y documentación técnica.

## Cambios principales
- Se corrige la lectura de parámetros en `frontend/app/casero/vivienda/[id]/(tabs)` para mantener el contexto local de vivienda en limpieza, incidencias y tablón
- Se amplían y ajustan los endpoints y servicios de cobros, deudas, gastos recurrentes, inventario y push en backend
- Se integra la gestión de gastos fijos en la vista de vivienda del casero y se elimina su acceso desde la vista de inquilino
- Se actualizan cronjobs de mensualidades y recordatorios, junto con soporte de notificaciones push y configuración asociada
- Se alinean `README`, `CONTEXT.md`, guías de setup y documentación API con el comportamiento actual del sistema

## UI / UX
- Se ajusta la UI de cobros y detalle de vivienda usando `Theme.ts`, superficies soft tint y copy más natural para mensualidades y avisos
- Se reorganizan tabs y pantallas de casero e inquilino para que cada flujo viva en su contexto funcional correcto

## Changelog
- `docs/changelog/epica-12-issue-195-mensualidades-cronjobs.md`
- `docs/changelog/epica-12-issue-196-justificante-pago.md`
- `docs/changelog/epica-12-issue-197-casero-dashboard-cobros.md`
- `docs/changelog/epica-12-issue-198-sistema-push.md`
- `docs/changelog/epica-12-issue-sin-numero.md`
- `docs/changelog/epica-11-issue-sin-numero.md`

## Testing
- `npm run lint` en `frontend`
- `npm run build` en `backend`
- Not run (not requested)