### PR TITLE
Add módulos configurables por vivienda

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -91,6 +91,9 @@ model Vivienda {
   codigo_postal    String
   ciudad           String
   provincia        String
+  mod_limpieza     Boolean          @default(true)
+  mod_gastos       Boolean          @default(true)
+  mod_inventario   Boolean          @default(true)
   habitaciones     Habitacion[]
   incidencias      Incidencia[]
   anuncios         Anuncio[]

--- a/backend/src/controllers/vivienda.controller.ts
+++ b/backend/src/controllers/vivienda.controller.ts
@@ -98,6 +98,86 @@ export const obtenerVivienda: express.RequestHandler = async (req, res) => {
   res.status(200).json(vivienda);
 };
 
+export const actualizarVivienda: express.RequestHandler = async (req, res) => {
+  const id = parseInt(req.params['id'] as string, 10);
+  const { mod_limpieza, mod_gastos, mod_inventario } = req.body as {
+    mod_limpieza?: unknown;
+    mod_gastos?: unknown;
+    mod_inventario?: unknown;
+  };
+
+  if (!Number.isInteger(id) || id <= 0) {
+    res.status(400).json({ error: 'ID de vivienda invalido.' });
+    return;
+  }
+
+  if (req.usuario!.rol !== RolUsuario.CASERO) {
+    res.status(403).json({ error: 'Solo el casero puede configurar los modulos de una vivienda.' });
+    return;
+  }
+
+  const vivienda = await prisma.vivienda.findUnique({ where: { id } });
+  if (!vivienda || vivienda.casero_id !== req.usuario!.id) {
+    res.status(404).json({ error: 'Vivienda no encontrada.' });
+    return;
+  }
+
+  const data: {
+    mod_limpieza?: boolean;
+    mod_gastos?: boolean;
+    mod_inventario?: boolean;
+  } = {};
+
+  if (mod_limpieza !== undefined) {
+    if (typeof mod_limpieza !== 'boolean') {
+      res.status(400).json({ error: 'mod_limpieza debe ser booleano.' });
+      return;
+    }
+    data.mod_limpieza = mod_limpieza;
+  }
+
+  if (mod_gastos !== undefined) {
+    if (typeof mod_gastos !== 'boolean') {
+      res.status(400).json({ error: 'mod_gastos debe ser booleano.' });
+      return;
+    }
+    data.mod_gastos = mod_gastos;
+  }
+
+  if (mod_inventario !== undefined) {
+    if (typeof mod_inventario !== 'boolean') {
+      res.status(400).json({ error: 'mod_inventario debe ser booleano.' });
+      return;
+    }
+    data.mod_inventario = mod_inventario;
+  }
+
+  if (Object.keys(data).length === 0) {
+    res.status(400).json({ error: 'No hay modulos para actualizar.' });
+    return;
+  }
+
+  const viviendaActualizada = await prisma.vivienda.update({
+    where: { id },
+    data,
+    include: {
+      habitaciones: {
+        include: {
+          inquilino: {
+            select: { id: true, nombre: true, apellidos: true, email: true },
+          },
+          incidencias: {
+            where: { estado: { in: [EstadoIncidencia.PENDIENTE, EstadoIncidencia.EN_PROCESO] } },
+            select: { id: true, titulo: true, prioridad: true, estado: true },
+          },
+        },
+      },
+    },
+  });
+
+  res.status(200).json(viviendaActualizada);
+};
+
 export const crearHabitacion: express.RequestHandler = async (req, res) => {
   const viviendaId = parseInt(req.params['id'] as string, 10);
 

--- a/backend/src/middlewares/module.guard.ts
+++ b/backend/src/middlewares/module.guard.ts
@@ -1,0 +1,86 @@
+import express from 'express';
+import { prisma } from '../lib/prisma';
+
+type ModuloVivienda = 'limpieza' | 'gastos' | 'inventario';
+type CampoModulo = 'mod_limpieza' | 'mod_gastos' | 'mod_inventario';
+
+const CAMPO_MODULO: Record<ModuloVivienda, CampoModulo> = {
+  limpieza: 'mod_limpieza',
+  gastos: 'mod_gastos',
+  inventario: 'mod_inventario',
+};
+
+const obtenerParamNumerico = (valor: string | string[] | undefined) => {
+  const normalizado = Array.isArray(valor) ? valor[0] : valor;
+  return normalizado ? parseInt(normalizado, 10) : NaN;
+};
+
+const resolverViviendaIdDesdeParams: ResolverViviendaId = async (req) => {
+  const viviendaId = obtenerParamNumerico(req.params['viviendaId'] ?? req.params['id']);
+  return Number.isInteger(viviendaId) && viviendaId > 0 ? viviendaId : null;
+};
+
+type ResolverViviendaId = (req: express.Request) => Promise<number | null> | number | null;
+
+export const protegerModuloVivienda = (
+  modulo: ModuloVivienda,
+  resolverViviendaId: ResolverViviendaId = resolverViviendaIdDesdeParams,
+): express.RequestHandler => async (req, res, next) => {
+  const viviendaId = await resolverViviendaId(req);
+
+  if (!viviendaId) {
+    res.status(400).json({ error: 'viviendaId invalido.' });
+    return;
+  }
+
+  const campo = CAMPO_MODULO[modulo];
+  const vivienda = await prisma.vivienda.findUnique({
+    where: { id: viviendaId },
+    select: { [campo]: true },
+  });
+
+  if (!vivienda) {
+    res.status(404).json({ error: 'Vivienda no encontrada.' });
+    return;
+  }
+
+  if (!vivienda[campo]) {
+    res.status(403).json({ error: `El modulo ${modulo} esta desactivado para esta vivienda.` });
+    return;
+  }
+
+  next();
+};
+
+export const resolverViviendaIdDesdeItemInventario: ResolverViviendaId = async (req) => {
+  const itemId = obtenerParamNumerico(req.params['itemId']);
+  if (!Number.isInteger(itemId) || itemId <= 0) {
+    return null;
+  }
+
+  const item = await prisma.itemInventario.findUnique({
+    where: { id: itemId },
+    select: {
+      vivienda_id: true,
+      habitacion: { select: { vivienda_id: true } },
+    },
+  });
+
+  return item?.vivienda_id ?? item?.habitacion?.vivienda_id ?? null;
+};
+
+export const resolverViviendaIdDesdeDeuda: ResolverViviendaId = async (req) => {
+  const deudaId = obtenerParamNumerico(req.params['deudaId']);
+  if (!Number.isInteger(deudaId) || deudaId <= 0) {
+    return null;
+  }
+
+  const deuda = await prisma.deuda.findUnique({
+    where: { id: deudaId },
+    select: {
+      gasto: { select: { vivienda_id: true } },
+    },
+  });
+
+  return deuda?.gasto.vivienda_id ?? null;
+};

--- a/backend/src/routes/deuda.routes.ts
+++ b/backend/src/routes/deuda.routes.ts
@@ -2,12 +2,15 @@ import express from 'express';
 import { uploadJustificanteFoto } from '../config/cloudinary.config';
 import { subirJustificanteDeuda } from '../controllers/deuda.controller';
 import { verificarToken } from '../middlewares/auth.middleware';
+import { protegerModuloVivienda, resolverViviendaIdDesdeDeuda } from '../middlewares/module.guard';
 
 const router = express.Router();
+const gastosActivosPorDeuda = protegerModuloVivienda('gastos', resolverViviendaIdDesdeDeuda);
 
 router.post(
   '/deudas/:deudaId/justificante',
   verificarToken,
+  gastosActivosPorDeuda,
   uploadJustificanteFoto.single('justificante'),
   subirJustificanteDeuda,
 );

--- a/backend/src/routes/gasto-recurrente.routes.ts
+++ b/backend/src/routes/gasto-recurrente.routes.ts
@@ -1,13 +1,15 @@
 import express from 'express';
 import { verificarToken } from '../middlewares/auth.middleware';
+import { protegerModuloVivienda } from '../middlewares/module.guard';
 import {
   crearGastoRecurrente,
   listarGastosRecurrentes,
 } from '../controllers/gasto-recurrente.controller';
 
 const router = express.Router();
+const gastosActivos = protegerModuloVivienda('gastos');
 
-router.get('/:viviendaId/gastos-recurrentes', verificarToken, listarGastosRecurrentes);
-router.post('/:viviendaId/gastos-recurrentes', verificarToken, crearGastoRecurrente);
+router.get('/:viviendaId/gastos-recurrentes', verificarToken, gastosActivos, listarGastosRecurrentes);
+router.post('/:viviendaId/gastos-recurrentes', verificarToken, gastosActivos, crearGastoRecurrente);
 
 export default router;

--- a/backend/src/routes/gasto.routes.ts
+++ b/backend/src/routes/gasto.routes.ts
@@ -1,14 +1,16 @@
 import express from 'express';
 import { listarCobrosVivienda } from '../controllers/cobros.controller';
 import { verificarToken } from '../middlewares/auth.middleware';
+import { protegerModuloVivienda } from '../middlewares/module.guard';
 import { listarGastos, crearGasto, listarDeudas, saldarDeuda } from '../controllers/gasto.controller';
 
 const router = express.Router();
+const gastosActivos = protegerModuloVivienda('gastos');
 
-router.get('/:viviendaId/gastos', verificarToken, listarGastos);
-router.post('/:viviendaId/gastos', verificarToken, crearGasto);
-router.get('/:viviendaId/deudas', verificarToken, listarDeudas);
-router.get('/:viviendaId/cobros', verificarToken, listarCobrosVivienda);
-router.patch('/:viviendaId/deudas/:deudaId/saldar', verificarToken, saldarDeuda);
+router.get('/:viviendaId/gastos', verificarToken, gastosActivos, listarGastos);
+router.post('/:viviendaId/gastos', verificarToken, gastosActivos, crearGasto);
+router.get('/:viviendaId/deudas', verificarToken, gastosActivos, listarDeudas);
+router.get('/:viviendaId/cobros', verificarToken, gastosActivos, listarCobrosVivienda);
+router.patch('/:viviendaId/deudas/:deudaId/saldar', verificarToken, gastosActivos, saldarDeuda);
 
 export default router;

--- a/backend/src/routes/inventario.routes.ts
+++ b/backend/src/routes/inventario.routes.ts
@@ -7,30 +7,37 @@ import {
 } from '../controllers/inventario.controller';
 import { uploadInventarioFoto } from '../config/cloudinary.config';
 import { verificarToken } from '../middlewares/auth.middleware';
+import { protegerModuloVivienda, resolverViviendaIdDesdeItemInventario } from '../middlewares/module.guard';
 
 const router = express.Router();
+const inventarioActivo = protegerModuloVivienda('inventario');
+const inventarioActivoPorItem = protegerModuloVivienda('inventario', resolverViviendaIdDesdeItemInventario);
 
 router.post(
   '/viviendas/:viviendaId/inventario',
   verificarToken,
+  inventarioActivo,
   crearItemInventario,
 );
 
 router.get(
   '/viviendas/:viviendaId/inventario',
   verificarToken,
+  inventarioActivo,
   listarInventarioVivienda,
 );
 
 router.patch(
   '/inventario/:itemId/conformidad',
   verificarToken,
+  inventarioActivoPorItem,
   marcarConformidadInventario,
 );
 
 router.post(
   '/inventario/:itemId/fotos',
   verificarToken,
+  inventarioActivoPorItem,
   uploadInventarioFoto.single('foto'),
   subirFotoInventario,
 );

--- a/backend/src/routes/limpieza.routes.ts
+++ b/backend/src/routes/limpieza.routes.ts
@@ -1,17 +1,19 @@
 import express from 'express';
 import { verificarToken } from '../middlewares/auth.middleware';
+import { protegerModuloVivienda } from '../middlewares/module.guard';
 import { crearZona, listarZonas, actualizarZona, eliminarZona, asignarZonaFija, quitarAsignacionFija, generarTurnos, obtenerTurnos, marcarTurnoHecho } from '../controllers/limpieza.controller';
 
 const router = express.Router();
+const limpiezaActiva = protegerModuloVivienda('limpieza');
 
-router.post('/:id/limpieza/zonas', verificarToken, crearZona);
-router.get('/:id/limpieza/zonas', verificarToken, listarZonas);
-router.put('/:id/limpieza/zonas/:zonaId', verificarToken, actualizarZona);
-router.delete('/:id/limpieza/zonas/:zonaId', verificarToken, eliminarZona);
-router.post('/:id/limpieza/zonas/:zonaId/asignacion', verificarToken, asignarZonaFija);
-router.delete('/:id/limpieza/zonas/:zonaId/asignacion', verificarToken, quitarAsignacionFija);
-router.post('/:id/limpieza/generar', verificarToken, generarTurnos);
-router.get('/:id/limpieza/turnos', verificarToken, obtenerTurnos);
-router.patch('/:id/limpieza/turnos/:turnoId/hecho', verificarToken, marcarTurnoHecho);
+router.post('/:id/limpieza/zonas', verificarToken, limpiezaActiva, crearZona);
+router.get('/:id/limpieza/zonas', verificarToken, limpiezaActiva, listarZonas);
+router.put('/:id/limpieza/zonas/:zonaId', verificarToken, limpiezaActiva, actualizarZona);
+router.delete('/:id/limpieza/zonas/:zonaId', verificarToken, limpiezaActiva, eliminarZona);
+router.post('/:id/limpieza/zonas/:zonaId/asignacion', verificarToken, limpiezaActiva, asignarZonaFija);
+router.delete('/:id/limpieza/zonas/:zonaId/asignacion', verificarToken, limpiezaActiva, quitarAsignacionFija);
+router.post('/:id/limpieza/generar', verificarToken, limpiezaActiva, generarTurnos);
+router.get('/:id/limpieza/turnos', verificarToken, limpiezaActiva, obtenerTurnos);
+router.patch('/:id/limpieza/turnos/:turnoId/hecho', verificarToken, limpiezaActiva, marcarTurnoHecho);
 
 export default router;

--- a/backend/src/routes/vivienda.routes.ts
+++ b/backend/src/routes/vivienda.routes.ts
@@ -1,12 +1,13 @@
 import express from 'express';
 import { verificarToken } from '../middlewares/auth.middleware';
-import { listarViviendas, crearVivienda, obtenerVivienda, crearHabitacion, editarHabitacion, eliminarHabitacion, expulsarInquilino } from '../controllers/vivienda.controller';
+import { listarViviendas, crearVivienda, obtenerVivienda, actualizarVivienda, crearHabitacion, editarHabitacion, eliminarHabitacion, expulsarInquilino } from '../controllers/vivienda.controller';
 
 const router = express.Router();
 
 router.get('/', verificarToken, listarViviendas);
 router.post('/', verificarToken, crearVivienda);
 router.get('/:id', verificarToken, obtenerVivienda);
+router.patch('/:id', verificarToken, actualizarVivienda);
 router.post('/:id/habitaciones', verificarToken, crearHabitacion);
 router.put('/:id/habitaciones/:habId', verificarToken, editarHabitacion);
 router.delete('/:id/habitaciones/:habId/inquilino', verificarToken, expulsarInquilino);

--- a/docs/changelog/epica13/epica-13-issue-217.md
+++ b/docs/changelog/epica13/epica-13-issue-217.md
@@ -1,0 +1,26 @@
+# Issue #217 — modulos configurables por vivienda
+
+**Fecha:** 2026-04-10
+**Epica:** 13
+
+## Cambios tecnicos
+
+- `backend/prisma/schema.prisma`: anadidos `mod_limpieza`, `mod_gastos` y `mod_inventario` en `Vivienda` con `@default(true)`.
+- `backend/src/middlewares/module.guard.ts`: creado guard reutilizable para bloquear con 403 los modulos desactivados por vivienda, incluyendo resolvers para item de inventario y deuda.
+- `backend/src/controllers/vivienda.controller.ts`: expuesto `PATCH /viviendas/:id` para actualizar flags de modulos solo por el casero propietario.
+- `backend/src/routes/limpieza.routes.ts`: protegido el modulo de limpieza en zonas, turnos y asignaciones.
+- `backend/src/routes/gasto.routes.ts`: protegido el modulo de gastos en gastos, deudas, cobros y saldado.
+- `backend/src/routes/gasto-recurrente.routes.ts`: protegido el modulo de gastos en mensualidades recurrentes.
+- `backend/src/routes/deuda.routes.ts`: protegido el modulo de gastos antes de subir justificantes de deuda.
+- `backend/src/routes/inventario.routes.ts`: protegido el modulo de inventario en alta, listado, conformidad y subida de fotos.
+- `backend/src/routes/vivienda.routes.ts`: registrada la ruta `PATCH /viviendas/:id`.
+- `frontend/app/casero/vivienda/[id]/(tabs)/index.tsx`: anadida seccion "Configuracion de Modulos" con switches y actualizacion PATCH.
+- `frontend/styles/casero/vivienda/detalle.styles.ts`: estilos de tarjetas de modulos con `Theme.radius.lg`, `Theme.shadows.sm` y superficies blancas.
+- `frontend/app/casero/(tabs)/_layout.tsx`: ocultacion condicional de tabs globales de Cobros e Inventario segun viviendas con modulo activo.
+- `frontend/app/casero/vivienda/[id]/(tabs)/_layout.tsx`: ocultacion condicional de la tab Limpieza segun la vivienda abierta.
+- `frontend/app/inquilino/(tabs)/_layout.tsx`: ocultacion condicional de Limpieza, Gastos e Inventario segun la vivienda del inquilino.
+
+## Validacion
+
+- `backend`: `npm run build`.
+- `frontend`: `npm run lint` sin errores bloqueantes; quedan warnings preexistentes del proyecto.

--- a/frontend/app/casero/(tabs)/_layout.tsx
+++ b/frontend/app/casero/(tabs)/_layout.tsx
@@ -1,8 +1,47 @@
-import { Tabs } from 'expo-router';
+import { useCallback, useState } from 'react';
+import { Tabs, useFocusEffect } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { Theme } from '@/constants/theme';
+import api from '@/services/api';
+
+type ViviendaModulos = {
+  mod_gastos: boolean;
+  mod_inventario: boolean;
+};
 
 export default function CaseroTabsLayout() {
+  const [modulos, setModulos] = useState({
+    gastos: true,
+    inventario: true,
+  });
+
+  useFocusEffect(
+    useCallback(() => {
+      let activo = true;
+
+      const cargarModulos = async () => {
+        try {
+          const { data } = await api.get<ViviendaModulos[]>('/viviendas');
+          if (!activo || data.length === 0) return;
+
+          setModulos({
+            gastos: data.some((vivienda) => vivienda.mod_gastos),
+            inventario: data.some((vivienda) => vivienda.mod_inventario),
+          });
+        } catch {
+          if (activo) {
+            setModulos({ gastos: true, inventario: true });
+          }
+        }
+      };
+
+      cargarModulos();
+      return () => {
+        activo = false;
+      };
+    }, []),
+  );
+
   return (
     <Tabs
       screenOptions={{
@@ -37,6 +76,7 @@ export default function CaseroTabsLayout() {
         name="cobros"
         options={{
           title: 'Cobros',
+          href: modulos.gastos ? undefined : null,
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="wallet-outline" size={size} color={color} />
           ),
@@ -46,6 +86,7 @@ export default function CaseroTabsLayout() {
         name="inventario"
         options={{
           title: 'Inventario',
+          href: modulos.inventario ? undefined : null,
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="albums-outline" size={size} color={color} />
           ),

--- a/frontend/app/casero/vivienda/[id]/(tabs)/_layout.tsx
+++ b/frontend/app/casero/vivienda/[id]/(tabs)/_layout.tsx
@@ -1,10 +1,42 @@
-import { Tabs, useRouter } from 'expo-router';
+import { useCallback, useState } from 'react';
+import { Tabs, useFocusEffect, useLocalSearchParams, useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { Pressable } from 'react-native';
 import { Theme } from '@/constants/theme';
+import api from '@/services/api';
+
+type ViviendaModulos = {
+  mod_limpieza: boolean;
+};
 
 export default function ViviendaTabsLayout() {
   const router = useRouter();
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const [modulos, setModulos] = useState({ limpieza: true });
+
+  useFocusEffect(
+    useCallback(() => {
+      let activo = true;
+
+      const cargarModulos = async () => {
+        try {
+          const { data } = await api.get<ViviendaModulos>(`/viviendas/${id}`);
+          if (activo) {
+            setModulos({ limpieza: data.mod_limpieza });
+          }
+        } catch {
+          if (activo) {
+            setModulos({ limpieza: true });
+          }
+        }
+      };
+
+      cargarModulos();
+      return () => {
+        activo = false;
+      };
+    }, [id]),
+  );
 
   return (
     <Tabs
@@ -70,6 +102,7 @@ export default function ViviendaTabsLayout() {
         name="limpieza"
         options={{
           title: 'Limpieza',
+          href: modulos.limpieza ? undefined : null,
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="sparkles-outline" size={size} color={color} />
           ),

--- a/frontend/app/casero/vivienda/[id]/(tabs)/index.tsx
+++ b/frontend/app/casero/vivienda/[id]/(tabs)/index.tsx
@@ -6,6 +6,7 @@ import {
   Pressable,
   ScrollView,
   Share,
+  Switch,
   Text,
   View,
 } from 'react-native';
@@ -55,8 +56,13 @@ type Vivienda = {
   id: number;
   alias_nombre: string;
   direccion: string;
+  mod_limpieza: boolean;
+  mod_gastos: boolean;
+  mod_inventario: boolean;
   habitaciones: Habitacion[];
 };
+
+type ModuloViviendaKey = 'mod_limpieza' | 'mod_gastos' | 'mod_inventario';
 
 type GastoRecurrente = {
   id: number;
@@ -84,6 +90,32 @@ const HAB_ICONS: Record<string, any> = {
 
 const formatearImporte = (importe: number) =>
   importe.toLocaleString('es-ES', { style: 'currency', currency: 'EUR' });
+
+const MODULOS_VIVIENDA: {
+  key: ModuloViviendaKey;
+  titulo: string;
+  descripcion: string;
+  icono: keyof typeof Ionicons.glyphMap;
+}[] = [
+  {
+    key: 'mod_limpieza',
+    titulo: 'Limpieza y Tareas',
+    descripcion: 'Turnos, zonas y asignaciones de limpieza.',
+    icono: 'sparkles-outline',
+  },
+  {
+    key: 'mod_gastos',
+    titulo: 'Gastos y Finanzas',
+    descripcion: 'Gastos compartidos, deudas, cobros y mensualidades.',
+    icono: 'wallet-outline',
+  },
+  {
+    key: 'mod_inventario',
+    titulo: 'Inventario y Assets',
+    descripcion: 'Items, fotos y conformidad del inventario.',
+    icono: 'albums-outline',
+  },
+];
 
 const AvatarInitials = ({
   nombre,
@@ -126,13 +158,16 @@ export default function ResumenViviendaTab() {
   const [importeMensualidad, setImporteMensualidad] = useState('');
   const [diaMensualidad, setDiaMensualidad] = useState('');
   const [guardandoMensualidad, setGuardandoMensualidad] = useState(false);
+  const [actualizandoModulo, setActualizandoModulo] = useState<ModuloViviendaKey | null>(null);
 
   const cargarVivienda = useCallback(async () => {
     try {
       const { data } = await api.get<Vivienda>(`/viviendas/${id}`);
       setVivienda(data);
+      return data;
     } catch {
       Toast.show({ type: 'error', text1: 'No se pudo cargar la vivienda.' });
+      return null;
     }
   }, [id]);
 
@@ -153,7 +188,12 @@ export default function ResumenViviendaTab() {
     useCallback(() => {
       const cargarTodo = async () => {
         setLoading(true);
-        await Promise.all([cargarVivienda(), cargarGastosRecurrentes()]);
+        const viviendaActual = await cargarVivienda();
+        if (viviendaActual?.mod_gastos) {
+          await cargarGastosRecurrentes();
+        } else {
+          setGastosRecurrentes([]);
+        }
         setLoading(false);
       };
 
@@ -298,6 +338,33 @@ export default function ResumenViviendaTab() {
     }
   };
 
+  const actualizarModulo = async (key: ModuloViviendaKey, value: boolean) => {
+    if (!vivienda || actualizandoModulo) return;
+
+    const anterior = vivienda;
+    setVivienda({ ...vivienda, [key]: value });
+    setActualizandoModulo(key);
+
+    try {
+      const { data } = await api.patch<Vivienda>(`/viviendas/${id}`, { [key]: value });
+      setVivienda(data);
+      if (key === 'mod_gastos' && !value) {
+        setGastosRecurrentes([]);
+      } else if (key === 'mod_gastos' && value) {
+        await cargarGastosRecurrentes();
+      }
+      Toast.show({ type: 'success', text1: 'Configuracion actualizada.' });
+    } catch (err: any) {
+      setVivienda(anterior);
+      Toast.show({
+        type: 'error',
+        text1: err.response?.data?.error ?? 'No se pudo actualizar el modulo.',
+      });
+    } finally {
+      setActualizandoModulo(null);
+    }
+  };
+
   const puedeGuardarMensualidad =
     conceptoMensualidad.trim().length > 0 &&
     importeMensualidad.trim().length > 0 &&
@@ -363,6 +430,45 @@ export default function ResumenViviendaTab() {
           </Pressable>
         </View>
 
+        <View style={styles.modulosSection}>
+          <View style={styles.sectionHeaderTextGroup}>
+            <Text style={styles.seccionTitulo}>Configuracion de Modulos</Text>
+            <Text style={styles.sectionDescription}>
+              Activa solo las herramientas que quieres usar en esta vivienda.
+            </Text>
+          </View>
+
+          <View style={styles.modulosList}>
+            {MODULOS_VIVIENDA.map((modulo) => {
+              const activo = vivienda[modulo.key];
+              const actualizando = actualizandoModulo === modulo.key;
+
+              return (
+                <View key={modulo.key} style={styles.moduloCard}>
+                  <View style={styles.moduloIconBox}>
+                    <Ionicons name={modulo.icono} size={20} color={Theme.colors.primary} />
+                  </View>
+                  <View style={styles.moduloBody}>
+                    <Text style={styles.moduloTitulo}>{modulo.titulo}</Text>
+                    <Text style={styles.moduloDescripcion}>{modulo.descripcion}</Text>
+                  </View>
+                  <Switch
+                    value={activo}
+                    disabled={actualizandoModulo !== null}
+                    onValueChange={(value) => actualizarModulo(modulo.key, value)}
+                    trackColor={{ false: Theme.colors.border, true: Theme.colors.success }}
+                    thumbColor={Theme.colors.surface}
+                    accessibilityLabel={`${activo ? 'Desactivar' : 'Activar'} ${modulo.titulo}`}
+                  />
+                  {actualizando && <View style={styles.moduloUpdatingOverlay} />}
+                </View>
+              );
+            })}
+          </View>
+        </View>
+
+        {vivienda.mod_gastos && (
+          <>
         <View style={styles.sectionHeaderRow}>
           <View style={styles.sectionHeaderTextGroup}>
             <Text style={styles.seccionTitulo}>Gastos fijos / Mensualidades</Text>
@@ -411,6 +517,8 @@ export default function ResumenViviendaTab() {
               </View>
             </View>
           ))
+        )}
+          </>
         )}
 
         <Text style={styles.seccionTitulo}>Habitaciones</Text>

--- a/frontend/app/inquilino/(tabs)/_layout.tsx
+++ b/frontend/app/inquilino/(tabs)/_layout.tsx
@@ -1,8 +1,50 @@
-import { Tabs } from "expo-router";
+import { useCallback, useState } from "react";
+import { Tabs, useFocusEffect } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import { Theme } from "@/constants/theme";
+import api from "@/services/api";
+
+type ViviendaModulos = {
+  mod_limpieza: boolean;
+  mod_gastos: boolean;
+  mod_inventario: boolean;
+};
 
 export default function InquilinoTabsLayout() {
+  const [modulos, setModulos] = useState({
+    limpieza: false,
+    gastos: false,
+    inventario: false,
+  });
+
+  useFocusEffect(
+    useCallback(() => {
+      let activo = true;
+
+      const cargarModulos = async () => {
+        try {
+          const { data } = await api.get<{ vivienda: ViviendaModulos }>("/inquilino/vivienda");
+          if (!activo) return;
+
+          setModulos({
+            limpieza: data.vivienda.mod_limpieza,
+            gastos: data.vivienda.mod_gastos,
+            inventario: data.vivienda.mod_inventario,
+          });
+        } catch {
+          if (activo) {
+            setModulos({ limpieza: false, gastos: false, inventario: false });
+          }
+        }
+      };
+
+      cargarModulos();
+      return () => {
+        activo = false;
+      };
+    }, []),
+  );
+
   return (
     <Tabs
       screenOptions={{
@@ -46,6 +88,7 @@ export default function InquilinoTabsLayout() {
         name="limpieza"
         options={{
           title: "Limpieza",
+          href: modulos.limpieza ? undefined : null,
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="sparkles-outline" size={size} color={color} />
           ),
@@ -55,6 +98,7 @@ export default function InquilinoTabsLayout() {
         name="gastos"
         options={{
           title: "Gastos",
+          href: modulos.gastos ? undefined : null,
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="wallet-outline" size={size} color={color} />
           ),
@@ -64,6 +108,7 @@ export default function InquilinoTabsLayout() {
         name="inventario"
         options={{
           title: "Inventario",
+          href: modulos.inventario ? undefined : null,
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="images-outline" size={size} color={color} />
           ),

--- a/frontend/styles/casero/vivienda/detalle.styles.ts
+++ b/frontend/styles/casero/vivienda/detalle.styles.ts
@@ -146,6 +146,50 @@ export const styles = StyleSheet.create({
     fontWeight: '800',
     color: Theme.colors.primary,
   },
+  modulosSection: {
+    marginBottom: Theme.spacing.lg,
+    gap: Theme.spacing.md,
+  },
+  modulosList: {
+    gap: Theme.spacing.sm,
+  },
+  moduloCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Theme.spacing.base,
+    backgroundColor: Theme.colors.surface,
+    borderRadius: Theme.radius.lg,
+    padding: Theme.spacing.base,
+    ...Theme.shadows.sm,
+  },
+  moduloIconBox: {
+    width: 44,
+    height: 44,
+    borderRadius: Theme.radius.lg,
+    backgroundColor: Theme.colors.primaryLight,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+  moduloBody: {
+    flex: 1,
+    gap: Theme.spacing.xs,
+  },
+  moduloTitulo: {
+    fontSize: Theme.typography.body,
+    fontWeight: '800',
+    color: Theme.colors.text,
+  },
+  moduloDescripcion: {
+    fontSize: Theme.typography.label,
+    color: Theme.colors.textSecondary,
+    lineHeight: 20,
+  },
+  moduloUpdatingOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    borderRadius: Theme.radius.lg,
+    backgroundColor: Theme.colors.surface + '66',
+  },
   recurringCard: {
     flexDirection: 'row',
     alignItems: 'center',


### PR DESCRIPTION
## Objetivo
Permitir activar o desactivar funcionalidades por vivienda para controlar qué módulos están disponibles para caseros e inquilinos.

## Cambios principales
* Añade flags de módulo en `Vivienda`: limpieza, gastos e inventario.
* Incorpora un guard backend reutilizable que bloquea con `403` los endpoints de módulos desactivados.
* Protege rutas de limpieza, gastos, cobros, deudas, mensualidades e inventario.
* Añade actualización de configuración de módulos desde `PATCH /viviendas/:id`.
* Oculta tabs de módulos desactivados en la navegación de casero e inquilino.

## UI / UX
* Añade sección de configuración de módulos con switches en la vista de vivienda del casero.
* Usa superficies blancas, `Theme.radius.lg`, `Theme.shadows.sm` y tokens de `Theme.ts`.

## Changelog
* `docs/changelog/epica13/epica-13-issue-217.md`

## Testing
* `backend`: `npm run build`
* `frontend`: `npx tsc --noEmit`
* `frontend`: `npm run lint`