### PR TITLE
Refactor [Épica 13] mueve módulos de vivienda a opciones

### DIFF
--- a/docs/changelog/epica13/epica-13-issue-227.md
+++ b/docs/changelog/epica13/epica-13-issue-227.md
@@ -1,0 +1,20 @@
+# Issue #227 — modulos de vivienda desde opciones
+
+**Fecha:** 2026-04-11
+**Epica:** 13
+
+## Cambios tecnicos
+
+- `frontend/app/casero/vivienda/[id]/(tabs)/opciones.tsx`: creado el nuevo tab `Opciones` de la vivienda para centralizar la gestion de modulos en el lugar natural de configuracion de la casa.
+- `frontend/components/casero/vivienda/ModulosViviendaManager.tsx`: extraida la UI de switches de modulos a un componente reutilizable que actualiza `mod_limpieza`, `mod_gastos` y `mod_inventario` mediante `PATCH /viviendas/:id`.
+- `frontend/utils/viviendaModules.ts`: anadido un canal local de notificacion para propagar cambios de modulos por `viviendaId` sin requerir recargar la app ni salir de la navegacion actual.
+- `frontend/app/casero/vivienda/[id]/(tabs)/_layout.tsx`: incorporado el tab `Opciones` y suscripcion a cambios de modulos para ocultar o mostrar `Limpieza` automaticamente segun la vivienda abierta.
+- `frontend/app/casero/vivienda/[id]/(tabs)/index.tsx`: retirada la seccion de configuracion de modulos del resumen para evitar duplicidad y dejar la gestion dentro de opciones.
+- `frontend/app/casero/(tabs)/_layout.tsx`: refresco automatico de tabs globales de casero cuando cambian los modulos de una vivienda.
+- `frontend/app/casero/(tabs)/cobros.tsx`: filtrado de viviendas para que el dashboard solo pueda seleccionar casas con `mod_gastos` activo y no intente cargar cobros de viviendas donde el modulo esta desactivado.
+- `frontend/app/casero/(tabs)/inventario.tsx`: filtrado de viviendas para que inventario solo trabaje con casas con `mod_inventario` activo y evite estados inconsistentes tras desactivar el modulo.
+
+## Validacion
+
+- `frontend`: `npm run lint` sin errores bloqueantes; quedan warnings preexistentes del proyecto.
+- `frontend`: `npx tsc --noEmit` sin errores.

--- a/frontend/app/casero/(tabs)/_layout.tsx
+++ b/frontend/app/casero/(tabs)/_layout.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Tabs, useFocusEffect } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { Theme } from '@/constants/theme';
 import api from '@/services/api';
+import { onModulosViviendaActualizados } from '@/utils/viviendaModules';
 
 type ViviendaModulos = {
   mod_gastos: boolean;
@@ -15,11 +16,24 @@ export default function CaseroTabsLayout() {
     inventario: true,
   });
 
+  const cargarModulos = useCallback(async () => {
+    try {
+      const { data } = await api.get<ViviendaModulos[]>('/viviendas');
+
+      setModulos({
+        gastos: data.some((vivienda) => vivienda.mod_gastos),
+        inventario: data.some((vivienda) => vivienda.mod_inventario),
+      });
+    } catch {
+      setModulos({ gastos: true, inventario: true });
+    }
+  }, []);
+
   useFocusEffect(
     useCallback(() => {
       let activo = true;
 
-      const cargarModulos = async () => {
+      const cargarModulosSeguro = async () => {
         try {
           const { data } = await api.get<ViviendaModulos[]>('/viviendas');
           if (!activo || data.length === 0) return;
@@ -35,12 +49,14 @@ export default function CaseroTabsLayout() {
         }
       };
 
-      cargarModulos();
+      cargarModulosSeguro();
       return () => {
         activo = false;
       };
     }, []),
   );
+
+  useEffect(() => onModulosViviendaActualizados(() => cargarModulos()), [cargarModulos]);
 
   return (
     <Tabs

--- a/frontend/app/casero/(tabs)/cobros.tsx
+++ b/frontend/app/casero/(tabs)/cobros.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   KeyboardAvoidingView,
@@ -22,6 +22,7 @@ import { CustomInput } from '@/components/common/CustomInput';
 import { LoadingScreen } from '@/components/common/LoadingScreen';
 import { Theme } from '@/constants/theme';
 import api from '@/services/api';
+import { onModulosViviendaActualizados } from '@/utils/viviendaModules';
 import {
   ESTADO_BADGE_BG,
   ESTADO_BADGE_BORDER,
@@ -33,6 +34,7 @@ type Vivienda = {
   id: number;
   alias_nombre: string;
   direccion: string;
+  mod_gastos: boolean;
 };
 
 type InquilinoActivo = {
@@ -145,6 +147,7 @@ const recalcularResumenCobros = (deudas: DeudaCobro[]) => ({
 export default function CaseroCobrosScreen() {
   const router = useRouter();
   const [viviendas, setViviendas] = useState<Vivienda[]>([]);
+  const [hayViviendas, setHayViviendas] = useState(false);
   const [viviendaSeleccionadaId, setViviendaSeleccionadaId] = useState<number | null>(null);
   const [resumen, setResumen] = useState<CobrosResponse | null>(null);
   const [loading, setLoading] = useState(true);
@@ -274,21 +277,26 @@ export default function CaseroCobrosScreen() {
     setLoading(true);
     try {
       const { data } = await api.get<Vivienda[]>('/viviendas');
-      setViviendas(data);
+      const viviendasConGastos = data.filter((vivienda) => vivienda.mod_gastos);
+      setHayViviendas(data.length > 0);
+      setViviendas(viviendasConGastos);
 
-      if (data.length === 0) {
+      if (viviendasConGastos.length === 0) {
         setViviendaSeleccionadaId(null);
         setResumen(null);
+        setInquilinosActivos([]);
         return;
       }
 
       const viviendaInicial =
-        data.find((vivienda) => vivienda.id === viviendaSeleccionadaId) ?? data[0];
+        viviendasConGastos.find((vivienda) => vivienda.id === viviendaSeleccionadaId) ??
+        viviendasConGastos[0];
 
       setViviendaSeleccionadaId(viviendaInicial.id);
       await Promise.all([cargarCobros(viviendaInicial.id), cargarInquilinosActivos(viviendaInicial.id)]);
     } catch {
       setViviendas([]);
+      setHayViviendas(false);
       setViviendaSeleccionadaId(null);
       setResumen(null);
       Toast.show({ type: 'error', text1: 'No se pudieron cargar tus viviendas.' });
@@ -302,6 +310,8 @@ export default function CaseroCobrosScreen() {
       cargarContexto();
     }, [cargarContexto]),
   );
+
+  useEffect(() => onModulosViviendaActualizados(() => cargarContexto()), [cargarContexto]);
 
   const cambiarVivienda = async (viviendaId: number) => {
     setViviendaSeleccionadaId(viviendaId);
@@ -610,8 +620,8 @@ export default function CaseroCobrosScreen() {
             El dashboard de cobros aparecerá aquí en cuanto tengas una propiedad creada.
           </Text>
           <CustomButton
-            label="Crear vivienda"
-            onPress={() => router.push('/casero/nueva-vivienda')}
+            label={hayViviendas ? 'Ver viviendas' : 'Crear vivienda'}
+            onPress={() => router.push(hayViviendas ? '/casero/viviendas' : '/casero/nueva-vivienda')}
             style={styles.emptyAction}
           />
         </View>

--- a/frontend/app/casero/(tabs)/inventario.tsx
+++ b/frontend/app/casero/(tabs)/inventario.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
   ActivityIndicator,
   KeyboardAvoidingView,
@@ -21,6 +21,7 @@ import { CustomInput } from '@/components/common/CustomInput';
 import { LoadingScreen } from '@/components/common/LoadingScreen';
 import { Theme } from '@/constants/theme';
 import api from '@/services/api';
+import { onModulosViviendaActualizados } from '@/utils/viviendaModules';
 import {
   ESTADO_ITEM_BG,
   ESTADO_ITEM_BORDER,
@@ -40,6 +41,7 @@ type Vivienda = {
   id: number;
   alias_nombre: string;
   direccion: string;
+  mod_inventario: boolean;
   habitaciones: Habitacion[];
 };
 
@@ -85,6 +87,7 @@ const ETIQUETAS_ESTADO: Record<EstadoItem, string> = {
 export default function CaseroInventarioScreen() {
   const router = useRouter();
   const [viviendas, setViviendas] = useState<Vivienda[]>([]);
+  const [hayViviendas, setHayViviendas] = useState(false);
   const [viviendaSeleccionadaId, setViviendaSeleccionadaId] = useState<number | null>(null);
   const [items, setItems] = useState<ItemInventario[]>([]);
   const [loading, setLoading] = useState(true);
@@ -118,21 +121,25 @@ export default function CaseroInventarioScreen() {
     setLoading(true);
     try {
       const { data } = await api.get<Vivienda[]>('/viviendas');
-      setViviendas(data);
+      const viviendasConInventario = data.filter((vivienda) => vivienda.mod_inventario);
+      setHayViviendas(data.length > 0);
+      setViviendas(viviendasConInventario);
 
-      if (data.length === 0) {
+      if (viviendasConInventario.length === 0) {
         setViviendaSeleccionadaId(null);
         setItems([]);
         return;
       }
 
       const viviendaInicial =
-        data.find((vivienda) => vivienda.id === viviendaSeleccionadaId) ?? data[0];
+        viviendasConInventario.find((vivienda) => vivienda.id === viviendaSeleccionadaId) ??
+        viviendasConInventario[0];
 
       setViviendaSeleccionadaId(viviendaInicial.id);
       await cargarInventario(viviendaInicial.id);
     } catch {
       setViviendas([]);
+      setHayViviendas(false);
       setViviendaSeleccionadaId(null);
       setItems([]);
       Toast.show({ type: 'error', text1: 'No se pudieron cargar tus viviendas.' });
@@ -146,6 +153,8 @@ export default function CaseroInventarioScreen() {
       cargarContexto();
     }, [cargarContexto]),
   );
+
+  useEffect(() => onModulosViviendaActualizados(() => cargarContexto()), [cargarContexto]);
 
   const reiniciarFormulario = useCallback(() => {
     setNombre('');
@@ -285,8 +294,8 @@ export default function CaseroInventarioScreen() {
             En cuanto tengas una propiedad creada podrás registrar muebles, electrodomésticos y su estado.
           </Text>
           <CustomButton
-            label="Crear vivienda"
-            onPress={() => router.push('/casero/nueva-vivienda')}
+            label={hayViviendas ? 'Ver viviendas' : 'Crear vivienda'}
+            onPress={() => router.push(hayViviendas ? '/casero/viviendas' : '/casero/nueva-vivienda')}
             style={styles.emptyAction}
           />
         </View>

--- a/frontend/app/casero/vivienda/[id]/(tabs)/_layout.tsx
+++ b/frontend/app/casero/vivienda/[id]/(tabs)/_layout.tsx
@@ -1,12 +1,15 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Tabs, useFocusEffect, useLocalSearchParams, useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { Pressable } from 'react-native';
 import { Theme } from '@/constants/theme';
 import api from '@/services/api';
+import { onModulosViviendaActualizados } from '@/utils/viviendaModules';
 
 type ViviendaModulos = {
   mod_limpieza: boolean;
+  mod_gastos: boolean;
+  mod_inventario: boolean;
 };
 
 export default function ViviendaTabsLayout() {
@@ -14,11 +17,20 @@ export default function ViviendaTabsLayout() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const [modulos, setModulos] = useState({ limpieza: true });
 
+  const cargarModulos = useCallback(async () => {
+    try {
+      const { data } = await api.get<ViviendaModulos>(`/viviendas/${id}`);
+      setModulos({ limpieza: data.mod_limpieza });
+    } catch {
+      setModulos({ limpieza: true });
+    }
+  }, [id]);
+
   useFocusEffect(
     useCallback(() => {
       let activo = true;
 
-      const cargarModulos = async () => {
+      const cargarModulosSeguro = async () => {
         try {
           const { data } = await api.get<ViviendaModulos>(`/viviendas/${id}`);
           if (activo) {
@@ -31,11 +43,23 @@ export default function ViviendaTabsLayout() {
         }
       };
 
-      cargarModulos();
+      cargarModulosSeguro();
       return () => {
         activo = false;
       };
     }, [id]),
+  );
+
+  useEffect(
+    () =>
+      onModulosViviendaActualizados((event) => {
+        if (String(event.viviendaId) === String(id)) {
+          setModulos({ limpieza: event.modulos.mod_limpieza });
+        } else {
+          cargarModulos();
+        }
+      }),
+    [cargarModulos, id],
   );
 
   return (
@@ -105,6 +129,15 @@ export default function ViviendaTabsLayout() {
           href: modulos.limpieza ? undefined : null,
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="sparkles-outline" size={size} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="opciones"
+        options={{
+          title: 'Opciones',
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="settings-outline" size={size} color={color} />
           ),
         }}
       />

--- a/frontend/app/casero/vivienda/[id]/(tabs)/index.tsx
+++ b/frontend/app/casero/vivienda/[id]/(tabs)/index.tsx
@@ -6,7 +6,6 @@ import {
   Pressable,
   ScrollView,
   Share,
-  Switch,
   Text,
   View,
 } from 'react-native';
@@ -63,8 +62,6 @@ type Vivienda = {
   habitaciones: Habitacion[];
 };
 
-type ModuloViviendaKey = 'mod_limpieza' | 'mod_gastos' | 'mod_inventario';
-
 type GastoRecurrente = {
   id: number;
   concepto: string;
@@ -91,32 +88,6 @@ const HAB_ICONS: Record<string, any> = {
 
 const formatearImporte = (importe: number) =>
   importe.toLocaleString('es-ES', { style: 'currency', currency: 'EUR' });
-
-const MODULOS_VIVIENDA: {
-  key: ModuloViviendaKey;
-  titulo: string;
-  descripcion: string;
-  icono: keyof typeof Ionicons.glyphMap;
-}[] = [
-  {
-    key: 'mod_limpieza',
-    titulo: 'Limpieza y Tareas',
-    descripcion: 'Turnos, zonas y asignaciones de limpieza.',
-    icono: 'sparkles-outline',
-  },
-  {
-    key: 'mod_gastos',
-    titulo: 'Gastos y Finanzas',
-    descripcion: 'Gastos compartidos, deudas, cobros y mensualidades.',
-    icono: 'wallet-outline',
-  },
-  {
-    key: 'mod_inventario',
-    titulo: 'Inventario y Assets',
-    descripcion: 'Items, fotos y conformidad del inventario.',
-    icono: 'albums-outline',
-  },
-];
 
 const AvatarInitials = ({
   nombre,
@@ -159,7 +130,6 @@ export default function ResumenViviendaTab() {
   const [importeMensualidad, setImporteMensualidad] = useState('');
   const [diaMensualidad, setDiaMensualidad] = useState('');
   const [guardandoMensualidad, setGuardandoMensualidad] = useState(false);
-  const [actualizandoModulo, setActualizandoModulo] = useState<ModuloViviendaKey | null>(null);
 
   const cargarVivienda = useCallback(async () => {
     try {
@@ -340,33 +310,6 @@ export default function ResumenViviendaTab() {
     }
   };
 
-  const actualizarModulo = async (key: ModuloViviendaKey, value: boolean) => {
-    if (!vivienda || actualizandoModulo) return;
-
-    const anterior = vivienda;
-    setVivienda({ ...vivienda, [key]: value });
-    setActualizandoModulo(key);
-
-    try {
-      const { data } = await api.patch<Vivienda>(`/viviendas/${id}`, { [key]: value });
-      setVivienda(data);
-      if (key === 'mod_gastos' && !value) {
-        setGastosRecurrentes([]);
-      } else if (key === 'mod_gastos' && value) {
-        await cargarGastosRecurrentes();
-      }
-      Toast.show({ type: 'success', text1: 'Configuracion actualizada.' });
-    } catch (err: any) {
-      setVivienda(anterior);
-      Toast.show({
-        type: 'error',
-        text1: err.response?.data?.error ?? 'No se pudo actualizar el modulo.',
-      });
-    } finally {
-      setActualizandoModulo(null);
-    }
-  };
-
   const puedeGuardarMensualidad =
     conceptoMensualidad.trim().length > 0 &&
     importeMensualidad.trim().length > 0 &&
@@ -430,43 +373,6 @@ export default function ResumenViviendaTab() {
             </View>
             <Text style={styles.accionLabel}>Nueva Incidencia</Text>
           </Pressable>
-        </View>
-
-        <View style={styles.modulosSection}>
-          <View style={styles.sectionHeaderTextGroup}>
-            <Text style={styles.seccionTitulo}>Configuracion de Modulos</Text>
-            <Text style={styles.sectionDescription}>
-              Activa solo las herramientas que quieres usar en esta vivienda.
-            </Text>
-          </View>
-
-          <View style={styles.modulosList}>
-            {MODULOS_VIVIENDA.map((modulo) => {
-              const activo = vivienda[modulo.key];
-              const actualizando = actualizandoModulo === modulo.key;
-
-              return (
-                <View key={modulo.key} style={styles.moduloCard}>
-                  <View style={styles.moduloIconBox}>
-                    <Ionicons name={modulo.icono} size={20} color={Theme.colors.primary} />
-                  </View>
-                  <View style={styles.moduloBody}>
-                    <Text style={styles.moduloTitulo}>{modulo.titulo}</Text>
-                    <Text style={styles.moduloDescripcion}>{modulo.descripcion}</Text>
-                  </View>
-                  <Switch
-                    value={activo}
-                    disabled={actualizandoModulo !== null}
-                    onValueChange={(value) => actualizarModulo(modulo.key, value)}
-                    trackColor={{ false: Theme.colors.border, true: Theme.colors.success }}
-                    thumbColor={Theme.colors.surface}
-                    accessibilityLabel={`${activo ? 'Desactivar' : 'Activar'} ${modulo.titulo}`}
-                  />
-                  {actualizando && <View style={styles.moduloUpdatingOverlay} />}
-                </View>
-              );
-            })}
-          </View>
         </View>
 
         {vivienda.mod_gastos && (

--- a/frontend/app/casero/vivienda/[id]/(tabs)/opciones.tsx
+++ b/frontend/app/casero/vivienda/[id]/(tabs)/opciones.tsx
@@ -1,0 +1,63 @@
+import { useCallback, useState } from 'react';
+import { ScrollView, Text, View } from 'react-native';
+import Toast from 'react-native-toast-message';
+import { useFocusEffect, useLocalSearchParams } from 'expo-router';
+import { LoadingScreen } from '@/components/common/LoadingScreen';
+import { ModulosViviendaManager } from '@/components/casero/vivienda/ModulosViviendaManager';
+import api from '@/services/api';
+import { styles } from '@/styles/casero/vivienda/detalle.styles';
+import { ModulosVivienda } from '@/utils/viviendaModules';
+
+type Vivienda = ModulosVivienda & {
+  id: number;
+  alias_nombre: string;
+  direccion: string;
+};
+
+export default function OpcionesViviendaTab() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const [vivienda, setVivienda] = useState<Vivienda | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const cargarVivienda = useCallback(async () => {
+    setLoading(true);
+    try {
+      const { data } = await api.get<Vivienda>(`/viviendas/${id}`);
+      setVivienda(data);
+    } catch {
+      Toast.show({ type: 'error', text1: 'No se pudo cargar la configuracion.' });
+      setVivienda(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [id]);
+
+  useFocusEffect(
+    useCallback(() => {
+      cargarVivienda();
+    }, [cargarVivienda]),
+  );
+
+  if (loading) return <LoadingScreen />;
+
+  if (!vivienda) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.errorTexto}>Vivienda no encontrada.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+        <View style={styles.headerCard}>
+          <Text style={styles.headerNombre}>Opciones</Text>
+          <Text style={styles.headerDireccion}>{vivienda.alias_nombre}</Text>
+        </View>
+
+        <ModulosViviendaManager vivienda={vivienda} onViviendaChange={setVivienda} />
+      </ScrollView>
+    </View>
+  );
+}

--- a/frontend/components/casero/vivienda/ModulosViviendaManager.tsx
+++ b/frontend/components/casero/vivienda/ModulosViviendaManager.tsx
@@ -1,0 +1,125 @@
+import { Switch, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import Toast from 'react-native-toast-message';
+import { useState } from 'react';
+import { Theme } from '@/constants/theme';
+import api from '@/services/api';
+import { styles } from '@/styles/casero/vivienda/detalle.styles';
+import {
+  ModulosVivienda,
+  notificarModulosViviendaActualizados,
+} from '@/utils/viviendaModules';
+
+type ModuloViviendaKey = keyof ModulosVivienda;
+
+type ViviendaConModulos = ModulosVivienda & {
+  id: number;
+};
+
+type Props<T extends ViviendaConModulos> = {
+  vivienda: T;
+  onViviendaChange: (vivienda: T) => void;
+};
+
+const MODULOS_VIVIENDA: {
+  key: ModuloViviendaKey;
+  titulo: string;
+  descripcion: string;
+  icono: keyof typeof Ionicons.glyphMap;
+}[] = [
+  {
+    key: 'mod_limpieza',
+    titulo: 'Limpieza y tareas',
+    descripcion: 'Turnos, zonas y asignaciones de limpieza.',
+    icono: 'sparkles-outline',
+  },
+  {
+    key: 'mod_gastos',
+    titulo: 'Gastos y finanzas',
+    descripcion: 'Gastos compartidos, deudas, cobros y mensualidades.',
+    icono: 'wallet-outline',
+  },
+  {
+    key: 'mod_inventario',
+    titulo: 'Inventario y assets',
+    descripcion: 'Items, fotos y conformidad del inventario.',
+    icono: 'albums-outline',
+  },
+];
+
+export function ModulosViviendaManager<T extends ViviendaConModulos>({
+  vivienda,
+  onViviendaChange,
+}: Props<T>) {
+  const [actualizandoModulo, setActualizandoModulo] = useState<ModuloViviendaKey | null>(null);
+
+  const actualizarModulo = async (key: ModuloViviendaKey, value: boolean) => {
+    if (actualizandoModulo) return;
+
+    const anterior = vivienda;
+    const viviendaOptimista = { ...vivienda, [key]: value };
+    onViviendaChange(viviendaOptimista);
+    setActualizandoModulo(key);
+
+    try {
+      const { data } = await api.patch<T>(`/viviendas/${vivienda.id}`, { [key]: value });
+      onViviendaChange(data);
+      notificarModulosViviendaActualizados({
+        viviendaId: data.id,
+        modulos: {
+          mod_limpieza: data.mod_limpieza,
+          mod_gastos: data.mod_gastos,
+          mod_inventario: data.mod_inventario,
+        },
+      });
+      Toast.show({ type: 'success', text1: 'Configuracion actualizada.' });
+    } catch (err: any) {
+      onViviendaChange(anterior);
+      Toast.show({
+        type: 'error',
+        text1: err.response?.data?.error ?? 'No se pudo actualizar el modulo.',
+      });
+    } finally {
+      setActualizandoModulo(null);
+    }
+  };
+
+  return (
+    <View style={styles.modulosSection}>
+      <View style={styles.sectionHeaderTextGroup}>
+        <Text style={styles.seccionTitulo}>Modulos de la vivienda</Text>
+        <Text style={styles.sectionDescription}>
+          Activa solo las herramientas que quieres usar en esta casa.
+        </Text>
+      </View>
+
+      <View style={styles.modulosList}>
+        {MODULOS_VIVIENDA.map((modulo) => {
+          const activo = vivienda[modulo.key];
+          const actualizando = actualizandoModulo === modulo.key;
+
+          return (
+            <View key={modulo.key} style={styles.moduloCard}>
+              <View style={styles.moduloIconBox}>
+                <Ionicons name={modulo.icono} size={20} color={Theme.colors.primary} />
+              </View>
+              <View style={styles.moduloBody}>
+                <Text style={styles.moduloTitulo}>{modulo.titulo}</Text>
+                <Text style={styles.moduloDescripcion}>{modulo.descripcion}</Text>
+              </View>
+              <Switch
+                value={activo}
+                disabled={actualizandoModulo !== null}
+                onValueChange={(value) => actualizarModulo(modulo.key, value)}
+                trackColor={{ false: Theme.colors.border, true: Theme.colors.success }}
+                thumbColor={Theme.colors.surface}
+                accessibilityLabel={`${activo ? 'Desactivar' : 'Activar'} ${modulo.titulo}`}
+              />
+              {actualizando && <View style={styles.moduloUpdatingOverlay} />}
+            </View>
+          );
+        })}
+      </View>
+    </View>
+  );
+}

--- a/frontend/utils/viviendaModules.ts
+++ b/frontend/utils/viviendaModules.ts
@@ -1,0 +1,25 @@
+export type ModulosVivienda = {
+  mod_limpieza: boolean;
+  mod_gastos: boolean;
+  mod_inventario: boolean;
+};
+
+export type ModulosViviendaActualizados = {
+  viviendaId: number;
+  modulos: ModulosVivienda;
+};
+
+type Listener = (event: ModulosViviendaActualizados) => void;
+
+const listeners = new Set<Listener>();
+
+export const onModulosViviendaActualizados = (listener: Listener) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+export const notificarModulosViviendaActualizados = (event: ModulosViviendaActualizados) => {
+  listeners.forEach((listener) => listener(event));
+};


### PR DESCRIPTION
## Summary
- Mueve la gestión de módulos de vivienda al tab `Opciones` de cada casa.
- Añade un componente reutilizable para actualizar `mod_limpieza`, `mod_gastos` y `mod_inventario` por vivienda.
- Propaga los cambios de módulos en la UI para refrescar tabs sin recargar la app.
- Filtra `Cobros` e `Inventario` para usar solo viviendas con el módulo activo.
- Añade changelog en `docs/changelog/epica13/epica-13-issue-227.md`.

## Testing
- `npm run lint`
- `npx tsc --noEmit`