### PR TITLE
Fix carga de configuración y zonas en tabs de vivienda

### DIFF
--- a/docs/changelog/epica13/epica-13-issue-227.md
+++ b/docs/changelog/epica13/epica-13-issue-227.md
@@ -14,6 +14,13 @@
 - `frontend/app/casero/(tabs)/cobros.tsx`: filtrado de viviendas para que el dashboard solo pueda seleccionar casas con `mod_gastos` activo y no intente cargar cobros de viviendas donde el modulo esta desactivado.
 - `frontend/app/casero/(tabs)/inventario.tsx`: filtrado de viviendas para que inventario solo trabaje con casas con `mod_inventario` activo y evite estados inconsistentes tras desactivar el modulo.
 
+## Bugfix posterior
+
+- `frontend/app/casero/vivienda/[id]/(tabs)/_layout.tsx`: lectura de `id` con `useGlobalSearchParams` para conservar el parametro de la ruta dinamica dentro de tabs anidados.
+- `frontend/app/casero/vivienda/[id]/(tabs)/opciones.tsx`: evitadas llamadas a `/viviendas/undefined` al cargar la configuracion de modulos.
+- `frontend/app/casero/vivienda/[id]/(tabs)/limpieza.tsx`: evitadas llamadas a endpoints de zonas, turnos y asignaciones cuando el `id` de vivienda aun no esta disponible.
+- `frontend/app/casero/vivienda/[id]/(tabs)/index.tsx`, `incidencias.tsx` y `tablon.tsx`: normalizada la lectura del `id` de vivienda en todos los tabs hermanos para mantener el mismo comportamiento de navegacion.
+
 ## Validacion
 
 - `frontend`: `npm run lint` sin errores bloqueantes; quedan warnings preexistentes del proyecto.

--- a/frontend/app/casero/vivienda/[id]/(tabs)/_layout.tsx
+++ b/frontend/app/casero/vivienda/[id]/(tabs)/_layout.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Tabs, useFocusEffect, useLocalSearchParams, useRouter } from 'expo-router';
+import { Tabs, useFocusEffect, useGlobalSearchParams, useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { Pressable } from 'react-native';
 import { Theme } from '@/constants/theme';
@@ -14,10 +14,13 @@ type ViviendaModulos = {
 
 export default function ViviendaTabsLayout() {
   const router = useRouter();
-  const { id } = useLocalSearchParams<{ id: string }>();
+  const params = useGlobalSearchParams<{ id?: string | string[] }>();
+  const id = Array.isArray(params.id) ? params.id[0] : params.id;
   const [modulos, setModulos] = useState({ limpieza: true });
 
   const cargarModulos = useCallback(async () => {
+    if (!id) return;
+
     try {
       const { data } = await api.get<ViviendaModulos>(`/viviendas/${id}`);
       setModulos({ limpieza: data.mod_limpieza });
@@ -31,6 +34,8 @@ export default function ViviendaTabsLayout() {
       let activo = true;
 
       const cargarModulosSeguro = async () => {
+        if (!id) return;
+
         try {
           const { data } = await api.get<ViviendaModulos>(`/viviendas/${id}`);
           if (activo) {

--- a/frontend/app/casero/vivienda/[id]/(tabs)/incidencias.tsx
+++ b/frontend/app/casero/vivienda/[id]/(tabs)/incidencias.tsx
@@ -4,7 +4,7 @@ import Toast from 'react-native-toast-message';
 import { LoadingScreen } from '@/components/common/LoadingScreen';
 import { Theme } from '@/constants/theme';
 import { useState, useCallback } from 'react';
-import { useLocalSearchParams, useRouter, useFocusEffect } from 'expo-router';
+import { useGlobalSearchParams, useRouter, useFocusEffect } from 'expo-router';
 import api from '@/services/api';
 import {
   styles,
@@ -34,13 +34,16 @@ type Incidencia = {
 const ESTADOS: Estado[] = ['PENDIENTE', 'EN_PROCESO', 'RESUELTA'];
 
 export default function IncidenciasCaseroTab() {
-  const { id } = useLocalSearchParams<{ id: string }>();
+  const params = useGlobalSearchParams<{ id?: string | string[] }>();
+  const id = Array.isArray(params.id) ? params.id[0] : params.id;
   const router = useRouter();
   const [incidencias, setIncidencias] = useState<Incidencia[]>([]);
   const [loading, setLoading] = useState(true);
   const [mostrarHistorial, setMostrarHistorial] = useState(false);
 
   const cargarIncidencias = async () => {
+    if (!id) return;
+
     setLoading(true);
     try {
       const { data } = await api.get<Incidencia[]>(`/incidencias?viviendaId=${id}`);

--- a/frontend/app/casero/vivienda/[id]/(tabs)/index.tsx
+++ b/frontend/app/casero/vivienda/[id]/(tabs)/index.tsx
@@ -13,7 +13,7 @@ import { Ionicons } from '@expo/vector-icons';
 import Toast from 'react-native-toast-message';
 import { LoadingScreen } from '@/components/common/LoadingScreen';
 import { useState, useCallback } from 'react';
-import { useLocalSearchParams, useRouter, useFocusEffect } from 'expo-router';
+import { useGlobalSearchParams, useRouter, useFocusEffect } from 'expo-router';
 import * as LocalAuthentication from 'expo-local-authentication';
 import * as Clipboard from 'expo-clipboard';
 import api from '@/services/api';
@@ -119,7 +119,8 @@ const AvatarInitials = ({
 };
 
 export default function ResumenViviendaTab() {
-  const { id } = useLocalSearchParams<{ id: string }>();
+  const params = useGlobalSearchParams<{ id?: string | string[] }>();
+  const id = Array.isArray(params.id) ? params.id[0] : params.id;
   const router = useRouter();
   const [vivienda, setVivienda] = useState<Vivienda | null>(null);
   const [gastosRecurrentes, setGastosRecurrentes] = useState<GastoRecurrente[]>([]);
@@ -132,6 +133,8 @@ export default function ResumenViviendaTab() {
   const [guardandoMensualidad, setGuardandoMensualidad] = useState(false);
 
   const cargarVivienda = useCallback(async () => {
+    if (!id) return null;
+
     try {
       const { data } = await api.get<Vivienda>(`/viviendas/${id}`);
       setVivienda(data);
@@ -143,6 +146,8 @@ export default function ResumenViviendaTab() {
   }, [id]);
 
   const cargarGastosRecurrentes = useCallback(async () => {
+    if (!id) return;
+
     try {
       const { data } = await api.get<GastoRecurrente[]>(`/viviendas/${id}/gastos-recurrentes`);
       setGastosRecurrentes(data);
@@ -245,6 +250,8 @@ export default function ResumenViviendaTab() {
   };
 
   const handleEditarHabitacion = (hab: Habitacion) => {
+    if (!id) return;
+
     router.push({
       pathname: '/casero/vivienda/[id]/editar-habitacion',
       params: {
@@ -268,6 +275,8 @@ export default function ResumenViviendaTab() {
   };
 
   const handleGuardarMensualidad = async () => {
+    if (!id) return;
+
     const importeNum = parseFloat(importeMensualidad.replace(',', '.'));
     const diaNum = parseInt(diaMensualidad, 10);
 

--- a/frontend/app/casero/vivienda/[id]/(tabs)/limpieza.tsx
+++ b/frontend/app/casero/vivienda/[id]/(tabs)/limpieza.tsx
@@ -14,7 +14,7 @@ import { Ionicons } from '@expo/vector-icons';
 import Toast from 'react-native-toast-message';
 import { Theme } from '@/constants/theme';
 import { useState, useEffect } from 'react';
-import { useLocalSearchParams } from 'expo-router';
+import { useGlobalSearchParams } from 'expo-router';
 import api from '@/services/api';
 import { Card } from '@/components/common/Card';
 import { CustomButton } from '@/components/common/CustomButton';
@@ -122,7 +122,8 @@ type Turno = {
 // ─────────────────────────────────────────────────────────────────────────────
 
 export default function LimpiezaCaseroTab() {
-  const { id } = useLocalSearchParams<{ id: string }>();
+  const params = useGlobalSearchParams<{ id?: string | string[] }>();
+  const id = Array.isArray(params.id) ? params.id[0] : params.id;
 
   // — Vista activa —
   const [vistaActual, setVistaActual] = useState<'CONFIG' | 'CALENDARIO'>('CONFIG');
@@ -170,6 +171,8 @@ export default function LimpiezaCaseroTab() {
   }, [vistaActual, fechaObjetivo]);
 
   const cargarZonas = async () => {
+    if (!id) return;
+
     try {
       const { data } = await api.get<ZonaLimpieza[]>(`/viviendas/${id}/limpieza/zonas`);
       setZonas(data);
@@ -179,6 +182,8 @@ export default function LimpiezaCaseroTab() {
   };
 
   const cargarInquilinos = async () => {
+    if (!id) return;
+
     try {
       const { data } = await api.get<{ habitaciones: { inquilino: Inquilino | null }[] }>(`/viviendas/${id}`);
       setInquilinos(
@@ -190,6 +195,8 @@ export default function LimpiezaCaseroTab() {
   };
 
   const cargarTurnos = async (fecha?: Date) => {
+    if (!id) return;
+
     setLoadingTurnos(true);
     try {
       const base = fecha ?? fechaObjetivo;
@@ -219,7 +226,7 @@ export default function LimpiezaCaseroTab() {
   };
 
   const handleGuardar = async () => {
-    if (!nombre.trim() || pesoSeleccionado === null) return;
+    if (!id || !nombre.trim() || pesoSeleccionado === null) return;
     setGuardando(true);
     try {
       const { data } = await api.post<ZonaLimpieza>(`/viviendas/${id}/limpieza/zonas`, {
@@ -239,6 +246,8 @@ export default function LimpiezaCaseroTab() {
 
   // — Starter Pack —
   const handleGenerarZonasBasicas = async () => {
+    if (!id) return;
+
     setCreandoBase(true);
     try {
       const resultados = await Promise.all(
@@ -270,7 +279,7 @@ export default function LimpiezaCaseroTab() {
   };
 
   const handleGuardarAsignacion = async () => {
-    if (!zonaSeleccionada) return;
+    if (!id || !zonaSeleccionada) return;
     setAsignando(true);
     try {
       const { data } = await api.post<AsignacionFija[]>(
@@ -311,6 +320,8 @@ export default function LimpiezaCaseroTab() {
   };
 
   const handleGenerarTurnos = async () => {
+    if (!id) return;
+
     setGenerando(true);
     try {
       await api.post(`/viviendas/${id}/limpieza/generar`);

--- a/frontend/app/casero/vivienda/[id]/(tabs)/opciones.tsx
+++ b/frontend/app/casero/vivienda/[id]/(tabs)/opciones.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 import { ScrollView, Text, View } from 'react-native';
 import Toast from 'react-native-toast-message';
-import { useFocusEffect, useLocalSearchParams } from 'expo-router';
+import { useFocusEffect, useGlobalSearchParams } from 'expo-router';
 import { LoadingScreen } from '@/components/common/LoadingScreen';
 import { ModulosViviendaManager } from '@/components/casero/vivienda/ModulosViviendaManager';
 import api from '@/services/api';
@@ -15,11 +15,18 @@ type Vivienda = ModulosVivienda & {
 };
 
 export default function OpcionesViviendaTab() {
-  const { id } = useLocalSearchParams<{ id: string }>();
+  const params = useGlobalSearchParams<{ id?: string | string[] }>();
+  const id = Array.isArray(params.id) ? params.id[0] : params.id;
   const [vivienda, setVivienda] = useState<Vivienda | null>(null);
   const [loading, setLoading] = useState(true);
 
   const cargarVivienda = useCallback(async () => {
+    if (!id) {
+      setVivienda(null);
+      setLoading(false);
+      return;
+    }
+
     setLoading(true);
     try {
       const { data } = await api.get<Vivienda>(`/viviendas/${id}`);

--- a/frontend/app/casero/vivienda/[id]/(tabs)/tablon.tsx
+++ b/frontend/app/casero/vivienda/[id]/(tabs)/tablon.tsx
@@ -14,7 +14,7 @@ import { Ionicons } from '@expo/vector-icons';
 import Toast from 'react-native-toast-message';
 import { Theme } from '@/constants/theme';
 import { useState, useCallback } from 'react';
-import { useLocalSearchParams, useFocusEffect } from 'expo-router';
+import { useGlobalSearchParams, useFocusEffect } from 'expo-router';
 import api from '@/services/api';
 import { styles } from '@/styles/tablon/tablon.styles';
 
@@ -28,7 +28,8 @@ type Anuncio = {
 };
 
 export default function CaseroTablonTab() {
-  const { id } = useLocalSearchParams<{ id: string }>();
+  const params = useGlobalSearchParams<{ id?: string | string[] }>();
+  const id = Array.isArray(params.id) ? params.id[0] : params.id;
   const [anuncios, setAnuncios] = useState<Anuncio[]>([]);
   const [loading, setLoading] = useState(true);
   const [modalVisible, setModalVisible] = useState(false);
@@ -39,6 +40,8 @@ export default function CaseroTablonTab() {
   const [contenidoFocused, setContenidoFocused] = useState(false);
 
   const cargarAnuncios = async () => {
+    if (!id) return;
+
     setLoading(true);
     try {
       const { data } = await api.get<Anuncio[]>(`/anuncios?viviendaId=${id}`);
@@ -53,7 +56,7 @@ export default function CaseroTablonTab() {
   useFocusEffect(useCallback(() => { cargarAnuncios(); }, [id]));
 
   const handlePublicar = async () => {
-    if (!titulo.trim() || !contenido.trim()) return;
+    if (!id || !titulo.trim() || !contenido.trim()) return;
     setPublicando(true);
     try {
       const { data } = await api.post<Anuncio>('/anuncios', {


### PR DESCRIPTION
## Summary
- Corrige la lectura del `id` de vivienda en tabs anidados usando parámetros globales de Expo Router.
- Evita llamadas a endpoints de configuración, limpieza, incidencias y tablón cuando el `id` aún no está disponible.
- Soluciona los errores de carga de configuración de módulos y zonas de limpieza con base de datos correcta.
- Actualiza el changelog técnico en `docs/changelog/epica13/epica-13-issue-227.md`.

## Testing
- `npx tsc --noEmit`
- `npm run lint`