### PR TITLE
Update reparto de facturas puntuales de Épica 14

### DIFF
--- a/backend/src/controllers/gasto.controller.ts
+++ b/backend/src/controllers/gasto.controller.ts
@@ -210,10 +210,13 @@ export const crearGasto: express.RequestHandler = async (req, res) => {
       (linea) =>
         !Number.isInteger(linea.usuario_id) ||
         linea.usuario_id <= 0 ||
-        !Number.isFinite(linea.importe),
+        !Number.isFinite(linea.importe) ||
+        linea.importe < 0,
     )
   ) {
-    res.status(400).json({ error: 'repartoManual debe incluir usuario_id numerico e importe valido.' });
+    res.status(400).json({
+      error: 'repartoManual debe incluir usuario_id numerico e importe valido no negativo.',
+    });
     return;
   }
 

--- a/backend/src/services/gasto.service.ts
+++ b/backend/src/services/gasto.service.ts
@@ -44,6 +44,19 @@ export const obtenerInquilinosActivosIds = async (viviendaId: number) => {
   return habitaciones.map((habitacion) => habitacion.inquilino_id!);
 };
 
+const desdeCentimos = (centimos: number) => centimos / 100;
+
+const repartirImporteEnCentimos = (importe: number, participantesIds: number[]) => {
+  const totalCentimos = Math.round(importe * 100);
+  const base = Math.floor(totalCentimos / participantesIds.length);
+  const resto = totalCentimos % participantesIds.length;
+
+  return participantesIds.map((usuarioId, index) => ({
+    usuario_id: usuarioId,
+    importe: desdeCentimos(base + (index < resto ? 1 : 0)),
+  }));
+};
+
 export const crearGastoDividido = async ({
   concepto,
   importe,
@@ -96,9 +109,9 @@ export const crearGastoDividido = async ({
       throw new Error('Todos los usuarios de repartoManual deben ser inquilinos activos de la vivienda.');
     }
 
-    const hayImportesInvalidos = repartoManual.some((linea) => linea.importe <= 0);
+    const hayImportesInvalidos = repartoManual.some((linea) => linea.importe < 0);
     if (hayImportesInvalidos) {
-      throw new Error('Todos los importes de repartoManual deben ser mayores que 0.');
+      throw new Error('Los importes de repartoManual no pueden ser negativos.');
     }
 
     const totalCentimos = Math.round(importe * 100);
@@ -144,7 +157,10 @@ export const crearGastoDividido = async ({
   }
 
   const deudoresIds = participantesIds.filter((id) => id !== pagadorId);
-  const importePorPersona = parseFloat((importe / participantesIds.length).toFixed(2));
+  const repartoAutomatico = repartirImporteEnCentimos(importe, participantesIds);
+  const importesPorUsuario = new Map(
+    repartoAutomatico.map((linea) => [linea.usuario_id, parseFloat(linea.importe.toFixed(2))]),
+  );
 
   return prisma.gasto.create({
     data: {
@@ -158,7 +174,7 @@ export const crearGastoDividido = async ({
         create: deudoresIds.map((deudorId) => ({
           deudor_id: deudorId,
           acreedor_id: pagadorId,
-          importe: importePorPersona,
+          importe: importesPorUsuario.get(deudorId) ?? 0,
         })),
       },
     },

--- a/docs/changelog/Epica14/epica-14-issue-228-reparto-facturas-puntuales.md
+++ b/docs/changelog/Epica14/epica-14-issue-228-reparto-facturas-puntuales.md
@@ -1,0 +1,19 @@
+# Issue #228 - Reparto igualitario y cuotas a 0 en facturas puntuales
+
+**Fecha:** 2026-04-11
+**Epica:** 14 - Facturacion flexible y precios privados
+
+## Cambios tecnicos
+
+- `frontend/app/casero/(tabs)/cobros.tsx`: el modal de factura puntual permite dejar vacios todos los importes para calcular un reparto igualitario automatico entre los participantes seleccionados.
+- `frontend/app/casero/(tabs)/cobros.tsx`: se diferencia campo vacio de importe `0`, permitiendo que una persona seleccionada no pague esa factura sin bloquear el formulario.
+- `frontend/app/casero/(tabs)/cobros.tsx`: el reparto se calcula en centimos para que los redondeos mantengan cuadrado el total, incluyendo casos como 100 EUR entre 3 personas.
+- `frontend/app/casero/(tabs)/cobros.tsx`: se mantiene la validacion de importes negativos, importes invalidos, repartos manuales incompletos y sumas que no coinciden con el total.
+- `frontend/styles/casero/cobros.styles.ts`: se anaden estilos para selector de participantes, estado no incluido y ayuda visual del contador de reparto usando tokens de `Theme`.
+- `backend/src/controllers/gasto.controller.ts`: `repartoManual` acepta importes `0` y rechaza importes negativos o invalidos.
+- `backend/src/services/gasto.service.ts`: el reparto automatico usa centimos y distribuye el resto entre participantes para que la suma de deudas coincida con el gasto.
+
+## Validacion
+
+- `backend`: `npm run build`.
+- `frontend`: `npm run lint` sin errores; persisten warnings previos en pantallas no tocadas.

--- a/frontend/app/casero/(tabs)/cobros.tsx
+++ b/frontend/app/casero/(tabs)/cobros.tsx
@@ -114,6 +114,12 @@ type GastoActualizadoResponse = {
   }[];
 };
 
+type RepartoFacturaPuntualLinea = {
+  usuario_id: number;
+  importe: number;
+  automatico: boolean;
+};
+
 const formatearImporte = (importe: number) =>
   importe.toLocaleString('es-ES', { style: 'currency', currency: 'EUR' });
 
@@ -127,12 +133,35 @@ const formatearFecha = (fechaIso: string) =>
 const obtenerIniciales = (nombre: string, apellidos: string | null) =>
   `${nombre[0] ?? ''}${apellidos?.[0] ?? ''}`.toUpperCase();
 
-const parsearImporte = (valor: string) => {
-  const numero = parseFloat(valor.replace(',', '.'));
-  return Number.isFinite(numero) ? numero : 0;
+const normalizarInputImporte = (valor: string) => {
+  const limpio = valor.trim();
+
+  if (!limpio) {
+    return { vacio: true, numero: null, valido: true };
+  }
+
+  const numero = Number(limpio.replace(',', '.'));
+  return { vacio: false, numero, valido: Number.isFinite(numero) };
 };
 
 const aCentimos = (importe: number) => Math.round(importe * 100);
+
+const desdeCentimos = (centimos: number) => centimos / 100;
+
+const repartirCentimos = (totalCentimos: number, participantes: number[]) => {
+  if (participantes.length === 0) {
+    return [];
+  }
+
+  const base = Math.floor(totalCentimos / participantes.length);
+  const resto = totalCentimos % participantes.length;
+
+  return participantes.map((usuarioId, index) => ({
+    usuario_id: usuarioId,
+    importe: desdeCentimos(base + (index < resto ? 1 : 0)),
+    automatico: true,
+  }));
+};
 
 const recalcularResumenCobros = (deudas: DeudaCobro[]) => ({
   total_pagado_mes: deudas
@@ -165,6 +194,9 @@ export default function CaseroCobrosScreen() {
   const [fechaFacturaPuntual, setFechaFacturaPuntual] = useState(new Date().toISOString().slice(0, 10));
   const [importeFacturaPuntual, setImporteFacturaPuntual] = useState('');
   const [repartoFacturaPuntual, setRepartoFacturaPuntual] = useState<Record<number, string>>({});
+  const [participantesFacturaPuntual, setParticipantesFacturaPuntual] = useState<Record<number, boolean>>(
+    {},
+  );
   const [facturaAdjuntaPuntual, setFacturaAdjuntaPuntual] =
     useState<DocumentPicker.DocumentPickerAsset | null>(null);
   const [guardandoFacturaPuntual, setGuardandoFacturaPuntual] = useState(false);
@@ -178,26 +210,120 @@ export default function CaseroCobrosScreen() {
     [resumen],
   );
   const importeFacturaPuntualNumero = useMemo(
-    () => parsearImporte(importeFacturaPuntual),
+    () => normalizarInputImporte(importeFacturaPuntual).numero ?? 0,
     [importeFacturaPuntual],
   );
-  const totalAsignadoFacturaPuntual = useMemo(
+  const participantesSeleccionadosFacturaPuntual = useMemo(
     () =>
-      Object.values(repartoFacturaPuntual).reduce(
-        (total, valor) => total + parsearImporte(valor),
-        0,
+      inquilinosActivos.filter(
+        (inquilino) => participantesFacturaPuntual[inquilino.id] ?? true,
       ),
-    [repartoFacturaPuntual],
+    [inquilinosActivos, participantesFacturaPuntual],
   );
+  const repartoCalculadoFacturaPuntual = useMemo(() => {
+    const totalCentimos = aCentimos(importeFacturaPuntualNumero);
+    const participantesIds = participantesSeleccionadosFacturaPuntual.map((inquilino) => inquilino.id);
+    const entradas = participantesIds.map((usuarioId) => ({
+      usuarioId,
+      normalizado: normalizarInputImporte(repartoFacturaPuntual[usuarioId] ?? ''),
+    }));
+    const entradasInformadas = entradas.filter((entrada) => !entrada.normalizado.vacio);
+    const hayImportesInvalidos = entradas.some(
+      (entrada) =>
+        !entrada.normalizado.valido ||
+        (entrada.normalizado.numero != null && entrada.normalizado.numero < 0),
+    );
+
+    if (participantesIds.length === 0) {
+      return {
+        lineas: [] as RepartoFacturaPuntualLinea[],
+        total: 0,
+        valido: false,
+        automatico: false,
+        mensaje: 'Selecciona al menos un inquilino para repartir la factura.',
+      };
+    }
+
+    if (importeFacturaPuntualNumero <= 0) {
+      return {
+        lineas: [] as RepartoFacturaPuntualLinea[],
+        total: 0,
+        valido: false,
+        automatico: false,
+        mensaje: 'Introduce un importe total mayor que 0.',
+      };
+    }
+
+    if (hayImportesInvalidos) {
+      return {
+        lineas: [] as RepartoFacturaPuntualLinea[],
+        total: 0,
+        valido: false,
+        automatico: false,
+        mensaje: 'Usa importes válidos y nunca negativos. El 0 sí está permitido.',
+      };
+    }
+
+    if (entradasInformadas.length === 0) {
+      const lineas = repartirCentimos(totalCentimos, participantesIds);
+      return {
+        lineas,
+        total: importeFacturaPuntualNumero,
+        valido: true,
+        automatico: true,
+        mensaje: 'Sin importes manuales: se reparte a partes iguales.',
+      };
+    }
+
+    if (entradasInformadas.length !== participantesIds.length) {
+      return {
+        lineas: [] as RepartoFacturaPuntualLinea[],
+        total: entradasInformadas.reduce(
+          (total, entrada) => total + (entrada.normalizado.numero ?? 0),
+          0,
+        ),
+        valido: false,
+        automatico: false,
+        mensaje: 'Para un reparto manual, rellena todos los importes seleccionados. Puedes usar 0.',
+      };
+    }
+
+    const lineas = entradas.map((entrada) => ({
+      usuario_id: entrada.usuarioId,
+      importe: entrada.normalizado.numero ?? 0,
+      automatico: false,
+    }));
+    const sumaCentimos = lineas.reduce((total, linea) => total + aCentimos(linea.importe), 0);
+
+    return {
+      lineas,
+      total: desdeCentimos(sumaCentimos),
+      valido: sumaCentimos === totalCentimos,
+      automatico: false,
+      mensaje:
+        sumaCentimos === totalCentimos
+          ? 'Reparto manual cuadrado.'
+          : 'El reparto manual debe sumar exactamente el importe total.',
+    };
+  }, [
+    importeFacturaPuntualNumero,
+    participantesSeleccionadosFacturaPuntual,
+    repartoFacturaPuntual,
+  ]);
+  const totalAsignadoFacturaPuntual = repartoCalculadoFacturaPuntual.total;
   const repartoPuntualCuadra =
-    importeFacturaPuntualNumero > 0 &&
-    aCentimos(totalAsignadoFacturaPuntual) === aCentimos(importeFacturaPuntualNumero);
+    repartoCalculadoFacturaPuntual.valido && importeFacturaPuntualNumero > 0;
+  const repartoPuntualAutomatico = repartoCalculadoFacturaPuntual.automatico;
   const puedeGuardarFacturaPuntual =
     conceptoFacturaPuntual.trim().length > 0 &&
     fechaFacturaPuntual.trim().length > 0 &&
-    inquilinosActivos.length > 0 &&
     repartoPuntualCuadra &&
     !guardandoFacturaPuntual;
+  const obtenerLineaRepartoCalculado = useCallback(
+    (usuarioId: number) =>
+      repartoCalculadoFacturaPuntual.lineas.find((linea) => linea.usuario_id === usuarioId),
+    [repartoCalculadoFacturaPuntual.lineas],
+  );
   const facturasEmitidas = useMemo(() => {
     if (!resumen) {
       return [];
@@ -250,9 +376,17 @@ export default function CaseroCobrosScreen() {
         });
         return siguiente;
       });
+      setParticipantesFacturaPuntual((actual) => {
+        const siguiente: Record<number, boolean> = {};
+        activos.forEach((inquilino) => {
+          siguiente[inquilino.id] = actual[inquilino.id] ?? true;
+        });
+        return siguiente;
+      });
     } catch {
       setInquilinosActivos([]);
       setRepartoFacturaPuntual({});
+      setParticipantesFacturaPuntual({});
       Toast.show({ type: 'error', text1: 'No se pudieron cargar los inquilinos activos.' });
     }
   }, []);
@@ -329,6 +463,12 @@ export default function CaseroCobrosScreen() {
         return total;
       }, {}),
     );
+    setParticipantesFacturaPuntual(
+      inquilinosActivos.reduce<Record<number, boolean>>((total, inquilino) => {
+        total[inquilino.id] = true;
+        return total;
+      }, {}),
+    );
   };
 
   const cerrarModalFacturaPuntual = () => {
@@ -358,6 +498,13 @@ export default function CaseroCobrosScreen() {
     setRepartoFacturaPuntual((actual) => ({ ...actual, [usuarioId]: valor }));
   };
 
+  const alternarParticipanteFacturaPuntual = (usuarioId: number) => {
+    setParticipantesFacturaPuntual((actual) => ({
+      ...actual,
+      [usuarioId]: !(actual[usuarioId] ?? true),
+    }));
+  };
+
   const guardarFacturaPuntual = async () => {
     if (!viviendaSeleccionadaId || !puedeGuardarFacturaPuntual) {
       return;
@@ -370,11 +517,9 @@ export default function CaseroCobrosScreen() {
     formData.append(
       'repartoManual',
       JSON.stringify(
-        inquilinosActivos.map((inquilino) => ({
-          usuario_id: inquilino.id,
-          importe: parseFloat(
-            parsearImporte(repartoFacturaPuntual[inquilino.id] ?? '').toFixed(2),
-          ),
+        repartoCalculadoFacturaPuntual.lineas.map((linea) => ({
+          usuario_id: linea.usuario_id,
+          importe: parseFloat(linea.importe.toFixed(2)),
         })),
       ),
     );
@@ -923,40 +1068,84 @@ export default function CaseroCobrosScreen() {
               </Pressable>
 
               <View style={styles.splitHeader}>
-                <Text style={styles.sectionTitle}>Reparto desigual</Text>
-                <Text style={styles.sectionSubtitle}>Introduce la parte exacta de cada inquilino.</Text>
+                <Text style={styles.sectionTitle}>Reparto de la factura</Text>
+                <Text style={styles.sectionSubtitle}>
+                  Deja todos los importes vacíos para repartir a partes iguales. Si rellenas uno,
+                  completa todos los seleccionados; el 0 marca que no paga esta factura.
+                </Text>
               </View>
 
               <View style={styles.tenantList}>
-                {inquilinosActivos.map((inquilino) => (
-                  <View key={inquilino.id} style={styles.tenantRow}>
-                    <View style={styles.avatar}>
-                      <Text style={styles.avatarText}>
-                        {obtenerIniciales(inquilino.nombre, inquilino.apellidos)}
-                      </Text>
+                {inquilinosActivos.map((inquilino) => {
+                  const seleccionado = participantesFacturaPuntual[inquilino.id] ?? true;
+                  const lineaCalculada = obtenerLineaRepartoCalculado(inquilino.id);
+                  const importeCalculado = lineaCalculada?.importe ?? 0;
+                  const inputInformado = !normalizarInputImporte(
+                    repartoFacturaPuntual[inquilino.id] ?? '',
+                  ).vacio;
+
+                  return (
+                    <View
+                      key={inquilino.id}
+                      style={[styles.tenantRow, !seleccionado && styles.tenantRowDisabled]}
+                    >
+                      <Pressable
+                        style={[
+                          styles.participantToggle,
+                          seleccionado && styles.participantToggleActive,
+                        ]}
+                        onPress={() => alternarParticipanteFacturaPuntual(inquilino.id)}
+                        accessibilityRole="checkbox"
+                        accessibilityState={{ checked: seleccionado }}
+                        accessibilityLabel={`Incluir a ${nombreCompleto(
+                          inquilino.nombre,
+                          inquilino.apellidos,
+                        )} en el reparto`}
+                      >
+                        {seleccionado && (
+                          <Ionicons name="checkmark" size={16} color={Theme.colors.surface} />
+                        )}
+                      </Pressable>
+                      <View style={styles.avatar}>
+                        <Text style={styles.avatarText}>
+                          {obtenerIniciales(inquilino.nombre, inquilino.apellidos)}
+                        </Text>
+                      </View>
+                      <View style={styles.tenantInfo}>
+                        <Text style={styles.debtName} numberOfLines={1}>
+                          {nombreCompleto(inquilino.nombre, inquilino.apellidos)}
+                        </Text>
+                        <Text style={styles.debtDate}>
+                          {!seleccionado
+                            ? 'No incluido'
+                            : importeCalculado === 0 && (inputInformado || repartoPuntualAutomatico)
+                              ? 'No paga esta factura'
+                              : `Paga ${formatearImporte(importeCalculado)}`}
+                        </Text>
+                      </View>
+                      <TextInput
+                        style={[styles.splitInput, !seleccionado && styles.splitInputDisabled]}
+                        placeholder={
+                          repartoPuntualAutomatico ? formatearImporte(importeCalculado) : '0,00'
+                        }
+                        placeholderTextColor={Theme.colors.textMuted}
+                        value={repartoFacturaPuntual[inquilino.id] ?? ''}
+                        onChangeText={(valor) => actualizarRepartoPuntual(inquilino.id, valor)}
+                        keyboardType="decimal-pad"
+                        editable={seleccionado}
+                      />
                     </View>
-                    <View style={styles.tenantInfo}>
-                      <Text style={styles.debtName} numberOfLines={1}>
-                        {nombreCompleto(inquilino.nombre, inquilino.apellidos)}
-                      </Text>
-                      <Text style={styles.debtDate}>Parte asignada</Text>
-                    </View>
-                    <TextInput
-                      style={styles.splitInput}
-                      placeholder="0,00"
-                      placeholderTextColor={Theme.colors.textMuted}
-                      value={repartoFacturaPuntual[inquilino.id] ?? ''}
-                      onChangeText={(valor) => actualizarRepartoPuntual(inquilino.id, valor)}
-                      keyboardType="decimal-pad"
-                    />
-                  </View>
-                ))}
+                  );
+                })}
               </View>
 
               <View style={[styles.totalCounter, repartoPuntualCuadra && styles.totalCounterOk]}>
                 <Text style={[styles.totalCounterText, repartoPuntualCuadra && styles.totalCounterTextOk]}>
                   Total asignado: {formatearImporte(totalAsignadoFacturaPuntual)} /{' '}
                   {formatearImporte(importeFacturaPuntualNumero)}
+                </Text>
+                <Text style={[styles.totalCounterHelp, repartoPuntualCuadra && styles.totalCounterHelpOk]}>
+                  {repartoCalculadoFacturaPuntual.mensaje}
                 </Text>
               </View>
 

--- a/frontend/styles/casero/cobros.styles.ts
+++ b/frontend/styles/casero/cobros.styles.ts
@@ -465,6 +465,24 @@ export const styles = StyleSheet.create({
     padding: Theme.spacing.sm,
     minHeight: 76,
   },
+  tenantRowDisabled: {
+    opacity: 0.62,
+  },
+  participantToggle: {
+    width: 32,
+    height: 32,
+    borderRadius: Theme.radius.full,
+    borderWidth: 1.5,
+    borderColor: Theme.colors.border,
+    backgroundColor: Theme.colors.surface,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+  participantToggleActive: {
+    borderColor: Theme.colors.primary,
+    backgroundColor: Theme.colors.primary,
+  },
   tenantInfo: {
     flex: 1,
     minWidth: 0,
@@ -482,6 +500,10 @@ export const styles = StyleSheet.create({
     fontSize: Theme.typography.input,
     fontWeight: '800',
     color: Theme.colors.text,
+  },
+  splitInputDisabled: {
+    backgroundColor: Theme.colors.surface2,
+    color: Theme.colors.textMuted,
   },
   totalCounter: {
     borderRadius: Theme.radius.lg,
@@ -501,6 +523,17 @@ export const styles = StyleSheet.create({
     textAlign: 'center',
   },
   totalCounterTextOk: {
+    color: Theme.colors.success,
+  },
+  totalCounterHelp: {
+    marginTop: Theme.spacing.xs,
+    fontSize: Theme.typography.caption,
+    fontWeight: '700',
+    color: Theme.colors.textSecondary,
+    textAlign: 'center',
+    lineHeight: 18,
+  },
+  totalCounterHelpOk: {
     color: Theme.colors.success,
   },
   modalHandle: {


### PR DESCRIPTION
## Summary
* Permite crear facturas puntuales sin importes manuales, calculando reparto igualitario entre participantes seleccionados.
* Acepta cuotas manuales de 0 EUR y mantiene validaciones contra importes negativos, inválidos o descuadrados.
* Ajusta backend para validar `repartoManual` sin rechazar ceros y repartir en céntimos para cuadrar redondeos.
* Actualiza la UI del modal de cobros con selector de participantes, estados visuales y ayuda de reparto usando tokens de `Theme`.
* Añade changelog en `docs/changelog/Epica14/epica-14-issue-228-reparto-facturas-puntuales.md`.

## Testing
* `backend`: `npm run build`
* `frontend`: `npm run lint`