### PR TITLE
Fix [Épica 15] errores visuales del casero dentro de vivienda

### DIFF
--- a/docs/changelog/Epica15/epica-15-issue-233-casero-vivienda-ui.md
+++ b/docs/changelog/Epica15/epica-15-issue-233-casero-vivienda-ui.md
@@ -1,0 +1,16 @@
+# Issue #233 - Correccion visual del casero dentro de vivienda
+
+**Fecha:** 2026-04-11
+**Epica:** 15 - Pulido de casero en vivienda y gastos comunes
+
+## Cambios tecnicos
+
+- `frontend/app/casero/vivienda/[id]/(tabs)/_layout.tsx`: el layout de tabs internas lee el `id` de vivienda con `useLocalSearchParams` para no reaccionar a parametros globales de rutas hermanas.
+- `frontend/app/casero/vivienda/[id]/(tabs)/index.tsx`, `incidencias.tsx`, `limpieza.tsx`, `opciones.tsx` y `tablon.tsx`: aislamiento del parametro `id` en cada tab para evitar que perfiles, incidencias u otras pantallas con `[id]` mezclen estado con la vivienda abierta.
+- `frontend/hooks/useViviendaIdParam.ts`: nuevo helper para obtener el `id` local de vivienda con fallback al pathname cuando Expo Router no propaga el parametro en tabs anidados.
+- Se mantiene la navegacion interna de la vivienda separada de la navegacion global del casero, reduciendo solapes y renderizados inconsistentes al entrar o volver desde pantallas detalle.
+
+## Validacion
+
+- `frontend`: `npm run lint` sin errores; persisten warnings existentes del proyecto.
+- `frontend`: `npx tsc --noEmit` sin errores.

--- a/frontend/app/casero/vivienda/[id]/(tabs)/_layout.tsx
+++ b/frontend/app/casero/vivienda/[id]/(tabs)/_layout.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Tabs, useFocusEffect, useGlobalSearchParams, useRouter } from 'expo-router';
+import { Tabs, useFocusEffect, useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { Pressable } from 'react-native';
 import { Theme } from '@/constants/theme';
 import api from '@/services/api';
 import { onModulosViviendaActualizados } from '@/utils/viviendaModules';
+import { useViviendaIdParam } from '@/hooks/useViviendaIdParam';
 
 type ViviendaModulos = {
   mod_limpieza: boolean;
@@ -14,8 +15,7 @@ type ViviendaModulos = {
 
 export default function ViviendaTabsLayout() {
   const router = useRouter();
-  const params = useGlobalSearchParams<{ id?: string | string[] }>();
-  const id = Array.isArray(params.id) ? params.id[0] : params.id;
+  const id = useViviendaIdParam();
   const [modulos, setModulos] = useState({ limpieza: true });
 
   const cargarModulos = useCallback(async () => {

--- a/frontend/app/casero/vivienda/[id]/(tabs)/incidencias.tsx
+++ b/frontend/app/casero/vivienda/[id]/(tabs)/incidencias.tsx
@@ -4,8 +4,9 @@ import Toast from 'react-native-toast-message';
 import { LoadingScreen } from '@/components/common/LoadingScreen';
 import { Theme } from '@/constants/theme';
 import { useState, useCallback } from 'react';
-import { useGlobalSearchParams, useRouter, useFocusEffect } from 'expo-router';
+import { useRouter, useFocusEffect } from 'expo-router';
 import api from '@/services/api';
+import { useViviendaIdParam } from '@/hooks/useViviendaIdParam';
 import {
   styles,
   PRIORIDAD_BG,
@@ -34,8 +35,7 @@ type Incidencia = {
 const ESTADOS: Estado[] = ['PENDIENTE', 'EN_PROCESO', 'RESUELTA'];
 
 export default function IncidenciasCaseroTab() {
-  const params = useGlobalSearchParams<{ id?: string | string[] }>();
-  const id = Array.isArray(params.id) ? params.id[0] : params.id;
+  const id = useViviendaIdParam();
   const router = useRouter();
   const [incidencias, setIncidencias] = useState<Incidencia[]>([]);
   const [loading, setLoading] = useState(true);

--- a/frontend/app/casero/vivienda/[id]/(tabs)/index.tsx
+++ b/frontend/app/casero/vivienda/[id]/(tabs)/index.tsx
@@ -13,7 +13,7 @@ import { Ionicons } from '@expo/vector-icons';
 import Toast from 'react-native-toast-message';
 import { LoadingScreen } from '@/components/common/LoadingScreen';
 import { useState, useCallback } from 'react';
-import { useGlobalSearchParams, useRouter, useFocusEffect } from 'expo-router';
+import { useRouter, useFocusEffect } from 'expo-router';
 import * as LocalAuthentication from 'expo-local-authentication';
 import * as Clipboard from 'expo-clipboard';
 import api from '@/services/api';
@@ -22,6 +22,7 @@ import { styles } from '@/styles/casero/vivienda/detalle.styles';
 import { COLORES_PRIORIDAD } from '@/styles/casero/vivienda/incidencias.styles';
 import { CustomButton } from '@/components/common/CustomButton';
 import { CustomInput } from '@/components/common/CustomInput';
+import { useViviendaIdParam } from '@/hooks/useViviendaIdParam';
 
 type Prioridad = 'VERDE' | 'AMARILLO' | 'ROJO';
 type Estado = 'PENDIENTE' | 'EN_PROCESO' | 'RESUELTA';
@@ -119,8 +120,7 @@ const AvatarInitials = ({
 };
 
 export default function ResumenViviendaTab() {
-  const params = useGlobalSearchParams<{ id?: string | string[] }>();
-  const id = Array.isArray(params.id) ? params.id[0] : params.id;
+  const id = useViviendaIdParam();
   const router = useRouter();
   const [vivienda, setVivienda] = useState<Vivienda | null>(null);
   const [gastosRecurrentes, setGastosRecurrentes] = useState<GastoRecurrente[]>([]);

--- a/frontend/app/casero/vivienda/[id]/(tabs)/limpieza.tsx
+++ b/frontend/app/casero/vivienda/[id]/(tabs)/limpieza.tsx
@@ -14,12 +14,12 @@ import { Ionicons } from '@expo/vector-icons';
 import Toast from 'react-native-toast-message';
 import { Theme } from '@/constants/theme';
 import { useState, useEffect } from 'react';
-import { useGlobalSearchParams } from 'expo-router';
 import api from '@/services/api';
 import { Card } from '@/components/common/Card';
 import { CustomButton } from '@/components/common/CustomButton';
 import { CustomInput } from '@/components/common/CustomInput';
 import { styles } from '@/styles/casero/vivienda/limpieza.styles';
+import { useViviendaIdParam } from '@/hooks/useViviendaIdParam';
 
 // ── Helpers UI ────────────────────────────────────────────────────────────────
 
@@ -122,8 +122,7 @@ type Turno = {
 // ─────────────────────────────────────────────────────────────────────────────
 
 export default function LimpiezaCaseroTab() {
-  const params = useGlobalSearchParams<{ id?: string | string[] }>();
-  const id = Array.isArray(params.id) ? params.id[0] : params.id;
+  const id = useViviendaIdParam();
 
   // — Vista activa —
   const [vistaActual, setVistaActual] = useState<'CONFIG' | 'CALENDARIO'>('CONFIG');

--- a/frontend/app/casero/vivienda/[id]/(tabs)/opciones.tsx
+++ b/frontend/app/casero/vivienda/[id]/(tabs)/opciones.tsx
@@ -1,12 +1,13 @@
 import { useCallback, useState } from 'react';
 import { ScrollView, Text, View } from 'react-native';
 import Toast from 'react-native-toast-message';
-import { useFocusEffect, useGlobalSearchParams } from 'expo-router';
+import { useFocusEffect } from 'expo-router';
 import { LoadingScreen } from '@/components/common/LoadingScreen';
 import { ModulosViviendaManager } from '@/components/casero/vivienda/ModulosViviendaManager';
 import api from '@/services/api';
 import { styles } from '@/styles/casero/vivienda/detalle.styles';
 import { ModulosVivienda } from '@/utils/viviendaModules';
+import { useViviendaIdParam } from '@/hooks/useViviendaIdParam';
 
 type Vivienda = ModulosVivienda & {
   id: number;
@@ -15,8 +16,7 @@ type Vivienda = ModulosVivienda & {
 };
 
 export default function OpcionesViviendaTab() {
-  const params = useGlobalSearchParams<{ id?: string | string[] }>();
-  const id = Array.isArray(params.id) ? params.id[0] : params.id;
+  const id = useViviendaIdParam();
   const [vivienda, setVivienda] = useState<Vivienda | null>(null);
   const [loading, setLoading] = useState(true);
 

--- a/frontend/app/casero/vivienda/[id]/(tabs)/tablon.tsx
+++ b/frontend/app/casero/vivienda/[id]/(tabs)/tablon.tsx
@@ -14,9 +14,10 @@ import { Ionicons } from '@expo/vector-icons';
 import Toast from 'react-native-toast-message';
 import { Theme } from '@/constants/theme';
 import { useState, useCallback } from 'react';
-import { useGlobalSearchParams, useFocusEffect } from 'expo-router';
+import { useFocusEffect } from 'expo-router';
 import api from '@/services/api';
 import { styles } from '@/styles/tablon/tablon.styles';
+import { useViviendaIdParam } from '@/hooks/useViviendaIdParam';
 
 type Anuncio = {
   id: number;
@@ -28,8 +29,7 @@ type Anuncio = {
 };
 
 export default function CaseroTablonTab() {
-  const params = useGlobalSearchParams<{ id?: string | string[] }>();
-  const id = Array.isArray(params.id) ? params.id[0] : params.id;
+  const id = useViviendaIdParam();
   const [anuncios, setAnuncios] = useState<Anuncio[]>([]);
   const [loading, setLoading] = useState(true);
   const [modalVisible, setModalVisible] = useState(false);

--- a/frontend/hooks/useViviendaIdParam.ts
+++ b/frontend/hooks/useViviendaIdParam.ts
@@ -1,0 +1,20 @@
+import { useLocalSearchParams, usePathname } from 'expo-router';
+import { useMemo } from 'react';
+
+export function useViviendaIdParam() {
+  const params = useLocalSearchParams<{ id?: string | string[] }>();
+  const pathname = usePathname();
+
+  return useMemo(() => {
+    const localId = Array.isArray(params.id) ? params.id[0] : params.id;
+    if (localId) {
+      return localId;
+    }
+
+    const segments = pathname.split('/').filter(Boolean);
+    const viviendaIndex = segments.findIndex((segment) => segment === 'vivienda');
+    const idFromPath = viviendaIndex >= 0 ? segments[viviendaIndex + 1] : undefined;
+
+    return idFromPath ? decodeURIComponent(idFromPath) : undefined;
+  }, [params.id, pathname]);
+}


### PR DESCRIPTION
## Summary
- Aísla el `id` de vivienda en las tabs internas del casero para evitar mezcla de estado con rutas hermanas que también usan `[id]`.
- Añade un helper compartido para resolver el `id` local con fallback al pathname en tabs anidados de Expo Router.
- Actualiza el changelog: `docs/changelog/Epica15/epica-15-issue-233-casero-vivienda-ui.md`.

## Testing
- `npm run lint`.
- `npx tsc --noEmit`.