### PR TITLE
Remove etiqueta redundante de rol en perfil de propietario

### DIFF
--- a/docs/changelog/Epica15/epica-15-issue-235-perfil-casero-propietario.md
+++ b/docs/changelog/Epica15/epica-15-issue-235-perfil-casero-propietario.md
@@ -1,0 +1,15 @@
+# Issue #235 - Perfil de casero como Propietario
+
+**Fecha:** 2026-04-11
+**Epica:** 15 - Pulido de casero en vivienda y gastos comunes
+
+## Cambios tecnicos
+
+- `frontend/app/perfil.tsx`: el badge visible del perfil muestra `Propietario` para usuarios con rol `CASERO`.
+- `frontend/app/perfil.tsx`: se elimina la tarjeta redundante de `Rol` del perfil compartido.
+- El perfil del inquilino mantiene su identidad visible mediante el badge `Inquilino`, sin mostrar un campo de rol adicional.
+
+## Validacion
+
+- `frontend`: `npm run lint` sin errores; persisten warnings existentes del proyecto.
+- `frontend`: `npx tsc --noEmit` sin errores.

--- a/frontend/app/perfil.tsx
+++ b/frontend/app/perfil.tsx
@@ -63,7 +63,7 @@ export default function PerfilScreen() {
         <Text style={styles.nombreCompleto}>{perfil.nombre} {perfil.apellidos}</Text>
 
         <View style={[styles.badge, esCasero ? styles.badgeCasero : styles.badgeInquilino]}>
-          <Text style={styles.badgeTexto}>{esCasero ? 'Casero' : 'Inquilino'}</Text>
+          <Text style={styles.badgeTexto}>{esCasero ? 'Propietario' : 'Inquilino'}</Text>
         </View>
 
         <View style={styles.tarjeta}>
@@ -77,11 +77,6 @@ export default function PerfilScreen() {
             <Text style={styles.tarjetaValor}>{perfil.telefono}</Text>
           </View>
         ) : null}
-
-        <View style={styles.tarjeta}>
-          <Text style={styles.tarjetaLabel}>Rol</Text>
-          <Text style={styles.tarjetaValor}>{esCasero ? 'Propietario / Casero' : 'Inquilino'}</Text>
-        </View>
 
         <Pressable
           style={({ pressed }) => [styles.botonLogout, pressed && styles.pressed]}


### PR DESCRIPTION
## Summary
- El perfil del casero muestra la identidad visible como `Propietario`.
- Se elimina la tarjeta redundante de `Rol` del perfil compartido.
- El perfil del inquilino mantiene su badge `Inquilino` sin campo de rol adicional.
- Changelog actualizado: `docs/changelog/Epica15/epica-15-issue-235-perfil-casero-propietario.md`.

## Testing
- `npm run lint` sin errores; persisten warnings existentes del proyecto.
- `npx tsc --noEmit` sin errores.