### PR TITLE
Fix textos con ñ y acentos en la app

### DIFF
--- a/backend/src/controllers/gasto.controller.ts
+++ b/backend/src/controllers/gasto.controller.ts
@@ -199,7 +199,7 @@ export const crearGasto: express.RequestHandler = async (req, res) => {
   try {
     repartoManual = normalizarRepartoManual(req.body.repartoManual);
   } catch (error) {
-    const mensaje = error instanceof Error ? error.message : 'repartoManual no es valido.';
+    const mensaje = error instanceof Error ? error.message : 'repartoManual no es válido.';
     res.status(400).json({ error: mensaje });
     return;
   }
@@ -215,7 +215,7 @@ export const crearGasto: express.RequestHandler = async (req, res) => {
     )
   ) {
     res.status(400).json({
-      error: 'repartoManual debe incluir usuario_id numerico e importe valido no negativo.',
+      error: 'repartoManual debe incluir usuario_id numérico e importe válido no negativo.',
     });
     return;
   }
@@ -230,7 +230,7 @@ export const crearGasto: express.RequestHandler = async (req, res) => {
 
   const fechaGasto = fecha ? new Date(fecha) : undefined;
   if (fecha && Number.isNaN(fechaGasto?.getTime())) {
-    res.status(400).json({ error: 'fecha debe ser una fecha valida.' });
+    res.status(400).json({ error: 'fecha debe ser una fecha válida.' });
     return;
   }
 
@@ -274,12 +274,12 @@ export const actualizarGasto: express.RequestHandler = async (req, res) => {
   const usuarioId = req.usuario!.id;
 
   if (!Number.isInteger(viviendaId) || viviendaId <= 0) {
-    res.status(400).json({ error: 'viviendaId invalido.' });
+    res.status(400).json({ error: 'viviendaId inválido.' });
     return;
   }
 
   if (!Number.isInteger(gastoId) || gastoId <= 0) {
-    res.status(400).json({ error: 'gastoId invalido.' });
+    res.status(400).json({ error: 'gastoId inválido.' });
     return;
   }
 
@@ -297,7 +297,7 @@ export const actualizarGasto: express.RequestHandler = async (req, res) => {
 
   if (concepto !== undefined) {
     if (!concepto.trim()) {
-      res.status(400).json({ error: 'El concepto no puede estar vacio.' });
+      res.status(400).json({ error: 'El concepto no puede estar vacío.' });
       return;
     }
 
@@ -306,7 +306,7 @@ export const actualizarGasto: express.RequestHandler = async (req, res) => {
 
   if (importe !== undefined) {
     if (typeof importe !== 'number' || !Number.isFinite(importe) || importe <= 0) {
-      res.status(400).json({ error: 'El importe debe ser un numero mayor que 0.' });
+      res.status(400).json({ error: 'El importe debe ser un número mayor que 0.' });
       return;
     }
 
@@ -317,7 +317,7 @@ export const actualizarGasto: express.RequestHandler = async (req, res) => {
     const fechaActualizada = new Date(fecha);
 
     if (Number.isNaN(fechaActualizada.getTime())) {
-      res.status(400).json({ error: 'La fecha indicada no es valida.' });
+      res.status(400).json({ error: 'La fecha indicada no es válida.' });
       return;
     }
 
@@ -325,7 +325,7 @@ export const actualizarGasto: express.RequestHandler = async (req, res) => {
   }
 
   if (Object.keys(datosActualizacion).length === 0) {
-    res.status(400).json({ error: 'No hay campos validos para actualizar.' });
+    res.status(400).json({ error: 'No hay campos válidos para actualizar.' });
     return;
   }
 
@@ -387,17 +387,17 @@ export const subirFacturaGasto: express.RequestHandler = async (req, res) => {
   const usuarioId = req.usuario!.id;
 
   if (!cloudinaryEstaConfigurado) {
-    res.status(500).json({ error: 'Cloudinary no esta configurado en el servidor.' });
+    res.status(500).json({ error: 'Cloudinary no está configurado en el servidor.' });
     return;
   }
 
   if (!Number.isInteger(viviendaId) || viviendaId <= 0) {
-    res.status(400).json({ error: 'viviendaId invalido.' });
+    res.status(400).json({ error: 'viviendaId inválido.' });
     return;
   }
 
   if (!Number.isInteger(gastoId) || gastoId <= 0) {
-    res.status(400).json({ error: 'gastoId invalido.' });
+    res.status(400).json({ error: 'gastoId inválido.' });
     return;
   }
 

--- a/backend/src/controllers/user.controller.ts
+++ b/backend/src/controllers/user.controller.ts
@@ -5,7 +5,7 @@ export const actualizarPushToken: express.RequestHandler = async (req, res) => {
   const { token } = req.body as { token?: unknown };
 
   if (token !== null && (typeof token !== 'string' || token.trim().length === 0)) {
-    res.status(400).json({ error: 'Debes enviar un token valido.' });
+    res.status(400).json({ error: 'Debes enviar un token válido.' });
     return;
   }
 

--- a/backend/src/controllers/vivienda.controller.ts
+++ b/backend/src/controllers/vivienda.controller.ts
@@ -126,12 +126,12 @@ export const actualizarVivienda: express.RequestHandler = async (req, res) => {
   };
 
   if (!Number.isInteger(id) || id <= 0) {
-    res.status(400).json({ error: 'ID de vivienda invalido.' });
+    res.status(400).json({ error: 'ID de vivienda inválido.' });
     return;
   }
 
   if (req.usuario!.rol !== RolUsuario.CASERO) {
-    res.status(403).json({ error: 'Solo el casero puede configurar los modulos de una vivienda.' });
+    res.status(403).json({ error: 'Solo el casero puede configurar los módulos de una vivienda.' });
     return;
   }
 
@@ -172,7 +172,7 @@ export const actualizarVivienda: express.RequestHandler = async (req, res) => {
   }
 
   if (Object.keys(data).length === 0) {
-    res.status(400).json({ error: 'No hay modulos para actualizar.' });
+    res.status(400).json({ error: 'No hay módulos para actualizar.' });
     return;
   }
 

--- a/backend/src/middlewares/module.guard.ts
+++ b/backend/src/middlewares/module.guard.ts
@@ -29,7 +29,7 @@ export const protegerModuloVivienda = (
   const viviendaId = await resolverViviendaId(req);
 
   if (!viviendaId) {
-    res.status(400).json({ error: 'viviendaId invalido.' });
+    res.status(400).json({ error: 'viviendaId inválido.' });
     return;
   }
 
@@ -45,7 +45,7 @@ export const protegerModuloVivienda = (
   }
 
   if (!vivienda[campo]) {
-    res.status(403).json({ error: `El modulo ${modulo} esta desactivado para esta vivienda.` });
+    res.status(403).json({ error: `El módulo ${modulo} está desactivado para esta vivienda.` });
     return;
   }
 

--- a/frontend/app/casero/(tabs)/_layout.tsx
+++ b/frontend/app/casero/(tabs)/_layout.tsx
@@ -82,7 +82,7 @@ export default function CaseroTabsLayout() {
       <Tabs.Screen
         name="viviendas"
         options={{
-          title: 'Mis viviendas',
+          title: 'Viviendas',
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="home-outline" size={size} color={color} />
           ),
@@ -101,7 +101,7 @@ export default function CaseroTabsLayout() {
       <Tabs.Screen
         name="inventario"
         options={{
-          title: 'Inventario',
+          title: 'Invent.',
           href: modulos.inventario ? undefined : null,
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="albums-outline" size={size} color={color} />

--- a/frontend/app/casero/(tabs)/cobros.tsx
+++ b/frontend/app/casero/(tabs)/cobros.tsx
@@ -605,12 +605,12 @@ export default function CaseroCobrosScreen() {
     const importeNormalizado = Number(importeEditado.replace(',', '.'));
 
     if (!conceptoNormalizado) {
-      Toast.show({ type: 'error', text1: 'El concepto no puede estar vacio.' });
+      Toast.show({ type: 'error', text1: 'El concepto no puede estar vacío.' });
       return;
     }
 
     if (!facturaTienePagos && (!Number.isFinite(importeNormalizado) || importeNormalizado <= 0)) {
-      Toast.show({ type: 'error', text1: 'Introduce un importe valido mayor que 0.' });
+      Toast.show({ type: 'error', text1: 'Introduce un importe válido mayor que 0.' });
       return;
     }
 
@@ -691,7 +691,7 @@ export default function CaseroCobrosScreen() {
         Toast.show({
           type: 'info',
           text1: 'Permiso necesario',
-          text2: 'Necesitamos acceso a tu galeria para adjuntar la factura.',
+          text2: 'Necesitamos acceso a tu galería para adjuntar la factura.',
         });
         return;
       }
@@ -869,7 +869,7 @@ export default function CaseroCobrosScreen() {
                 </View>
                 <Text style={styles.emptyTitle}>Sin facturas emitidas</Text>
                 <Text style={styles.emptySubtitle}>
-                  Las mensualidades generadas apareceran aqui para poder revisarlas.
+                  Las mensualidades generadas aparecerán aquí para poder revisarlas.
                 </Text>
               </View>
             ) : (
@@ -1182,7 +1182,7 @@ export default function CaseroCobrosScreen() {
             <View style={styles.modalHandle} />
             <Text style={styles.modalTitle}>Editar factura</Text>
             <Text style={styles.modalSubtitle}>
-              Actualiza los datos del recibo y se reflejara en los cobros abiertos.
+              Actualiza los datos del recibo y se reflejará en los cobros abiertos.
             </Text>
 
             {facturaTienePagos && (

--- a/frontend/app/inquilino/(tabs)/_layout.tsx
+++ b/frontend/app/inquilino/(tabs)/_layout.tsx
@@ -72,7 +72,7 @@ export default function InquilinoTabsLayout() {
       <Tabs.Screen
         name="inicio"
         options={{
-          title: "Mi vivienda",
+          title: "Vivienda",
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="home-outline" size={size} color={color} />
           ),
@@ -111,7 +111,7 @@ export default function InquilinoTabsLayout() {
       <Tabs.Screen
         name="inventario"
         options={{
-          title: "Inventario",
+          title: "Invent.",
           href: modulos.inventario ? undefined : null,
           tabBarIcon: ({ color, size }) => (
             <Ionicons name="images-outline" size={size} color={color} />

--- a/frontend/app/inquilino/(tabs)/gastos.tsx
+++ b/frontend/app/inquilino/(tabs)/gastos.tsx
@@ -341,7 +341,7 @@ export default function GastosInquilinoTab() {
 
     const importeNum = parseFloat(importe.replace(',', '.'));
     if (isNaN(importeNum) || importeNum <= 0) {
-      Toast.show({ type: 'error', text1: 'Introduce un importe valido mayor que 0.' });
+      Toast.show({ type: 'error', text1: 'Introduce un importe válido mayor que 0.' });
       return;
     }
 
@@ -413,12 +413,12 @@ export default function GastosInquilinoTab() {
           <View style={styles.heroHeader}>
             <View style={[styles.heroEtiquetaBadge, { backgroundColor: Theme.colors.primaryLight }]}>
               <Text style={[styles.heroEtiqueta, { color: Theme.colors.primary }]}>
-                RESUMEN ENTRE COMPANEROS
+                RESUMEN ENTRE COMPAÑEROS
               </Text>
             </View>
             <Text style={styles.heroTitulo}>Lo que debes y lo que te deben van por separado</Text>
             <Text style={styles.heroDescripcion}>
-              Ya no compensamos un pendiente con otro. Asi ves con claridad lo que debes y lo que
+              Ya no compensamos un pendiente con otro. Así ves con claridad lo que debes y lo que
               te deben dentro del piso.
             </Text>
           </View>
@@ -439,7 +439,7 @@ export default function GastosInquilinoTab() {
               <Text style={[styles.heroResumenImporte, { color: Theme.colors.danger }]}>
                 {formatImporte(totalDeboCompaneros)}
               </Text>
-              <Text style={styles.heroResumenTexto}>Pendiente con companeros</Text>
+              <Text style={styles.heroResumenTexto}>Pendiente con compañeros</Text>
             </View>
 
             <View
@@ -478,9 +478,9 @@ export default function GastosInquilinoTab() {
                 <Ionicons name="business-outline" size={18} color={Theme.colors.info} />
               </View>
               <View style={styles.caseroHeaderTextos}>
-                <Text style={styles.caseroTitulo}>Relacion con el casero</Text>
+                <Text style={styles.caseroTitulo}>Relación con el casero</Text>
                 <Text style={styles.caseroDescripcion}>
-                  Este bloque va aparte y no se mezcla con los companeros del piso.
+                  Este bloque va aparte y no se mezcla con los compañeros del piso.
                 </Text>
               </View>
             </View>
@@ -507,7 +507,7 @@ export default function GastosInquilinoTab() {
 
         {deudasPendientesCompaneros.length > 0 && (
           <>
-            <Text style={styles.seccionTitulo}>Pendientes con companeros</Text>
+            <Text style={styles.seccionTitulo}>Pendientes con compañeros</Text>
             {deudasPendientesCompaneros.map((deuda) => {
               const yoDebo = deuda.deudor_id === miId;
               const companero = yoDebo ? deuda.acreedor : deuda.deudor;
@@ -731,9 +731,9 @@ export default function GastosInquilinoTab() {
             <View style={styles.emptyIconBox}>
               <Ionicons name="wallet-outline" size={40} color={Theme.colors.primary} />
             </View>
-            <Text style={styles.emptyTitulo}>Sin gastos todavia</Text>
+            <Text style={styles.emptyTitulo}>Sin gastos todavía</Text>
             <Text style={styles.emptySubtitulo}>
-              Cuando alguien pague algo por la casa, aparecera aqui para que todos contribuyan su
+              Cuando alguien pague algo por la casa, aparecerá aquí para que todos contribuyan su
               parte.
             </Text>
           </View>
@@ -761,7 +761,7 @@ export default function GastosInquilinoTab() {
       <Pressable
         style={({ pressed }) => [styles.fab, pressed && styles.fabPressed]}
         onPress={abrirModal}
-        accessibilityLabel="Anadir nuevo gasto"
+        accessibilityLabel="Añadir nuevo gasto"
         accessibilityRole="button"
       >
         <Ionicons name="add" size={28} color={Theme.colors.surface} />
@@ -931,7 +931,7 @@ export default function GastosInquilinoTab() {
             </View>
 
             <View style={styles.participantesSection}>
-              <Text style={styles.inputLabel}>Quien participa?</Text>
+              <Text style={styles.inputLabel}>¿Quién participa?</Text>
               <ScrollView
                 horizontal
                 showsHorizontalScrollIndicator={false}
@@ -952,7 +952,7 @@ export default function GastosInquilinoTab() {
                       onPress={() => toggleImplicado(inquilino.id)}
                       accessibilityRole="button"
                       accessibilityLabel={`${
-                        estaSeleccionado ? 'Quitar de' : 'Anadir a'
+                        estaSeleccionado ? 'Quitar de' : 'Añadir a'
                       } participantes a ${esYo ? 'ti' : inquilino.nombre}`}
                     >
                       <AvatarInitials
@@ -968,7 +968,7 @@ export default function GastosInquilinoTab() {
                           ]}
                           numberOfLines={1}
                         >
-                          {esYo ? 'Tu' : inquilino.nombre}
+                          {esYo ? 'Tú' : inquilino.nombre}
                         </Text>
                         <Text
                           style={[


### PR DESCRIPTION
## Summary
- Restaura ñ y acentos en textos visibles de gastos comunes, cobros, navegación y perfil.
- Ajusta etiquetas de tabs para reducir truncados en móvil.
- Corrige mensajes de validación del backend que pueden mostrarse en Toast.

## Testing
- `npm run lint` en frontend: pasa con warnings existentes.
- `npm run build` en backend: pasa.