### PR TITLE
Fix textos de prueba en gastos comunes

### DIFF
--- a/docs/changelog/Epica15/epica-15-issue-237-eliminar-datos-prueba-gastos.md
+++ b/docs/changelog/Epica15/epica-15-issue-237-eliminar-datos-prueba-gastos.md
@@ -1,0 +1,14 @@
+# Issue #237 - Eliminar datos de prueba en gastos comunes
+
+**Epica:** 15 - Pulido de casero en vivienda y gastos comunes
+
+## Cambios
+
+- La pantalla de gastos comunes deja de mostrar textos explicativos temporales en el resumen entre companeros.
+- Se elimina la nota de compensacion automatica del bloque superior.
+- Se elimina la descripcion temporal del bloque de relacion con el casero.
+- La pantalla de gastos comunes muestra un estado vacio cuando no hay pagos pendientes reales.
+
+## Verificacion
+
+- Pendiente de ejecutar build/lint tras la implementacion.

--- a/frontend/app/inquilino/(tabs)/gastos.tsx
+++ b/frontend/app/inquilino/(tabs)/gastos.tsx
@@ -203,6 +203,9 @@ export default function GastosInquilinoTab() {
   const totalMeDebenCasero = sumarImportes(
     deudasPendientesCasero.filter((deuda) => deuda.acreedor_id === miId),
   );
+  const noHayPendientes = deudasPendientes.length === 0;
+  const mostrarPendientesVacios =
+    noHayPendientes && (deudasRelacionadas.length > 0 || gastos.length > 0);
 
   const abrirModalPago = (deuda: Deuda) => {
     setDeudaSeleccionada(deuda);
@@ -410,19 +413,6 @@ export default function GastosInquilinoTab() {
         </View>
 
         <View style={styles.heroCard}>
-          <View style={styles.heroHeader}>
-            <View style={[styles.heroEtiquetaBadge, { backgroundColor: Theme.colors.primaryLight }]}>
-              <Text style={[styles.heroEtiqueta, { color: Theme.colors.primary }]}>
-                RESUMEN ENTRE COMPAÑEROS
-              </Text>
-            </View>
-            <Text style={styles.heroTitulo}>Lo que debes y lo que te deben van por separado</Text>
-            <Text style={styles.heroDescripcion}>
-              Ya no compensamos un pendiente con otro. Así ves con claridad lo que debes y lo que
-              te deben dentro del piso.
-            </Text>
-          </View>
-
           <View style={styles.heroResumenGrid}>
             <View
               style={[
@@ -463,12 +453,6 @@ export default function GastosInquilinoTab() {
             </View>
           </View>
 
-          <View style={styles.heroFootnote}>
-            <Ionicons name="swap-horizontal-outline" size={16} color={Theme.colors.textSecondary} />
-            <Text style={styles.heroFootnoteText}>
-              Solo se cruzan importes cuando la otra persona es la misma.
-            </Text>
-          </View>
         </View>
 
         {(totalDeboCasero > 0 || totalMeDebenCasero > 0) && (
@@ -479,9 +463,6 @@ export default function GastosInquilinoTab() {
               </View>
               <View style={styles.caseroHeaderTextos}>
                 <Text style={styles.caseroTitulo}>Relación con el casero</Text>
-                <Text style={styles.caseroDescripcion}>
-                  Este bloque va aparte y no se mezcla con los compañeros del piso.
-                </Text>
               </View>
             </View>
 
@@ -501,6 +482,21 @@ export default function GastosInquilinoTab() {
                   {formatImporte(totalMeDebenCasero)}
                 </Text>
               </View>
+            </View>
+          </View>
+        )}
+
+        {mostrarPendientesVacios && (
+          <View style={styles.pendientesEmptyCard}>
+            <View style={styles.pendientesEmptyIcon}>
+              <Ionicons name="checkmark-circle-outline" size={22} color={Theme.colors.success} />
+            </View>
+            <View style={styles.pendientesEmptyTextos}>
+              <Text style={styles.pendientesEmptyTitulo}>Sin pagos pendientes</Text>
+              <Text style={styles.pendientesEmptySubtitulo}>
+                Cuando haya una deuda real con un compañero o con el casero, aparecerá en esta
+                zona.
+              </Text>
             </View>
           </View>
         )}

--- a/frontend/styles/inquilino/gastos.styles.ts
+++ b/frontend/styles/inquilino/gastos.styles.ts
@@ -44,45 +44,15 @@ export const styles = StyleSheet.create({
     borderColor: Theme.colors.border,
     ...Theme.shadows.sm,
   },
-  heroHeader: {
-    alignItems: 'flex-start',
-  },
-  heroEtiquetaBadge: {
-    borderRadius: Theme.radius.full,
-    paddingHorizontal: Theme.spacing.md,
-    paddingVertical: 7,
-    marginBottom: Theme.spacing.md,
-  },
-  heroEtiqueta: {
-    fontSize: Theme.typography.caption,
-    fontWeight: '800',
-    textTransform: 'uppercase',
-    letterSpacing: 1.4,
-  },
   heroImporte: {
     fontSize: Theme.typography.hero,
     fontWeight: '900',
     letterSpacing: -1,
     lineHeight: 40,
   },
-  heroDescripcion: {
-    fontSize: Theme.typography.label,
-    fontWeight: '600',
-    marginTop: Theme.spacing.sm,
-    color: Theme.colors.textSecondary,
-    lineHeight: 21,
-  },
-  heroTitulo: {
-    fontSize: Theme.typography.heading,
-    fontWeight: '800',
-    color: Theme.colors.text,
-    letterSpacing: -0.4,
-    lineHeight: 30,
-  },
   heroResumenGrid: {
     flexDirection: 'row',
     gap: Theme.spacing.md,
-    marginTop: Theme.spacing.lg,
   },
   heroResumenCard: {
     flex: 1,
@@ -115,22 +85,6 @@ export const styles = StyleSheet.create({
     color: Theme.colors.textSecondary,
     lineHeight: 20,
   },
-  heroFootnote: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Theme.spacing.sm,
-    marginTop: Theme.spacing.base,
-    paddingTop: Theme.spacing.base,
-    borderTopWidth: 1,
-    borderTopColor: Theme.colors.border,
-  },
-  heroFootnoteText: {
-    flex: 1,
-    fontSize: Theme.typography.label,
-    color: Theme.colors.textSecondary,
-    lineHeight: 20,
-  },
-
   caseroCard: {
     backgroundColor: Theme.colors.surface,
     borderRadius: Theme.radius.xl,
@@ -164,11 +118,6 @@ export const styles = StyleSheet.create({
     color: Theme.colors.text,
     letterSpacing: -0.2,
   },
-  caseroDescripcion: {
-    fontSize: Theme.typography.label,
-    color: Theme.colors.textSecondary,
-    lineHeight: 20,
-  },
   caseroResumenGrid: {
     flexDirection: 'row',
     gap: Theme.spacing.md,
@@ -189,6 +138,39 @@ export const styles = StyleSheet.create({
     fontSize: Theme.typography.subtitle,
     fontWeight: '900',
     letterSpacing: -0.3,
+  },
+  pendientesEmptyCard: {
+    backgroundColor: Theme.colors.successLight,
+    borderRadius: Theme.radius.lg,
+    padding: Theme.spacing.base,
+    marginBottom: Theme.spacing.xl,
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: Theme.spacing.base,
+    borderWidth: 1,
+    borderColor: Theme.colors.success + '22',
+  },
+  pendientesEmptyIcon: {
+    width: 44,
+    height: 44,
+    borderRadius: Theme.radius.full,
+    backgroundColor: Theme.colors.surface,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  pendientesEmptyTextos: {
+    flex: 1,
+    gap: Theme.spacing.xs,
+  },
+  pendientesEmptyTitulo: {
+    fontSize: Theme.typography.body,
+    fontWeight: '800',
+    color: Theme.colors.text,
+  },
+  pendientesEmptySubtitulo: {
+    fontSize: Theme.typography.label,
+    color: Theme.colors.textSecondary,
+    lineHeight: 20,
   },
 
   seccionTitulo: {


### PR DESCRIPTION
## Objetivo
Eliminar copy temporal visible en la pantalla de gastos comunes para que la vista final no muestre textos de prueba o explicaciones internas.

## Cambios principales
* Se eliminan los textos hardcodeados del resumen entre compañeros.
* Se retira la nota explicativa de compensación automática.
* Se elimina la descripción temporal del bloque de relación con el casero.
* Se añade un estado vacío específico cuando no hay pagos pendientes reales.

## UI / UX
* Se simplifica la jerarquía visual del resumen de gastos manteniendo los importes reales como foco.
* Se reutilizan tokens de `Theme.ts` para el estado vacío de pendientes.

## Changelog
* `docs/changelog/Epica15/epica-15-issue-237-eliminar-datos-prueba-gastos.md`

## Testing
* `npx tsc --noEmit` en frontend.
* `npm run lint` en frontend, con warnings preexistentes en archivos no relacionados.