### PR TITLE
Update visual hierarchy for common expenses

### DIFF
--- a/docs/changelog/Epica15/epica-15-issue-238-copy-gastos-comunes.md
+++ b/docs/changelog/Epica15/epica-15-issue-238-copy-gastos-comunes.md
@@ -1,0 +1,14 @@
+# Issue #238 - Copy y jerarquia visual de gastos comunes
+
+**Epica:** 15 - Pulido de casero en vivienda y gastos comunes
+
+## Cambios
+
+- Se revisa el copy principal de la pantalla de gastos comunes para separar el balance entre companeros de los pendientes con el casero.
+- Se anade un encabezado visual para el bloque entre companeros y una descripcion en el bloque de relacion con el casero.
+- Se incorporan subtitulos en las secciones de pendientes para aclarar el origen de cada deuda.
+- Se aumenta el espacio inferior del scroll y se eleva el FAB para que no tape datos ni acciones al final de la lista.
+
+## Verificacion
+
+- `npm run lint` en `frontend` ejecutado correctamente. Mantiene warnings preexistentes en otras pantallas.

--- a/frontend/app/inquilino/(tabs)/gastos.tsx
+++ b/frontend/app/inquilino/(tabs)/gastos.tsx
@@ -406,13 +406,25 @@ export default function GastosInquilinoTab() {
       <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
         <View style={styles.header}>
           <Text style={styles.headerEtiqueta}>Gastos comunes</Text>
-          <Text style={styles.headerTitulo}>Balance del piso</Text>
+          <Text style={styles.headerTitulo}>Gastos del piso</Text>
           <Text style={styles.headerSubtitulo}>
-            Divide los gastos de forma justa y transparente.
+            Separa lo que os debéis entre compañeros de cualquier pendiente con el casero.
           </Text>
         </View>
 
         <View style={styles.heroCard}>
+          <View style={styles.heroHeader}>
+            <View style={styles.heroIconBox}>
+              <Ionicons name="people-outline" size={18} color={Theme.colors.primary} />
+            </View>
+            <View style={styles.heroHeaderTextos}>
+              <Text style={styles.heroTitulo}>Entre compañeros</Text>
+              <Text style={styles.heroSubtitulo}>
+                Solo recoge gastos compartidos por quienes viven en el piso.
+              </Text>
+            </View>
+          </View>
+
           <View style={styles.heroResumenGrid}>
             <View
               style={[
@@ -424,12 +436,14 @@ export default function GastosInquilinoTab() {
               ]}
             >
               <View style={[styles.heroResumenBadge, { backgroundColor: Theme.colors.dangerLight }]}>
-                <Text style={[styles.heroResumenBadgeText, { color: Theme.colors.danger }]}>Debes</Text>
+                <Text style={[styles.heroResumenBadgeText, { color: Theme.colors.danger }]}>
+                  Tú debes
+                </Text>
               </View>
               <Text style={[styles.heroResumenImporte, { color: Theme.colors.danger }]}>
                 {formatImporte(totalDeboCompaneros)}
               </Text>
-              <Text style={styles.heroResumenTexto}>Pendiente con compañeros</Text>
+              <Text style={styles.heroResumenTexto}>A compañeros por gastos comunes</Text>
             </View>
 
             <View
@@ -449,7 +463,7 @@ export default function GastosInquilinoTab() {
               <Text style={[styles.heroResumenImporte, { color: Theme.colors.success }]}>
                 {formatImporte(totalMeDebenCompaneros)}
               </Text>
-              <Text style={styles.heroResumenTexto}>Pendiente de cobrar</Text>
+              <Text style={styles.heroResumenTexto}>Compañeros pendientes contigo</Text>
             </View>
           </View>
 
@@ -463,6 +477,9 @@ export default function GastosInquilinoTab() {
               </View>
               <View style={styles.caseroHeaderTextos}>
                 <Text style={styles.caseroTitulo}>Relación con el casero</Text>
+                <Text style={styles.caseroSubtitulo}>
+                  Pagos asociados al propietario, separados del balance entre compañeros.
+                </Text>
               </View>
             </View>
 
@@ -503,7 +520,12 @@ export default function GastosInquilinoTab() {
 
         {deudasPendientesCompaneros.length > 0 && (
           <>
-            <Text style={styles.seccionTitulo}>Pendientes con compañeros</Text>
+            <View style={styles.seccionHeader}>
+              <Text style={styles.seccionTitulo}>Pendientes entre compañeros</Text>
+              <Text style={styles.seccionSubtitulo}>
+                Deudas generadas por gastos comunes del piso.
+              </Text>
+            </View>
             {deudasPendientesCompaneros.map((deuda) => {
               const yoDebo = deuda.deudor_id === miId;
               const companero = yoDebo ? deuda.acreedor : deuda.deudor;
@@ -583,7 +605,12 @@ export default function GastosInquilinoTab() {
 
         {deudasPendientesCasero.length > 0 && (
           <>
-            <Text style={styles.seccionTitulo}>Pendientes con casero</Text>
+            <View style={[styles.seccionHeader, styles.seccionHeaderCasero]}>
+              <Text style={styles.seccionTitulo}>Pendientes con el casero</Text>
+              <Text style={styles.seccionSubtitulo}>
+                Importes que no forman parte del reparto entre compañeros.
+              </Text>
+            </View>
             {deudasPendientesCasero.map((deuda) => {
               const yoDebo = deuda.deudor_id === miId;
               const contraparte = yoDebo ? deuda.acreedor : deuda.deudor;
@@ -661,7 +688,9 @@ export default function GastosInquilinoTab() {
 
         {deudasPagadasConJustificante.length > 0 && (
           <>
-            <Text style={styles.seccionTitulo}>Pagadas con justificante</Text>
+            <Text style={[styles.seccionTitulo, styles.seccionTituloSolo]}>
+              Pagadas con justificante
+            </Text>
             {deudasPagadasConJustificante.map((deuda) => {
               const yoPague = deuda.deudor_id === miId;
               const companero = yoPague ? deuda.acreedor : deuda.deudor;
@@ -735,7 +764,7 @@ export default function GastosInquilinoTab() {
           </View>
         ) : (
           <>
-            <Text style={styles.seccionTitulo}>Movimientos</Text>
+            <Text style={[styles.seccionTitulo, styles.seccionTituloSolo]}>Movimientos</Text>
             {gastos.map((gasto) => (
               <View key={gasto.id} style={styles.gastoCard}>
                 <AvatarInitials nombre={gasto.pagador.nombre} apellidos={gasto.pagador.apellidos} size={46} />
@@ -894,7 +923,7 @@ export default function GastosInquilinoTab() {
                     backgroundColor: Theme.colors.primaryLight,
                   },
                 ]}
-                placeholder="Ej. Papel higienico, gas, pizza..."
+                placeholder="Ej. Papel higiénico, gas, pizza..."
                 placeholderTextColor={Theme.colors.textMuted}
                 value={concepto}
                 onChangeText={setConcepto}

--- a/frontend/styles/inquilino/gastos.styles.ts
+++ b/frontend/styles/inquilino/gastos.styles.ts
@@ -6,7 +6,7 @@ export const styles = StyleSheet.create({
   content: {
     paddingHorizontal: Theme.spacing.lg,
     paddingTop: Theme.spacing.lg,
-    paddingBottom: 100,
+    paddingBottom: 180,
   },
 
   header: {
@@ -43,6 +43,35 @@ export const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: Theme.colors.border,
     ...Theme.shadows.sm,
+  },
+  heroHeader: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: Theme.spacing.base,
+    marginBottom: Theme.spacing.lg,
+  },
+  heroIconBox: {
+    width: 44,
+    height: 44,
+    borderRadius: Theme.radius.lg,
+    backgroundColor: Theme.colors.primaryLight,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  heroHeaderTextos: {
+    flex: 1,
+    gap: Theme.spacing.xs,
+  },
+  heroTitulo: {
+    fontSize: Theme.typography.subtitle,
+    fontWeight: '800',
+    color: Theme.colors.text,
+    letterSpacing: -0.2,
+  },
+  heroSubtitulo: {
+    fontSize: Theme.typography.label,
+    color: Theme.colors.textSecondary,
+    lineHeight: 20,
   },
   heroImporte: {
     fontSize: Theme.typography.hero,
@@ -118,6 +147,11 @@ export const styles = StyleSheet.create({
     color: Theme.colors.text,
     letterSpacing: -0.2,
   },
+  caseroSubtitulo: {
+    fontSize: Theme.typography.label,
+    color: Theme.colors.textSecondary,
+    lineHeight: 20,
+  },
   caseroResumenGrid: {
     flexDirection: 'row',
     gap: Theme.spacing.md,
@@ -173,11 +207,25 @@ export const styles = StyleSheet.create({
     lineHeight: 20,
   },
 
+  seccionHeader: {
+    marginBottom: Theme.spacing.md,
+    gap: Theme.spacing.xs,
+  },
+  seccionHeaderCasero: {
+    marginTop: Theme.spacing.sm,
+  },
   seccionTitulo: {
     fontSize: Theme.typography.subtitle,
     fontWeight: '700',
     color: Theme.colors.text,
+  },
+  seccionTituloSolo: {
     marginBottom: Theme.spacing.md,
+  },
+  seccionSubtitulo: {
+    fontSize: Theme.typography.label,
+    color: Theme.colors.textSecondary,
+    lineHeight: 20,
   },
 
   deudaCard: {
@@ -646,7 +694,7 @@ export const styles = StyleSheet.create({
 
   fab: {
     position: 'absolute',
-    bottom: Theme.spacing.xl,
+    bottom: 92,
     right: Theme.spacing.lg,
     width: 58,
     height: 58,


### PR DESCRIPTION
## Summary
- Clarifies copy on the tenant common expenses screen to separate roommate balances from landlord-related pending payments.
- Adds section context for roommate debts and landlord debts.
- Adjusts bottom spacing and FAB position so final list content remains accessible above navigation.
- Adds changelog entry: `docs/changelog/Epica15/epica-15-issue-238-copy-gastos-comunes.md`.

## Testing
- `npm run lint` in `frontend`