### PR TITLE
Add auditoría multi-tenant de permisos y datos

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "nodemon --exec ts-node src/index.ts",
+    "test": "node --test -r ts-node/register test/multitenant-security.test.ts",
     "build": "npx prisma generate && tsc",
     "start": "npx prisma db push --accept-data-loss && node dist/index.js"
   },

--- a/backend/src/controllers/anuncio.controller.ts
+++ b/backend/src/controllers/anuncio.controller.ts
@@ -118,7 +118,8 @@ export const eliminarAnuncio: express.RequestHandler = async (req, res) => {
     return;
   }
 
-  const esAutor = anuncio.autor_id === usuarioId;
+  const tieneAcceso = await verificarAccesoVivienda(usuarioId, req.usuario!.rol, anuncio.vivienda_id);
+  const esAutor = anuncio.autor_id === usuarioId && tieneAcceso;
   const esCasero = anuncio.vivienda.casero_id === usuarioId;
 
   if (!esAutor && !esCasero) {

--- a/backend/src/controllers/inquilino.controller.ts
+++ b/backend/src/controllers/inquilino.controller.ts
@@ -4,12 +4,15 @@ import { RolUsuario } from '../generated/prisma/client';
 import { generarCodigoInvitacion } from '../utils/generarCodigo';
 import { enviarNotificacionPush } from '../services/notification.service';
 
-const serializarHabitacionParaInquilino = <T extends { precio: number | null; inquilino_id?: number | null }>(
+const serializarHabitacionParaInquilino = <
+  T extends { precio: number | null; codigo_invitacion: string | null; inquilino_id?: number | null },
+>(
   habitacion: T,
   usuarioId: number,
-): T => ({
+): Omit<T, 'precio' | 'codigo_invitacion'> & { precio: number | null; codigo_invitacion: null } => ({
   ...habitacion,
   precio: habitacion.inquilino_id === usuarioId ? habitacion.precio : null,
+  codigo_invitacion: null,
 });
 
 export const obtenerPerfilInquilino: express.RequestHandler = async (req, res) => {
@@ -124,7 +127,7 @@ export const unirseHabitacion: express.RequestHandler = async (req, res) => {
 
   res.status(200).json({
     mensaje: 'Te has unido a la habitación correctamente.',
-    habitacion: habitacionActualizada,
+    habitacion: serializarHabitacionParaInquilino(habitacionActualizada, req.usuario!.id),
   });
 
   // Notify casero async (fire-and-forget)

--- a/backend/src/middlewares/module.guard.ts
+++ b/backend/src/middlewares/module.guard.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import { prisma } from '../lib/prisma';
+import { RolUsuario } from '../generated/prisma/client';
 
 type ModuloVivienda = 'limpieza' | 'gastos' | 'inventario';
 type CampoModulo = 'mod_limpieza' | 'mod_gastos' | 'mod_inventario';
@@ -33,14 +34,25 @@ export const protegerModuloVivienda = (
     return;
   }
 
+  const usuario = req.usuario;
+  if (!usuario) {
+    res.status(401).json({ error: 'Token no proporcionado.' });
+    return;
+  }
+
   const campo = CAMPO_MODULO[modulo];
-  const vivienda = await prisma.vivienda.findUnique({
-    where: { id: viviendaId },
+  const vivienda = await prisma.vivienda.findFirst({
+    where: {
+      id: viviendaId,
+      ...(usuario.rol === RolUsuario.CASERO
+        ? { casero_id: usuario.id }
+        : { habitaciones: { some: { inquilino_id: usuario.id } } }),
+    },
     select: { [campo]: true },
   });
 
   if (!vivienda) {
-    res.status(404).json({ error: 'Vivienda no encontrada.' });
+    res.status(403).json({ error: 'No tienes acceso a esta vivienda.' });
     return;
   }
 

--- a/backend/test/multitenant-security.test.ts
+++ b/backend/test/multitenant-security.test.ts
@@ -1,0 +1,313 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type express from 'express';
+
+type UsuarioTest = { id: number; rol: 'CASERO' | 'INQUILINO' };
+type Handler = express.RequestHandler;
+
+const prisma = {
+  vivienda: {
+    findUnique: async (_args: unknown): Promise<unknown> => unexpectedPrismaCall('vivienda.findUnique'),
+    findFirst: async (_args: unknown): Promise<unknown> => unexpectedPrismaCall('vivienda.findFirst'),
+  },
+  habitacion: {
+    findUnique: async (_args: unknown): Promise<unknown> => unexpectedPrismaCall('habitacion.findUnique'),
+    findFirst: async (_args: unknown): Promise<unknown> => unexpectedPrismaCall('habitacion.findFirst'),
+    update: async (_args: unknown): Promise<unknown> => unexpectedPrismaCall('habitacion.update'),
+  },
+  incidencia: {
+    findUnique: async (_args: unknown): Promise<unknown> => unexpectedPrismaCall('incidencia.findUnique'),
+    create: async (_args: unknown): Promise<unknown> => unexpectedPrismaCall('incidencia.create'),
+  },
+  anuncio: {
+    findUnique: async (_args: unknown): Promise<unknown> => unexpectedPrismaCall('anuncio.findUnique'),
+    delete: async (_args: unknown): Promise<unknown> => unexpectedPrismaCall('anuncio.delete'),
+  },
+};
+
+function unexpectedPrismaCall(method: string): never {
+  throw new Error(`Unexpected prisma call: ${method}`);
+}
+
+function mockModule(modulePath: string, exports: unknown) {
+  const resolved = require.resolve(modulePath);
+  require.cache[resolved] = {
+    id: resolved,
+    filename: resolved,
+    loaded: true,
+    exports,
+    children: [],
+    paths: [],
+  } as unknown as NodeJS.Module;
+}
+
+mockModule('../src/lib/prisma', { prisma });
+mockModule('../src/services/notification.service', {
+  enviarNotificacionPush: async () => undefined,
+});
+
+const { obtenerVivienda, editarHabitacion } = require('../src/controllers/vivienda.controller') as {
+  obtenerVivienda: Handler;
+  editarHabitacion: Handler;
+};
+const { obtenerMiVivienda, unirseHabitacion } = require('../src/controllers/inquilino.controller') as {
+  obtenerMiVivienda: Handler;
+  unirseHabitacion: Handler;
+};
+const { crearIncidencia } = require('../src/controllers/incidencia.controller') as {
+  crearIncidencia: Handler;
+};
+const { eliminarAnuncio } = require('../src/controllers/anuncio.controller') as {
+  eliminarAnuncio: Handler;
+};
+const { protegerModuloVivienda } = require('../src/middlewares/module.guard') as {
+  protegerModuloVivienda: (modulo: 'limpieza' | 'gastos' | 'inventario') => Handler;
+};
+
+function resetPrisma() {
+  prisma.vivienda.findUnique = async (_args: unknown): Promise<unknown> => unexpectedPrismaCall('vivienda.findUnique');
+  prisma.vivienda.findFirst = async (_args: unknown): Promise<unknown> => unexpectedPrismaCall('vivienda.findFirst');
+  prisma.habitacion.findUnique = async (_args: unknown): Promise<unknown> => unexpectedPrismaCall('habitacion.findUnique');
+  prisma.habitacion.findFirst = async (_args: unknown): Promise<unknown> => unexpectedPrismaCall('habitacion.findFirst');
+  prisma.habitacion.update = async (_args: unknown): Promise<unknown> => unexpectedPrismaCall('habitacion.update');
+  prisma.incidencia.findUnique = async (_args: unknown): Promise<unknown> => unexpectedPrismaCall('incidencia.findUnique');
+  prisma.incidencia.create = async (_args: unknown): Promise<unknown> => unexpectedPrismaCall('incidencia.create');
+  prisma.anuncio.findUnique = async (_args: unknown): Promise<unknown> => unexpectedPrismaCall('anuncio.findUnique');
+  prisma.anuncio.delete = async (_args: unknown): Promise<unknown> => unexpectedPrismaCall('anuncio.delete');
+}
+
+function request({
+  usuario,
+  params = {},
+  body = {},
+  query = {},
+}: {
+  usuario: UsuarioTest;
+  params?: Record<string, string>;
+  body?: Record<string, unknown>;
+  query?: Record<string, unknown>;
+}) {
+  return {
+    usuario,
+    params,
+    body,
+    query,
+  } as unknown as express.Request;
+}
+
+function response() {
+  const res = {
+    statusCode: 200,
+    body: undefined as unknown,
+    sent: false,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+    send(payload?: unknown) {
+      this.sent = true;
+      this.body = payload;
+      return this;
+    },
+  };
+  return res as unknown as express.Response & typeof res;
+}
+
+async function invoke(handler: Handler, req: express.Request) {
+  const res = response();
+  await handler(req, res, () => undefined);
+  return res;
+}
+
+test('casero no puede obtener una vivienda ajena', async () => {
+  resetPrisma();
+  prisma.vivienda.findUnique = async () => ({
+    id: 1,
+    casero_id: 99,
+    habitaciones: [],
+  });
+
+  const res = await invoke(
+    obtenerVivienda,
+    request({ usuario: { id: 10, rol: 'CASERO' }, params: { id: '1' } }),
+  );
+
+  assert.equal(res.statusCode, 404);
+});
+
+test('inquilino no puede editar habitaciones de una vivienda de casero', async () => {
+  resetPrisma();
+  prisma.vivienda.findUnique = async () => ({
+    id: 1,
+    casero_id: 99,
+  });
+
+  const res = await invoke(
+    editarHabitacion,
+    request({
+      usuario: { id: 20, rol: 'INQUILINO' },
+      params: { id: '1', habId: '2' },
+      body: { nombre: 'Dormitorio' },
+    }),
+  );
+
+  assert.equal(res.statusCode, 403);
+});
+
+test('inquilino no ve precios privados ajenos ni codigos de invitacion', async () => {
+  resetPrisma();
+  prisma.habitacion.findFirst = async () => ({
+    id: 1,
+    vivienda_id: 10,
+    inquilino_id: 20,
+    precio: 500,
+    codigo_invitacion: 'ROOM-OWN',
+    vivienda: {
+      id: 10,
+      habitaciones: [
+        { id: 1, inquilino_id: 20, precio: 500, codigo_invitacion: 'ROOM-OWN' },
+        { id: 2, inquilino_id: 21, precio: 650, codigo_invitacion: 'ROOM-OTHER' },
+      ],
+    },
+  });
+
+  const res = await invoke(
+    obtenerMiVivienda,
+    request({ usuario: { id: 20, rol: 'INQUILINO' } }),
+  );
+
+  assert.equal(res.statusCode, 200);
+  const body = res.body as {
+    vivienda: { habitaciones: Array<{ precio: number | null; codigo_invitacion: string | null }> };
+  };
+  assert.deepEqual(
+    body.vivienda.habitaciones.map((habitacion) => habitacion.precio),
+    [500, null],
+  );
+  assert.deepEqual(
+    body.vivienda.habitaciones.map((habitacion) => habitacion.codigo_invitacion),
+    [null, null],
+  );
+});
+
+test('unirse a habitacion quema el codigo usado y no devuelve el nuevo codigo', async () => {
+  resetPrisma();
+  let codigoRotado: string | null = null;
+
+  prisma.habitacion.findUnique = async (args: unknown) => {
+    const codigo = (args as { where: { codigo_invitacion: string } }).where.codigo_invitacion;
+    if (codigo === 'ROOM-OLD') {
+      return {
+        id: 1,
+        vivienda_id: 10,
+        inquilino_id: null,
+        precio: 500,
+        codigo_invitacion: 'ROOM-OLD',
+      };
+    }
+
+    return null;
+  };
+  prisma.habitacion.update = async (args: unknown) => {
+    const data = (args as { data: { inquilino_id: number; codigo_invitacion: string } }).data;
+    codigoRotado = data.codigo_invitacion;
+    return {
+      id: 1,
+      vivienda_id: 10,
+      inquilino_id: data.inquilino_id,
+      precio: 500,
+      codigo_invitacion: data.codigo_invitacion,
+      vivienda: { id: 10, casero_id: 2 },
+      inquilino: { nombre: 'Ada', apellidos: 'Lovelace' },
+    };
+  };
+
+  const res = await invoke(
+    unirseHabitacion,
+    request({
+      usuario: { id: 20, rol: 'INQUILINO' },
+      body: { codigo_invitacion: 'ROOM-OLD' },
+    }),
+  );
+
+  assert.equal(res.statusCode, 200);
+  assert.match(codigoRotado ?? '', /^ROOM-[A-Z0-9]{6}$/);
+  assert.notEqual(codigoRotado, 'ROOM-OLD');
+  assert.equal((res.body as { habitacion: { codigo_invitacion: string | null } }).habitacion.codigo_invitacion, null);
+});
+
+test('inquilino no puede crear incidencia en dormitorio ajeno', async () => {
+  resetPrisma();
+  let findFirstCalls = 0;
+  prisma.habitacion.findFirst = async () => {
+    findFirstCalls += 1;
+    if (findFirstCalls === 1) {
+      return { id: 1, vivienda_id: 10, inquilino_id: 20 };
+    }
+
+    return { id: 2, vivienda_id: 10, tipo: 'DORMITORIO', inquilino_id: 21 };
+  };
+
+  const res = await invoke(
+    crearIncidencia,
+    request({
+      usuario: { id: 20, rol: 'INQUILINO' },
+      body: {
+        titulo: 'Persiana rota',
+        descripcion: 'No sube',
+        habitacion_id: 2,
+      },
+    }),
+  );
+
+  assert.equal(res.statusCode, 403);
+});
+
+test('module guard valida pertenencia antes de revelar el estado del modulo', async () => {
+  resetPrisma();
+  let whereRecibido: unknown;
+  prisma.vivienda.findFirst = async (args: unknown) => {
+    whereRecibido = (args as { where: unknown }).where;
+    return null;
+  };
+
+  const middleware = protegerModuloVivienda('gastos');
+  let nextCalled = false;
+  const res = response();
+  await middleware(
+    request({ usuario: { id: 20, rol: 'INQUILINO' }, params: { viviendaId: '10' } }),
+    res,
+    () => {
+      nextCalled = true;
+    },
+  );
+
+  assert.equal(res.statusCode, 403);
+  assert.equal(nextCalled, false);
+  assert.deepEqual(whereRecibido, {
+    id: 10,
+    habitaciones: { some: { inquilino_id: 20 } },
+  });
+});
+
+test('autor que ya no pertenece a la vivienda no puede eliminar un anuncio antiguo', async () => {
+  resetPrisma();
+  prisma.anuncio.findUnique = async () => ({
+    id: 1,
+    vivienda_id: 10,
+    autor_id: 20,
+    vivienda: { casero_id: 99 },
+  });
+  prisma.habitacion.findFirst = async () => null;
+
+  const res = await invoke(
+    eliminarAnuncio,
+    request({ usuario: { id: 20, rol: 'INQUILINO' }, params: { id: '1' } }),
+  );
+
+  assert.equal(res.statusCode, 403);
+});

--- a/docs/changelog/Epica16/epica-16-issue-248-auditoria-multitenant.md
+++ b/docs/changelog/Epica16/epica-16-issue-248-auditoria-multitenant.md
@@ -1,0 +1,14 @@
+# Epica 16 - Issue 248 - Auditoria multi-tenant y proteccion de datos
+
+## Objetivo
+Cerrar fugas de datos entre viviendas y dejar tests negativos de regresion para los endpoints sensibles de viviendas, habitaciones, incidencias, anuncios, codigos de invitacion y guardas de modulos.
+
+## Cambios
+- Los inquilinos ya no reciben `codigo_invitacion` en `GET /api/inquilino/vivienda` ni en la respuesta de `POST /api/inquilino/unirse`.
+- `protegerModuloVivienda()` valida pertenencia antes de devolver si un modulo esta activo o desactivado, evitando revelar estado de viviendas ajenas.
+- El borrado de anuncios exige que el autor siga perteneciendo a la vivienda, o que el usuario sea el casero propietario.
+- Se anade `npm test` en backend con una suite de regresion multi-tenant basada en `node --test` y `ts-node`, sin dependencias nuevas.
+
+## Verificacion
+- `npm test` en `backend`.
+- `npm run build` en `backend`.


### PR DESCRIPTION
## Objetivo
Garantizar que caseros e inquilinos solo puedan consultar o modificar datos asociados a sus viviendas, reduciendo fugas entre tenants y cubriendo regresiones críticas de permisos.

## Cambios principales
* Refuerza la ocultación de `codigo_invitacion` y precio privado en respuestas de inquilino.
* Valida pertenencia en guardas de módulos antes de revelar si una vivienda tiene módulos activos.
* Endurece permisos de anuncios para impedir borrados por autores que ya no pertenecen a la vivienda.
* Añade suite backend de regresión multi-tenant para accesos cruzados, edición no autorizada, precio privado y burn-after-reading.

## Changelog
* `docs/changelog/Epica16/epica-16-issue-248-auditoria-multitenant.md`

## Testing
* `npm test` en `backend`.
* `npm run build` en `backend`.