### PR TITLE
[Épica 16] Update revisión de modelo, seed y consistencia

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -71,7 +71,7 @@ model Usuario {
   balance_limpieza   Float                    @default(0)
   estado_presencia   EstadoPresencia          @default(ACTIVO)
   viviendas          Vivienda[]
-  habitaciones       Habitacion[]
+  habitacion         Habitacion?
   incidencias        Incidencia[]
   anuncios           Anuncio[]
   turnos_limpieza    TurnoLimpieza[]
@@ -107,8 +107,8 @@ model Habitacion {
   id                Int              @id @default(autoincrement())
   vivienda_id       Int
   vivienda          Vivienda         @relation(fields: [vivienda_id], references: [id])
-  inquilino_id      Int?
-  inquilino         Usuario?         @relation(fields: [inquilino_id], references: [id])
+  inquilino_id      Int?             @unique
+  inquilino         Usuario?         @relation(fields: [inquilino_id], references: [id], onDelete: SetNull)
   nombre            String
   tipo              TipoHabitacion   @default(DORMITORIO)
   es_habitable      Boolean          @default(true)
@@ -126,7 +126,7 @@ model Incidencia {
   creador_id     Int
   creador        Usuario             @relation(fields: [creador_id], references: [id])
   habitacion_id  Int?
-  habitacion     Habitacion?         @relation(fields: [habitacion_id], references: [id])
+  habitacion     Habitacion?         @relation(fields: [habitacion_id], references: [id], onDelete: SetNull)
   titulo         String
   descripcion    String
   estado         EstadoIncidencia    @default(PENDIENTE)
@@ -175,7 +175,7 @@ model GastoRecurrente {
 model Deuda {
   id          Int         @id @default(autoincrement())
   gasto_id    Int
-  gasto       Gasto       @relation(fields: [gasto_id], references: [id])
+  gasto       Gasto       @relation(fields: [gasto_id], references: [id], onDelete: Cascade)
   deudor_id   Int
   deudor      Usuario     @relation("DeudorDeuda", fields: [deudor_id], references: [id])
   acreedor_id Int
@@ -183,6 +183,8 @@ model Deuda {
   importe     Float
   estado      EstadoDeuda @default(PENDIENTE)
   justificante_url String?
+
+  @@unique([gasto_id, deudor_id])
 }
 
 model ItemInventario {
@@ -203,7 +205,7 @@ model FotoAsset {
   id           Int            @id @default(autoincrement())
   url          String
   item_id      Int
-  item         ItemInventario @relation(fields: [item_id], references: [id])
+  item         ItemInventario @relation(fields: [item_id], references: [id], onDelete: Cascade)
   fecha_subida DateTime       @default(now())
 }
 
@@ -225,7 +227,7 @@ model ZonaLimpieza {
 model AsignacionLimpiezaFija {
   id         Int          @id @default(autoincrement())
   zona_id    Int
-  zona       ZonaLimpieza @relation(fields: [zona_id], references: [id])
+  zona       ZonaLimpieza @relation(fields: [zona_id], references: [id], onDelete: Cascade)
   usuario_id Int
   usuario    Usuario      @relation(fields: [usuario_id], references: [id])
 
@@ -238,7 +240,7 @@ model TurnoLimpieza {
   usuario_id   Int
   usuario      Usuario      @relation(fields: [usuario_id], references: [id])
   zona_id      Int
-  zona         ZonaLimpieza @relation(fields: [zona_id], references: [id])
+  zona         ZonaLimpieza @relation(fields: [zona_id], references: [id], onDelete: Cascade)
   fecha_inicio DateTime
   fecha_fin    DateTime
   estado       EstadoTurno  @default(PENDIENTE)

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -6,6 +6,11 @@ import 'dotenv/config';
 const adapter = new PrismaPg({ connectionString: process.env['DATABASE_URL']! });
 const prisma = new PrismaClient({ adapter });
 
+const LOCAL_CASERO_PASSWORD = 'casero123';
+const LOCAL_INQUILINO_PASSWORD = 'inquilino123';
+const DEMO_EMAIL_DOMAIN = 'example.test';
+const FORCE_DEMO_SEED = process.env['ROOMIES_ALLOW_PRODUCTION_SEED'] === 'true';
+
 type ParticipanteDeuda = {
   deudorId: number;
   importe: number;
@@ -22,6 +27,17 @@ const dayOfMonth = (day: number, monthsAgo = 0) => {
   const date = startOfMonth(monthsAgo);
   date.setDate(day);
   return date;
+};
+
+const assertSeedSeguro = () => {
+  const entorno = process.env['NODE_ENV'];
+  const railwayEnvironment = process.env['RAILWAY_ENVIRONMENT'];
+
+  if (!FORCE_DEMO_SEED && (entorno === 'production' || railwayEnvironment)) {
+    throw new Error(
+      'Seed demo bloqueado fuera de entorno local. Define ROOMIES_ALLOW_PRODUCTION_SEED=true solo para cargas controladas.',
+    );
+  }
 };
 
 async function crearGastoConDeudas({
@@ -60,17 +76,23 @@ async function crearGastoConDeudas({
 }
 
 async function main() {
+  assertSeedSeguro();
+
   const hash = (pw: string) => bcrypt.hash(pw, 10);
 
   const casero = await prisma.usuario.upsert({
-    where: { email: 'casero@test.com' },
-    update: {},
+    where: { documento_identidad: '11111111A' },
+    update: {
+      email: `casero@${DEMO_EMAIL_DOMAIN}`,
+      telefono: '600111111',
+      rol: RolUsuario.CASERO,
+    },
     create: {
       nombre: 'Carlos',
       apellidos: 'Garcia Lopez',
       documento_identidad: '11111111A',
-      email: 'casero@test.com',
-      password_hash: await hash('casero123'),
+      email: `casero@${DEMO_EMAIL_DOMAIN}`,
+      password_hash: await hash(LOCAL_CASERO_PASSWORD),
       telefono: '600111111',
       rol: RolUsuario.CASERO,
     },
@@ -81,45 +103,49 @@ async function main() {
       nombre: 'Ana',
       apellidos: 'Martinez Ruiz',
       documento_identidad: '22222222B',
-      email: 'ana@test.com',
+      email: `ana@${DEMO_EMAIL_DOMAIN}`,
       tel: '600222222',
     },
     {
       nombre: 'Bruno',
       apellidos: 'Sanchez Vega',
       documento_identidad: '33333333C',
-      email: 'bruno@test.com',
+      email: `bruno@${DEMO_EMAIL_DOMAIN}`,
       tel: '600333333',
     },
     {
       nombre: 'Carmen',
       apellidos: 'Lopez Fuentes',
       documento_identidad: '44444444D',
-      email: 'carmen@test.com',
+      email: `carmen@${DEMO_EMAIL_DOMAIN}`,
       tel: '600444444',
     },
     {
       nombre: 'Diego',
       apellidos: 'Romero Iglesias',
       documento_identidad: '55555555E',
-      email: 'diego@test.com',
+      email: `diego@${DEMO_EMAIL_DOMAIN}`,
       tel: '600555555',
     },
     {
       nombre: 'Elena',
       apellidos: 'Fernandez Castro',
       documento_identidad: '66666666F',
-      email: 'elena@test.com',
+      email: `elena@${DEMO_EMAIL_DOMAIN}`,
       tel: '600666666',
     },
   ];
 
-  const pw = await hash('inquilino123');
+  const pw = await hash(LOCAL_INQUILINO_PASSWORD);
   const inquilinos = await Promise.all(
     inquilinosData.map((inquilino) =>
       prisma.usuario.upsert({
-        where: { email: inquilino.email },
-        update: {},
+        where: { documento_identidad: inquilino.documento_identidad },
+        update: {
+          email: inquilino.email,
+          telefono: inquilino.tel,
+          rol: RolUsuario.INQUILINO,
+        },
         create: {
           nombre: inquilino.nombre,
           apellidos: inquilino.apellidos,
@@ -360,14 +386,14 @@ async function main() {
 ✅ Seed completado - Casa Testing (id: ${vivienda.id})
 
   Casero:
-    casero@test.com / casero123
+    casero@${DEMO_EMAIL_DOMAIN} / ${LOCAL_CASERO_PASSWORD}
 
-  Inquilinos (password: inquilino123):
-    ana@test.com    -> Habitacion 1
-    bruno@test.com  -> Habitacion 2
-    carmen@test.com -> Habitacion 3
-    diego@test.com  -> Habitacion 4
-    elena@test.com  -> Habitacion 5
+  Inquilinos (password: ${LOCAL_INQUILINO_PASSWORD}):
+    ana@${DEMO_EMAIL_DOMAIN}    -> Habitacion 1
+    bruno@${DEMO_EMAIL_DOMAIN}  -> Habitacion 2
+    carmen@${DEMO_EMAIL_DOMAIN} -> Habitacion 3
+    diego@${DEMO_EMAIL_DOMAIN}  -> Habitacion 4
+    elena@${DEMO_EMAIL_DOMAIN}  -> Habitacion 5
 
   Datos de prueba creados:
     - 5 gastos con deudas pendientes y pagadas

--- a/backend/src/controllers/limpieza.controller.ts
+++ b/backend/src/controllers/limpieza.controller.ts
@@ -159,7 +159,7 @@ export const eliminarZona: express.RequestHandler = async (req, res) => {
     return;
   }
 
-  // Eliminar registros dependientes antes de borrar la zona (sin cascade en schema).
+  // Mantiene compatibilidad con bases previas aunque el schema ya define cascada.
   await prisma.$transaction([
     prisma.turnoLimpieza.deleteMany({ where: { zona_id: zonaId } }),
     prisma.asignacionLimpiezaFija.deleteMany({ where: { zona_id: zonaId } }),

--- a/backend/tests/schema-consistency.test.ts
+++ b/backend/tests/schema-consistency.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, test } from 'vitest';
+
+const repoRoot = path.resolve(process.cwd(), '..');
+
+const readRepoFile = (relativePath: string) =>
+  readFileSync(path.join(repoRoot, relativePath), 'utf8');
+
+const schema = readRepoFile('backend/prisma/schema.prisma');
+
+describe('consistencia del modelo Prisma', () => {
+  test('no deja mojibake en schema, seed ni docs backend revisadas', () => {
+    const files = [
+      'backend/prisma/schema.prisma',
+      'backend/prisma/seed.ts',
+      'docs/backend/api.md',
+      'docs/backend/setup.md',
+    ];
+    const mojibakePattern = /Ã|Â|â[^\s]?|�/;
+
+    for (const file of files) {
+      assert.equal(mojibakePattern.test(readRepoFile(file)), false, `${file} contiene mojibake`);
+    }
+  });
+
+  test('limita un inquilino a una unica habitacion asignada', () => {
+    assert.match(schema, /inquilino_id\s+Int\?\s+@unique/);
+    assert.match(
+      schema,
+      /inquilino\s+Usuario\?\s+@relation\(fields: \[inquilino_id\], references: \[id\], onDelete: SetNull\)/,
+    );
+  });
+
+  test('evita duplicar deudas por gasto y deudor', () => {
+    assert.match(schema, /@@unique\(\[gasto_id, deudor_id\]\)/);
+  });
+
+  test('declara cascadas solo para registros dependientes directos', () => {
+    assert.match(schema, /gasto\s+Gasto\s+@relation\(fields: \[gasto_id\], references: \[id\], onDelete: Cascade\)/);
+    assert.match(
+      schema,
+      /item\s+ItemInventario\s+@relation\(fields: \[item_id\], references: \[id\], onDelete: Cascade\)/,
+    );
+    assert.match(
+      schema,
+      /zona\s+ZonaLimpieza\s+@relation\(fields: \[zona_id\], references: \[id\], onDelete: Cascade\)/,
+    );
+  });
+});

--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -1523,36 +1523,36 @@ Lista todos los items de inventario de una vivienda, incluyendo habitación asoc
 
 Sube una foto de inventario a Cloudinary y crea un `FotoAsset` vinculado al item.
 
-**Auth requerida:** SÃ­ â€” `Authorization: Bearer <token>`
+**Auth requerida:** Sí — `Authorization: Bearer <token>`
 
 **Content-Type:** `multipart/form-data`
 
 **Params:**
 
-| Param | DescripciÃ³n |
+| Param | Descripción |
 |---|---|
 | `itemId` | ID del `ItemInventario` |
 
 **Body multipart:**
 
-| Campo | Tipo | Requerido | DescripciÃ³n |
+| Campo | Tipo | Requerido | Descripción |
 |---|---|---|---|
-| `foto` | file | SÃ­ | Imagen (`jpg`, `jpeg`, `png`, `webp`) |
+| `foto` | file | Sí | Imagen (`jpg`, `jpeg`, `png`, `webp`) |
 
 **Reglas de acceso:**
 
 - `CASERO`: debe ser propietario de la vivienda a la que pertenece el item.
-- `INQUILINO`: debe tener habitaciÃ³n asignada en la vivienda a la que pertenece el item.
+- `INQUILINO`: debe tener habitación asignada en la vivienda a la que pertenece el item.
 
 **Respuestas:**
 
-| CÃ³digo | DescripciÃ³n |
+| Código | Descripción |
 |---|---|
 | `201` | Foto subida y asset creado. |
-| `400` | `itemId` invÃ¡lido, falta imagen o el item no tiene vivienda resoluble. |
+| `400` | `itemId` inválido, falta imagen o el item no tiene vivienda resoluble. |
 | `403` | El usuario no tiene permiso sobre el item. |
 | `404` | Item de inventario no encontrado. |
-| `500` | Cloudinary no estÃ¡ configurado en el servidor o no se obtiene la URL subida. |
+| `500` | Cloudinary no está configurado en el servidor o no se obtiene la URL subida. |
 
 **Ejemplo respuesta 201:**
 ```json
@@ -1865,3 +1865,10 @@ Notas:
 
 - `POST /viviendas/:viviendaId/inventario` crea los items con `revisado_por_inquilino = false`
 - `GET /viviendas/:viviendaId/inventario` devuelve tambien este flag
+
+## Update 2026-04-11 - Consistencia de datos
+
+- Un usuario inquilino solo puede estar asignado a una `Habitacion` a la vez (`Habitacion.inquilino_id` unico cuando no es `null`).
+- Una `Deuda` queda acotada a una pareja `gasto_id` + `deudor_id`; el backend no debe crear dos deudas del mismo gasto para el mismo usuario.
+- Las deudas se eliminan en cascada al borrar su `Gasto`; las fotos de inventario al borrar su `ItemInventario`; y los turnos/asignaciones al borrar su `ZonaLimpieza`.
+- Los importes siguen saliendo como numeros (`Float`) por compatibilidad de API. La logica de negocio reparte y compara en centimos antes de persistir.

--- a/docs/backend/setup.md
+++ b/docs/backend/setup.md
@@ -160,6 +160,18 @@ npx expo start --clear
 | JWT 7 dias | Simplicidad MVP, sin refresh tokens por ahora |
 | `req.usuario` en Express.Request | Extension de tipos en `src/types/express/index.d.ts` |
 
+## Decisiones de consistencia de datos
+
+| Decision | Motivo |
+|---|---|
+| `Habitacion.inquilino_id` es unico cuando tiene valor | Un inquilino solo puede ocupar una habitacion activa. PostgreSQL permite multiples `NULL`, asi que las habitaciones vacias y zonas comunes no quedan bloqueadas. |
+| `Deuda` es unica por `gasto_id` y `deudor_id` | Evita que un mismo gasto genere dos deudas para el mismo deudor. |
+| `Deuda`, `FotoAsset`, `AsignacionLimpiezaFija` y `TurnoLimpieza` usan cascada desde su padre directo | Son registros dependientes sin sentido fuera del gasto, item o zona que los contiene. |
+| `Incidencia.habitacion` y `Habitacion.inquilino` usan `SetNull` al borrar la entidad relacionada | Conserva el historial operativo aunque se elimine una habitacion o un usuario deje de existir. |
+| Importes monetarios siguen como `Float` por compatibilidad MVP | La logica de reparto convierte a centimos antes de comparar o dividir. Migrar a `Decimal` o centimos enteros queda pendiente de migracion coordinada con frontend, API y datos existentes. |
+
+El seed de demo esta pensado para desarrollo local: usa emails `example.test`, contrasenas obvias documentadas y se bloquea en `NODE_ENV=production` o Railway salvo que se fuerce con `ROOMIES_ALLOW_PRODUCTION_SEED=true`.
+
 ## Update 2026-04-09 - Backend real
 
 - El backend actual usa `backend/Dockerfile` en Railway.

--- a/docs/changelog/Epica16/epica-16-issue-249-modelo-seed-consistencia.md
+++ b/docs/changelog/Epica16/epica-16-issue-249-modelo-seed-consistencia.md
@@ -1,0 +1,22 @@
+# Epica 16 - Issue 249 - Modelo Prisma, seed y consistencia de datos
+
+## Objetivo
+Revisar el modelo de datos, seed y documentacion backend para reducir incoherencias relacionales, evitar datos demo fuera de entorno local y dejar validaciones repetibles sobre el schema.
+
+## Cambios
+- `Habitacion.inquilino_id` pasa a ser unico cuando tiene valor, manteniendo habitaciones vacias y zonas comunes con `NULL`.
+- `Deuda` queda protegida con `@@unique([gasto_id, deudor_id])` y cascada desde `Gasto`.
+- `FotoAsset`, `AsignacionLimpiezaFija` y `TurnoLimpieza` se borran en cascada desde su padre directo.
+- `Incidencia.habitacion` y `Habitacion.inquilino` usan `SetNull` para conservar historico si se elimina la entidad relacionada.
+- El seed usa emails `example.test`, constantes para credenciales locales y bloqueo en produccion/Railway salvo override explicito.
+- Docs backend corrigen mojibake localizado y documentan constraints, cascadas y la decision de mantener `Float` por compatibilidad MVP.
+- Se anade un test estatico para detectar mojibake y validar relaciones criticas del schema.
+
+## Verificacion
+- `npx prisma validate --schema prisma/schema.prisma`
+- `npm test`
+- `npm run build`
+
+## Riesgos conocidos
+- La migracion a `Decimal` o centimos enteros queda aplazada porque requiere coordinar API, frontend y datos existentes.
+- Si una base existente contiene un mismo inquilino asignado a varias habitaciones o deudas duplicadas por gasto/deudor, habra que limpiar esos datos antes de aplicar el nuevo constraint.


### PR DESCRIPTION
## Objetivo
Reforzar la consistencia del backend revisando el modelo Prisma, el seed demo y la documentación técnica asociada a datos críticos.

## Cambios principales
* Añade constraints y relaciones seguras en Prisma para habitación ocupada, deudas duplicadas y borrados dependientes.
* Protege el seed demo para uso local, con emails `example.test` y bloqueo en producción/Railway salvo override explícito.
* Corrige mojibake localizado en documentación backend y documenta decisiones sobre cascadas, constraints e importes `Float`.
* Añade test estático para validar schema, mojibake y relaciones críticas.

## Changelog
* `docs/changelog/Epica16/epica-16-issue-249-modelo-seed-consistencia.md`

## Summary
* Refuerza integridad de datos en Prisma y seed.
* Documenta decisiones técnicas de consistencia y precisión monetaria.
* Añade cobertura de regresión para el schema.

## Testing
* `npx prisma validate --schema prisma/schema.prisma`
* `npm test`
* `npm run build`