### PR TITLE
Add [Épica 16] revisión de módulos operativos

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import cors from 'cors';
+import multer from 'multer';
 import authRoutes from './routes/auth.routes';
 import viviendaRoutes from './routes/vivienda.routes';
 import inquilinoRoutes from './routes/inquilino.routes';
@@ -33,5 +34,27 @@ app.use('/api', deudaRoutes);
 app.use('/api', inventarioRoutes);
 app.use('/api/usuarios', userRoutes);
 app.use('/api/users', userRoutes);
+
+const uploadErrorHandler: express.ErrorRequestHandler = (error, _req, res, next) => {
+  if (error instanceof multer.MulterError) {
+    const status = error.code === 'LIMIT_FILE_SIZE' ? 413 : 400;
+    res.status(status).json({
+      error:
+        error.code === 'LIMIT_FILE_SIZE'
+          ? 'El archivo supera el tamano maximo permitido.'
+          : error.message,
+    });
+    return;
+  }
+
+  if (error instanceof Error && error.message.startsWith('Solo se permiten')) {
+    res.status(400).json({ error: error.message });
+    return;
+  }
+
+  next(error);
+};
+
+app.use(uploadErrorHandler);
 
 export default app;

--- a/backend/tests/limpieza.service.test.ts
+++ b/backend/tests/limpieza.service.test.ts
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, test, vi } from 'vitest';
+
+const prisma = vi.hoisted(() => ({
+  turnoLimpieza: {
+    findFirst: async (_args: unknown): Promise<unknown> => {
+      throw new Error('Unexpected prisma call: turnoLimpieza.findFirst');
+    },
+    createMany: (_args: unknown): unknown => {
+      throw new Error('Unexpected prisma call: turnoLimpieza.createMany');
+    },
+  },
+  habitacion: {
+    findMany: async (_args: unknown): Promise<unknown> => {
+      throw new Error('Unexpected prisma call: habitacion.findMany');
+    },
+  },
+  zonaLimpieza: {
+    findMany: async (_args: unknown): Promise<unknown> => {
+      throw new Error('Unexpected prisma call: zonaLimpieza.findMany');
+    },
+  },
+  usuario: {
+    update: (_args: unknown): unknown => {
+      throw new Error('Unexpected prisma call: usuario.update');
+    },
+  },
+  $transaction: async (_args: unknown): Promise<unknown> => {
+    throw new Error('Unexpected prisma call: $transaction');
+  },
+}));
+
+vi.mock('../src/lib/prisma', () => ({ prisma }));
+
+const { generarTurnosSemanales } = await import('../src/services/limpieza.service');
+
+type TurnoCreateMany = {
+  data: Array<{
+    usuario_id: number;
+    zona_id: number;
+    fecha_inicio: Date;
+    fecha_fin: Date;
+    estado: string;
+  }>;
+};
+
+let createManyArgs: TurnoCreateMany | null = null;
+let usuarioUpdateCalls: unknown[] = [];
+let transactionArgs: unknown[] | null = null;
+
+function resetPrisma() {
+  createManyArgs = null;
+  usuarioUpdateCalls = [];
+  transactionArgs = null;
+
+  prisma.turnoLimpieza.findFirst = async () => null;
+  prisma.turnoLimpieza.createMany = (args: unknown) => {
+    createManyArgs = args as TurnoCreateMany;
+    return { operation: 'createMany', args };
+  };
+  prisma.habitacion.findMany = async () => [
+    { inquilino: { id: 1, balance_limpieza: 0 } },
+    { inquilino: { id: 2, balance_limpieza: 2 } },
+  ];
+  prisma.zonaLimpieza.findMany = async () => [
+    { id: 10, peso: 3, asignaciones_fijas: [] },
+    { id: 11, peso: 1, asignaciones_fijas: [] },
+  ];
+  prisma.usuario.update = (args: unknown) => {
+    usuarioUpdateCalls.push(args);
+    return { operation: 'usuario.update', args };
+  };
+  prisma.$transaction = async (args: unknown) => {
+    transactionArgs = args as unknown[];
+    return [];
+  };
+}
+
+beforeEach(() => {
+  resetPrisma();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-04-08T12:00:00.000Z'));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('generacion de turnos de limpieza', () => {
+  test('reparte zonas por carga efectiva y actualiza balances semanales', async () => {
+    await generarTurnosSemanales(10);
+
+    assert.deepEqual(
+      createManyArgs?.data.map((turno) => ({
+        usuario_id: turno.usuario_id,
+        zona_id: turno.zona_id,
+        estado: turno.estado,
+      })),
+      [
+        { usuario_id: 1, zona_id: 10, estado: 'PENDIENTE' },
+        { usuario_id: 2, zona_id: 11, estado: 'PENDIENTE' },
+      ],
+    );
+    assert.equal(createManyArgs?.data[0]?.fecha_inicio.toISOString(), '2026-04-05T22:00:00.000Z');
+    assert.equal(createManyArgs?.data[0]?.fecha_fin.toISOString(), '2026-04-12T21:59:59.999Z');
+    assert.deepEqual(usuarioUpdateCalls, [
+      { where: { id: 1 }, data: { balance_limpieza: 1 } },
+      { where: { id: 2 }, data: { balance_limpieza: 1 } },
+    ]);
+    assert.equal(transactionArgs?.length, 3);
+  });
+
+  test('usa la semana siguiente al ultimo turno existente', async () => {
+    prisma.turnoLimpieza.findFirst = async () => ({
+      fecha_inicio: new Date('2026-04-13T00:00:00.000Z'),
+    });
+
+    await generarTurnosSemanales(10);
+
+    assert.equal(createManyArgs?.data[0]?.fecha_inicio.toISOString(), '2026-04-19T22:00:00.000Z');
+    assert.equal(createManyArgs?.data[0]?.fecha_fin.toISOString(), '2026-04-26T21:59:59.999Z');
+  });
+
+  test('lanza error si no hay inquilinos activos', async () => {
+    prisma.habitacion.findMany = async () => [];
+
+    await assert.rejects(
+      () => generarTurnosSemanales(10),
+      /no hay inquilinos activos/i,
+    );
+    assert.equal(createManyArgs, null);
+  });
+});

--- a/backend/tests/operational-modules.test.ts
+++ b/backend/tests/operational-modules.test.ts
@@ -1,0 +1,315 @@
+import assert from 'node:assert/strict';
+import type express from 'express';
+import jwt from 'jsonwebtoken';
+import request from 'supertest';
+import { beforeEach, describe, test, vi } from 'vitest';
+
+type UsuarioTest = { id: number; rol: 'CASERO' | 'INQUILINO' };
+type Handler = express.RequestHandler;
+
+const prisma = vi.hoisted(() => ({
+  vivienda: {
+    findFirst: async (_args: unknown): Promise<unknown> => {
+      throw new Error('Unexpected prisma call: vivienda.findFirst');
+    },
+    findUnique: async (_args: unknown): Promise<unknown> => {
+      throw new Error('Unexpected prisma call: vivienda.findUnique');
+    },
+  },
+  habitacion: {
+    findFirst: async (_args: unknown): Promise<unknown> => {
+      throw new Error('Unexpected prisma call: habitacion.findFirst');
+    },
+    findMany: async (_args: unknown): Promise<unknown> => {
+      throw new Error('Unexpected prisma call: habitacion.findMany');
+    },
+  },
+  itemInventario: {
+    findUnique: async (_args: unknown): Promise<unknown> => {
+      throw new Error('Unexpected prisma call: itemInventario.findUnique');
+    },
+    findMany: async (_args: unknown): Promise<unknown> => {
+      throw new Error('Unexpected prisma call: itemInventario.findMany');
+    },
+    update: async (_args: unknown): Promise<unknown> => {
+      throw new Error('Unexpected prisma call: itemInventario.update');
+    },
+  },
+  fotoAsset: {
+    create: async (_args: unknown): Promise<unknown> => {
+      throw new Error('Unexpected prisma call: fotoAsset.create');
+    },
+  },
+  anuncio: {
+    create: async (_args: unknown): Promise<unknown> => {
+      throw new Error('Unexpected prisma call: anuncio.create');
+    },
+  },
+  incidencia: {
+    findUnique: async (_args: unknown): Promise<unknown> => {
+      throw new Error('Unexpected prisma call: incidencia.findUnique');
+    },
+    update: async (_args: unknown): Promise<unknown> => {
+      throw new Error('Unexpected prisma call: incidencia.update');
+    },
+  },
+}));
+
+const enviarNotificacionPush = vi.hoisted(() => vi.fn());
+
+vi.mock('../src/lib/prisma', () => ({ prisma }));
+vi.mock('../src/services/notification.service', () => ({
+  enviarNotificacionPush,
+}));
+
+const app = (await import('../src/app')).default;
+const { protegerModuloVivienda } = await import('../src/middlewares/module.guard');
+const {
+  listarInventarioVivienda,
+  marcarConformidadInventario,
+  subirFotoInventario,
+} = await import('../src/controllers/inventario.controller');
+const { crearAnuncio } = await import('../src/controllers/anuncio.controller');
+const { actualizarEstadoIncidencia } = await import('../src/controllers/incidencia.controller');
+
+function resetPrisma() {
+  enviarNotificacionPush.mockReset();
+  prisma.vivienda.findFirst = async () => null;
+  prisma.vivienda.findUnique = async () => null;
+  prisma.habitacion.findFirst = async () => null;
+  prisma.habitacion.findMany = async () => [];
+  prisma.itemInventario.findUnique = async () => null;
+  prisma.itemInventario.findMany = async () => [];
+  prisma.itemInventario.update = async (args: unknown) => ({ id: 1, ...(args as { data: unknown }).data });
+  prisma.fotoAsset.create = async (args: unknown) => ({ id: 1, ...(args as { data: unknown }).data });
+  prisma.anuncio.create = async (args: unknown) => ({
+    id: 1,
+    ...(args as { data: Record<string, unknown> }).data,
+    titulo: (args as { data: { titulo: string } }).data.titulo,
+    autor: { nombre: 'Ada' },
+  });
+  prisma.incidencia.findUnique = async () => null;
+  prisma.incidencia.update = async (args: unknown) => ({ id: 1, ...(args as { data: unknown }).data });
+}
+
+beforeEach(() => {
+  resetPrisma();
+});
+
+function req({
+  usuario,
+  params = {},
+  body = {},
+  query = {},
+  file,
+}: {
+  usuario: UsuarioTest;
+  params?: Record<string, string>;
+  body?: Record<string, unknown>;
+  query?: Record<string, unknown>;
+  file?: Partial<Express.Multer.File>;
+}) {
+  return {
+    usuario,
+    params,
+    body,
+    query,
+    file,
+  } as unknown as express.Request;
+}
+
+function res() {
+  const response = {
+    statusCode: 200,
+    body: undefined as unknown,
+    sent: false,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+    send(payload?: unknown) {
+      this.sent = true;
+      this.body = payload;
+      return this;
+    },
+  };
+  return response as unknown as express.Response & typeof response;
+}
+
+async function invoke(handler: Handler, requestData: express.Request) {
+  const response = res();
+  await handler(requestData, response, () => undefined);
+  return response;
+}
+
+const token = (usuario: UsuarioTest) => jwt.sign(usuario, process.env.JWT_SECRET!);
+
+describe('modulos operativos desactivados', () => {
+  test.each([
+    ['limpieza', 'mod_limpieza'],
+    ['inventario', 'mod_inventario'],
+    ['gastos', 'mod_gastos'],
+  ] as const)('bloquea %s si la vivienda lo tiene desactivado', async (modulo, campo) => {
+    let nextCalled = false;
+    prisma.vivienda.findFirst = async () => ({ [campo]: false });
+
+    const middleware = protegerModuloVivienda(modulo);
+    const response = res();
+    await middleware(
+      req({ usuario: { id: 20, rol: 'INQUILINO' }, params: { viviendaId: '10' } }),
+      response,
+      () => {
+        nextCalled = true;
+      },
+    );
+
+    assert.equal(response.statusCode, 403);
+    assert.match((response.body as { error: string }).error, /desactivado/i);
+    assert.equal(nextCalled, false);
+  });
+});
+
+describe('inventario', () => {
+  test('casero no puede listar inventario de vivienda ajena', async () => {
+    let findManyCalled = false;
+    prisma.itemInventario.findMany = async () => {
+      findManyCalled = true;
+      return [];
+    };
+
+    const response = await invoke(
+      listarInventarioVivienda,
+      req({ usuario: { id: 99, rol: 'CASERO' }, params: { viviendaId: '10' } }),
+    );
+
+    assert.equal(response.statusCode, 403);
+    assert.equal(findManyCalled, false);
+  });
+
+  test('inquilino no puede dar conformidad a inventario ajeno', async () => {
+    let updateCalled = false;
+    prisma.itemInventario.findUnique = async () => ({
+      id: 1,
+      vivienda_id: 10,
+      habitacion: null,
+    });
+    prisma.itemInventario.update = async () => {
+      updateCalled = true;
+      return {};
+    };
+
+    const response = await invoke(
+      marcarConformidadInventario,
+      req({ usuario: { id: 20, rol: 'INQUILINO' }, params: { itemId: '1' } }),
+    );
+
+    assert.equal(response.statusCode, 403);
+    assert.equal(updateCalled, false);
+  });
+
+  test('subida de foto falla de forma explicita si Cloudinary no esta configurado', async () => {
+    const response = await invoke(
+      subirFotoInventario,
+      req({
+        usuario: { id: 20, rol: 'INQUILINO' },
+        params: { itemId: '1' },
+        file: { path: 'https://example.com/foto.jpg' },
+      }),
+    );
+
+    assert.equal(response.statusCode, 500);
+    assert.match((response.body as { error: string }).error, /cloudinary/i);
+  });
+});
+
+describe('incidencias', () => {
+  test('inquilino no puede cambiar estado de incidencia de otra vivienda', async () => {
+    let updateCalled = false;
+    prisma.incidencia.findUnique = async () => ({
+      id: 9,
+      vivienda_id: 10,
+      creador_id: 21,
+      habitacion_id: null,
+      titulo: 'Caldera',
+      vivienda: { casero_id: 99 },
+      habitacion: null,
+    });
+    prisma.incidencia.update = async () => {
+      updateCalled = true;
+      return {};
+    };
+
+    const response = await invoke(
+      actualizarEstadoIncidencia,
+      req({
+        usuario: { id: 20, rol: 'INQUILINO' },
+        params: { id: '9' },
+        body: { estado: 'RESUELTA' },
+      }),
+    );
+
+    assert.equal(response.statusCode, 403);
+    assert.equal(updateCalled, false);
+  });
+});
+
+describe('uploads', () => {
+  test('rechaza tipos no permitidos con respuesta JSON', async () => {
+    prisma.itemInventario.findUnique = async () => ({ vivienda_id: 10, habitacion: null });
+    prisma.vivienda.findFirst = async () => ({ mod_inventario: true });
+
+    const response = await request(app)
+      .post('/api/inventario/1/fotos')
+      .set('Authorization', `Bearer ${token({ id: 99, rol: 'CASERO' })}`)
+      .attach('foto', Buffer.from('texto'), {
+        filename: 'nota.txt',
+        contentType: 'text/plain',
+      });
+
+    assert.equal(response.status, 400);
+    assert.match(response.body.error, /solo se permiten/i);
+  });
+
+  test('rechaza imagenes que superan el tamano maximo', async () => {
+    prisma.itemInventario.findUnique = async () => ({ vivienda_id: 10, habitacion: null });
+    prisma.vivienda.findFirst = async () => ({ mod_inventario: true });
+
+    const response = await request(app)
+      .post('/api/inventario/1/fotos')
+      .set('Authorization', `Bearer ${token({ id: 99, rol: 'CASERO' })}`)
+      .attach('foto', Buffer.alloc(8 * 1024 * 1024 + 1), {
+        filename: 'foto.png',
+        contentType: 'image/png',
+      });
+
+    assert.equal(response.status, 413);
+    assert.match(response.body.error, /tamano maximo/i);
+  });
+});
+
+describe('push fire-and-forget', () => {
+  test('crear anuncio responde 201 aunque falle la notificacion push', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    enviarNotificacionPush.mockRejectedValueOnce(new Error('expo down'));
+    prisma.vivienda.findFirst = async () => ({ id: 10 });
+    prisma.habitacion.findMany = async () => [{ inquilino_id: 20 }];
+    prisma.vivienda.findUnique = async () => ({ casero_id: 99 });
+
+    const response = await invoke(
+      crearAnuncio,
+      req({
+        usuario: { id: 99, rol: 'CASERO' },
+        body: { titulo: 'Reunion', contenido: 'Hoy', vivienda_id: 10 },
+      }),
+    );
+
+    assert.equal(response.statusCode, 201);
+    assert.equal(enviarNotificacionPush.mock.calls.length, 1);
+    await Promise.resolve();
+    consoleError.mockRestore();
+  });
+});

--- a/docs/changelog/Epica16/epica-16-issue-251-modulos-operativos.md
+++ b/docs/changelog/Epica16/epica-16-issue-251-modulos-operativos.md
@@ -1,0 +1,19 @@
+# Epica 16 - Issue 251 - Modulos operativos
+
+## Objetivo
+Revisar los modulos operativos de convivencia con foco en permisos, estados, uploads y notificaciones para que los flujos criticos fallen de forma segura y queden cubiertos por tests.
+
+## Cambios
+- Se anade un manejador global de errores de subida para devolver JSON estable en tipos no permitidos y archivos demasiado grandes.
+- Se cubre la generacion semanal de turnos de limpieza, el avance de semana y la actualizacion de balances.
+- Se anaden tests de modulos desactivados para limpieza, inventario y gastos.
+- Se cubren accesos negativos a inventario ajeno y cambios de estado de incidencias fuera de pertenencia.
+- Se verifican errores de proveedor Cloudinary no configurado, tipo de archivo invalido y limite de tamano.
+- Se valida que una notificacion push fallida no rompe la creacion principal de un anuncio.
+
+## Verificacion
+- `npm test`
+- `npm run build`
+
+## Riesgos conocidos
+- Las pruebas de upload validan el middleware y el manejo de errores sin conectar contra Cloudinary real.


### PR DESCRIPTION
## Objetivo
Reforzar la revisión de módulos operativos de convivencia cubriendo permisos, estados, uploads, limpieza, inventario, incidencias, anuncios y notificaciones push.

## Cambios principales
* Añadido manejo JSON estable para errores de upload por tipo inválido y tamaño máximo.
* Añadidos tests de generación de turnos de limpieza, avance semanal y balances.
* Añadidos tests de módulos desactivados para limpieza, inventario y gastos.
* Añadidos tests negativos de inventario ajeno e incidencias fuera de pertenencia.
* Validado que fallos de push no bloquean la operación principal.

## Changelog
* `docs/changelog/Epica16/epica-16-issue-251-modulos-operativos.md`

## Summary
* Revisión backend centrada en seguridad operativa, errores controlados y cobertura de criterios del issue 251.

## Testing
* `npm test`
* `npm run build`