### PR TITLE
[Épica 16] Actualiza autenticación, navegación y cliente API

### DIFF
--- a/docs/changelog/issue-252-auth-navegacion-api.md
+++ b/docs/changelog/issue-252-auth-navegacion-api.md
@@ -1,0 +1,15 @@
+# Issue 252 - Autenticacion, navegacion y cliente API
+
+## Cambios
+
+- Se centralizo la ruta de dashboard por rol para login, registro, selector de rol y restauracion de sesion.
+- La restauracion de sesion elimina el token y vuelve a login cuando `/auth/me` falla o devuelve un rol no soportado.
+- El cliente Axios exige `EXPO_PUBLIC_API_URL` en builds de produccion; `localhost` queda limitado a entornos no productivos.
+- El perfil `production` de EAS declara explicitamente la URL publica de API y los client IDs publicos de Google.
+- `useViviendaIdParam()` prioriza el segmento `/vivienda/:id` de la ruta real para evitar contaminacion de otros parametros dinamicos.
+
+## Verificacion
+
+- Tests unitarios para rutas por rol, URL de API y parseo de parametros dinamicos.
+- Tests de render, error de login y redireccion de login por rol.
+- Tests de restauracion de sesion y borrado de token cuando `/auth/me` falla.

--- a/frontend/app/__tests__/_layout.test.tsx
+++ b/frontend/app/__tests__/_layout.test.tsx
@@ -1,0 +1,68 @@
+import { render, waitFor } from '@testing-library/react-native';
+import RootLayout from '../_layout';
+
+const mockReplace = jest.fn();
+const mockObtenerToken = jest.fn();
+const mockEliminarToken = jest.fn();
+const mockApiGet = jest.fn();
+const mockSyncPushToken = jest.fn();
+
+jest.mock('expo-router', () => {
+  return {
+    Stack: function MockStack() {
+      return null;
+    },
+    useRouter: () => ({ replace: mockReplace }),
+  };
+});
+
+jest.mock('react-native-toast-message', () => {
+  return function MockToast() {
+    return null;
+  };
+});
+
+jest.mock('@/services/auth.service', () => ({
+  obtenerToken: () => mockObtenerToken(),
+  eliminarToken: () => mockEliminarToken(),
+}));
+
+jest.mock('@/services/api', () => ({
+  get: (...args: unknown[]) => mockApiGet(...args),
+}));
+
+jest.mock('@/utils/notifications', () => ({
+  syncPushToken: () => mockSyncPushToken(),
+}));
+
+describe('RootLayout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('redirige una sesion restaurada al dashboard segun rol', async () => {
+    mockObtenerToken.mockResolvedValue('token');
+    mockApiGet.mockResolvedValue({ data: { rol: 'INQUILINO' } });
+
+    render(<RootLayout />);
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/inquilino/inicio');
+    });
+    expect(mockSyncPushToken).toHaveBeenCalled();
+    expect(mockEliminarToken).not.toHaveBeenCalled();
+  });
+
+  it('elimina el token y vuelve al login cuando /auth/me falla', async () => {
+    mockObtenerToken.mockResolvedValue('token');
+    mockApiGet.mockRejectedValue(new Error('No autorizado'));
+    mockEliminarToken.mockResolvedValue(undefined);
+
+    render(<RootLayout />);
+
+    await waitFor(() => {
+      expect(mockEliminarToken).toHaveBeenCalled();
+    });
+    expect(mockReplace).toHaveBeenCalledWith('/');
+  });
+});

--- a/frontend/app/__tests__/index.test.tsx
+++ b/frontend/app/__tests__/index.test.tsx
@@ -1,0 +1,110 @@
+import { TextInput } from 'react-native';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import LoginScreen from '../index';
+
+const mockPush = jest.fn();
+const mockReplace = jest.fn();
+const mockApiPost = jest.fn();
+const mockGuardarToken = jest.fn();
+const mockToastShow = jest.fn();
+const mockGooglePromptAsync = jest.fn();
+const mockSyncPushToken = jest.fn();
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: mockPush, replace: mockReplace }),
+}));
+
+jest.mock('react-native-toast-message', () => ({
+  show: (...args: unknown[]) => mockToastShow(...args),
+}));
+
+jest.mock('expo-auth-session/providers/google', () => ({
+  useAuthRequest: () => [null, null, mockGooglePromptAsync],
+}));
+
+jest.mock('expo-web-browser', () => ({
+  maybeCompleteAuthSession: jest.fn(),
+}));
+
+jest.mock('@expo/vector-icons', () => {
+  return {
+    AntDesign: function MockAntDesign() {
+      return null;
+    },
+    Ionicons: function MockIonicons() {
+      return null;
+    },
+  };
+});
+
+jest.mock('@/services/api', () => ({
+  post: (...args: unknown[]) => mockApiPost(...args),
+}));
+
+jest.mock('@/services/auth.service', () => ({
+  guardarToken: (...args: unknown[]) => mockGuardarToken(...args),
+}));
+
+jest.mock('@/utils/notifications', () => ({
+  syncPushToken: () => mockSyncPushToken(),
+}));
+
+describe('LoginScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renderiza el formulario de login', () => {
+    render(<LoginScreen />);
+
+    expect(screen.getByText('Roomies')).toBeTruthy();
+    expect(screen.getByText(/Gesti.n de pisos compartidos/)).toBeTruthy();
+    expect(screen.getByText(/Iniciar Sesi.n/)).toBeTruthy();
+  });
+
+  it('muestra el error de API cuando falla el login', async () => {
+    mockApiPost.mockRejectedValue({
+      response: { data: { error: 'Credenciales invalidas.' } },
+    });
+
+    const { UNSAFE_getAllByType } = render(<LoginScreen />);
+    const [emailInput, passwordInput] = UNSAFE_getAllByType(TextInput);
+
+    fireEvent.changeText(emailInput, 'inquilino@test.com');
+    fireEvent.changeText(passwordInput, 'mal');
+    fireEvent.press(screen.getByText(/Iniciar Sesi.n/));
+
+    await waitFor(() => {
+      expect(mockApiPost).toHaveBeenCalledWith('/auth/login', {
+        email: 'inquilino@test.com',
+        password: 'mal',
+      });
+    });
+    expect(mockToastShow).toHaveBeenCalledWith({
+      type: 'error',
+      text1: 'Credenciales invalidas.',
+    });
+    expect(mockGuardarToken).not.toHaveBeenCalled();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('guarda token y redirige por rol cuando el login funciona', async () => {
+    mockApiPost.mockResolvedValue({
+      data: { token: 'jwt', usuario: { rol: 'CASERO' } },
+    });
+    mockGuardarToken.mockResolvedValue(undefined);
+
+    const { UNSAFE_getAllByType } = render(<LoginScreen />);
+    const [emailInput, passwordInput] = UNSAFE_getAllByType(TextInput);
+
+    fireEvent.changeText(emailInput, 'casero@test.com');
+    fireEvent.changeText(passwordInput, 'casero123');
+    fireEvent.press(screen.getByText(/Iniciar Sesi.n/));
+
+    await waitFor(() => {
+      expect(mockGuardarToken).toHaveBeenCalledWith('jwt');
+    });
+    expect(mockSyncPushToken).toHaveBeenCalledTimes(1);
+    expect(mockReplace).toHaveBeenCalledWith('/casero/viviendas');
+  });
+});

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -7,6 +7,7 @@ import api from '@/services/api';
 import { Theme } from '@/constants/theme';
 import { toastConfig } from '@/constants/toastConfig';
 import { syncPushToken } from '@/utils/notifications';
+import { getDashboardRoute } from '@/utils/authRoutes';
 
 export default function RootLayout() {
   const router = useRouter();
@@ -19,11 +20,11 @@ export default function RootLayout() {
         if (token) {
           const { data } = await api.get<{ rol: string }>('/auth/me');
           void syncPushToken();
-          const destino = data.rol === 'CASERO' ? '/casero/viviendas' : '/inquilino/inicio';
-          router.replace(destino);
+          router.replace(getDashboardRoute(data.rol));
         }
       } catch {
         await eliminarToken();
+        router.replace('/');
       } finally {
         setChecking(false);
       }

--- a/frontend/app/index.tsx
+++ b/frontend/app/index.tsx
@@ -12,6 +12,7 @@ import api from '@/services/api';
 import { CustomButton } from '@/components/common/CustomButton';
 import { CustomInput } from '@/components/common/CustomInput';
 import { syncPushToken } from '@/utils/notifications';
+import { getDashboardRoute } from '@/utils/authRoutes';
 
 WebBrowser.maybeCompleteAuthSession();
 
@@ -37,8 +38,7 @@ export default function LoginScreen() {
   });
 
   const irAlDashboard = useCallback((rol: string) => {
-    const destino = rol === 'CASERO' ? '/casero/viviendas' : '/inquilino/inicio';
-    router.replace(destino);
+    router.replace(getDashboardRoute(rol));
   }, [router]);
 
   const handleGoogleLogin = useCallback(async (idToken: string) => {

--- a/frontend/app/registro.tsx
+++ b/frontend/app/registro.tsx
@@ -12,6 +12,7 @@ import { CustomButton } from '@/components/common/CustomButton';
 import { CustomInput } from '@/components/common/CustomInput';
 import { dniNieSchema, pasaporteSchema, passwordSchema } from '@/utils/schemas';
 import { syncPushToken } from '@/utils/notifications';
+import { getDashboardRoute } from '@/utils/authRoutes';
 
 WebBrowser.maybeCompleteAuthSession();
 
@@ -50,8 +51,7 @@ export default function RegistroScreen() {
       if (data.esNuevo) {
         router.replace('/rol');
       } else {
-        const destino = data.usuario.rol === 'CASERO' ? '/casero/viviendas' : '/inquilino/inicio';
-        router.replace(destino);
+        router.replace(getDashboardRoute(data.usuario.rol));
       }
     } catch {
       Toast.show({ type: 'error', text1: 'No se pudo completar el registro con Google.' });
@@ -111,8 +111,7 @@ export default function RegistroScreen() {
       );
       await guardarToken(data.token);
       void syncPushToken();
-      const destino = data.usuario.rol === 'CASERO' ? '/casero/viviendas' : '/inquilino/inicio';
-      router.replace(destino);
+      router.replace(getDashboardRoute(data.usuario.rol));
     } catch (err: any) {
       const mensaje = err.response?.data?.error ?? 'No se pudo crear la cuenta. Inténtalo de nuevo.';
       Toast.show({ type: 'error', text1: mensaje });

--- a/frontend/app/rol.tsx
+++ b/frontend/app/rol.tsx
@@ -6,6 +6,7 @@ import { styles } from '@/styles/rol.styles';
 import { guardarToken } from '@/services/auth.service';
 import api from '@/services/api';
 import { syncPushToken } from '@/utils/notifications';
+import { getDashboardRoute } from '@/utils/authRoutes';
 
 type Rol = 'CASERO' | 'INQUILINO';
 
@@ -23,8 +24,7 @@ export default function SeleccionRolScreen() {
       });
       await guardarToken(data.token);
       void syncPushToken();
-      const destino = data.usuario.rol === 'CASERO' ? '/casero/viviendas' : '/inquilino/inicio';
-      router.replace(destino);
+      router.replace(getDashboardRoute(data.usuario.rol));
     } catch {
       Toast.show({ type: 'error', text1: 'No se pudo guardar el rol. Inténtalo de nuevo.' });
     } finally {

--- a/frontend/eas.json
+++ b/frontend/eas.json
@@ -16,6 +16,11 @@
     "production": {
       "android": {
         "buildType": "app-bundle"
+      },
+      "env": {
+        "EXPO_PUBLIC_API_URL": "https://roomies-production-c884.up.railway.app/api",
+        "EXPO_PUBLIC_GOOGLE_CLIENT_ID": "343196560597-2oe0gikprqi4qe3v7m73jnhrclq48rju.apps.googleusercontent.com",
+        "EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID": "343196560597-i4vamt5kpum1q09aievn2krelod15n51.apps.googleusercontent.com"
       }
     }
   }

--- a/frontend/hooks/useViviendaIdParam.ts
+++ b/frontend/hooks/useViviendaIdParam.ts
@@ -1,20 +1,12 @@
 import { useLocalSearchParams, usePathname } from 'expo-router';
 import { useMemo } from 'react';
+import { resolveViviendaIdParam } from '@/utils/viviendaParams';
 
 export function useViviendaIdParam() {
   const params = useLocalSearchParams<{ id?: string | string[] }>();
   const pathname = usePathname();
 
   return useMemo(() => {
-    const localId = Array.isArray(params.id) ? params.id[0] : params.id;
-    if (localId) {
-      return localId;
-    }
-
-    const segments = pathname.split('/').filter(Boolean);
-    const viviendaIndex = segments.findIndex((segment) => segment === 'vivienda');
-    const idFromPath = viviendaIndex >= 0 ? segments[viviendaIndex + 1] : undefined;
-
-    return idFromPath ? decodeURIComponent(idFromPath) : undefined;
+    return resolveViviendaIdParam(params.id, pathname);
   }, [params.id, pathname]);
 }

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -1,8 +1,9 @@
 import axios from 'axios';
 import { obtenerToken } from './auth.service';
+import { getApiBaseUrl } from '@/utils/apiUrl';
 
 const api = axios.create({
-  baseURL: process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:3000/api',
+  baseURL: getApiBaseUrl(),
 });
 
 api.interceptors.request.use(async (config) => {

--- a/frontend/utils/__tests__/apiUrl.test.ts
+++ b/frontend/utils/__tests__/apiUrl.test.ts
@@ -1,0 +1,19 @@
+import { getApiBaseUrl } from '../apiUrl';
+
+describe('getApiBaseUrl', () => {
+  it('usa EXPO_PUBLIC_API_URL cuando esta configurada', () => {
+    expect(getApiBaseUrl({ EXPO_PUBLIC_API_URL: 'https://roomies.example/api' })).toBe(
+      'https://roomies.example/api'
+    );
+  });
+
+  it('permite localhost solo fuera de produccion', () => {
+    expect(getApiBaseUrl({ NODE_ENV: 'test' })).toBe('http://localhost:3000/api');
+  });
+
+  it('falla en produccion si falta EXPO_PUBLIC_API_URL', () => {
+    expect(() => getApiBaseUrl({ NODE_ENV: 'production' })).toThrow(
+      'EXPO_PUBLIC_API_URL es obligatoria'
+    );
+  });
+});

--- a/frontend/utils/__tests__/authRoutes.test.ts
+++ b/frontend/utils/__tests__/authRoutes.test.ts
@@ -1,0 +1,15 @@
+import { getDashboardRoute } from '../authRoutes';
+
+describe('getDashboardRoute', () => {
+  it('redirige al dashboard del casero', () => {
+    expect(getDashboardRoute('CASERO')).toBe('/casero/viviendas');
+  });
+
+  it('redirige al dashboard del inquilino', () => {
+    expect(getDashboardRoute('INQUILINO')).toBe('/inquilino/inicio');
+  });
+
+  it('rechaza roles no soportados para evitar estados inconsistentes', () => {
+    expect(() => getDashboardRoute('ADMIN')).toThrow('Rol de usuario no soportado');
+  });
+});

--- a/frontend/utils/__tests__/viviendaParams.test.ts
+++ b/frontend/utils/__tests__/viviendaParams.test.ts
@@ -1,0 +1,23 @@
+import { extractViviendaIdFromPath, resolveViviendaIdParam } from '../viviendaParams';
+
+describe('viviendaParams', () => {
+  it('extrae el id de vivienda desde tabs anidados', () => {
+    expect(extractViviendaIdFromPath('/casero/vivienda/42/tablon')).toBe('42');
+  });
+
+  it('extrae el id de vivienda desde pantallas hijas', () => {
+    expect(extractViviendaIdFromPath('/casero/vivienda/42/editar-habitacion')).toBe('42');
+  });
+
+  it('prioriza la ruta real sobre un params.id contaminado por otra pantalla dinamica', () => {
+    expect(resolveViviendaIdParam('999', '/casero/vivienda/42/incidencias')).toBe('42');
+  });
+
+  it('usa params.id como fallback cuando no hay segmento vivienda', () => {
+    expect(resolveViviendaIdParam(['77'], '/casero/viviendas')).toBe('77');
+  });
+
+  it('devuelve undefined para parametros vacios', () => {
+    expect(resolveViviendaIdParam('', '/casero/viviendas')).toBeUndefined();
+  });
+});

--- a/frontend/utils/apiUrl.ts
+++ b/frontend/utils/apiUrl.ts
@@ -1,0 +1,20 @@
+const LOCAL_DEV_API_URL = 'http://localhost:3000/api';
+
+type ApiEnv = {
+  EXPO_PUBLIC_API_URL?: string;
+  NODE_ENV?: string;
+};
+
+export function getApiBaseUrl(env: ApiEnv = process.env): string {
+  const configuredUrl = env.EXPO_PUBLIC_API_URL?.trim();
+
+  if (configuredUrl) {
+    return configuredUrl;
+  }
+
+  if (env.NODE_ENV === 'production') {
+    throw new Error('EXPO_PUBLIC_API_URL es obligatoria en builds de produccion.');
+  }
+
+  return LOCAL_DEV_API_URL;
+}

--- a/frontend/utils/authRoutes.ts
+++ b/frontend/utils/authRoutes.ts
@@ -1,0 +1,14 @@
+export type RolUsuario = 'CASERO' | 'INQUILINO';
+export type DashboardRoute = '/casero/viviendas' | '/inquilino/inicio';
+
+export function getDashboardRoute(rol: string | null | undefined): DashboardRoute {
+  if (rol === 'CASERO') {
+    return '/casero/viviendas';
+  }
+
+  if (rol === 'INQUILINO') {
+    return '/inquilino/inicio';
+  }
+
+  throw new Error(`Rol de usuario no soportado: ${rol ?? 'sin rol'}`);
+}

--- a/frontend/utils/viviendaParams.ts
+++ b/frontend/utils/viviendaParams.ts
@@ -1,0 +1,32 @@
+type RouteParam = string | string[] | null | undefined;
+
+function normalizeParam(param: RouteParam): string | undefined {
+  const value = Array.isArray(param) ? param[0] : param;
+  const trimmed = value?.trim();
+
+  return trimmed ? trimmed : undefined;
+}
+
+function decodePathSegment(segment: string | undefined): string | undefined {
+  if (!segment) {
+    return undefined;
+  }
+
+  try {
+    return normalizeParam(decodeURIComponent(segment));
+  } catch {
+    return normalizeParam(segment);
+  }
+}
+
+export function extractViviendaIdFromPath(pathname: string): string | undefined {
+  const [pathWithoutQuery] = pathname.split(/[?#]/);
+  const segments = pathWithoutQuery.split('/').filter(Boolean);
+  const viviendaIndex = segments.findIndex((segment) => segment === 'vivienda');
+
+  return viviendaIndex >= 0 ? decodePathSegment(segments[viviendaIndex + 1]) : undefined;
+}
+
+export function resolveViviendaIdParam(paramsId: RouteParam, pathname: string): string | undefined {
+  return extractViviendaIdFromPath(pathname) ?? normalizeParam(paramsId);
+}


### PR DESCRIPTION
## Summary
- Centraliza la redirección por rol para login, registro, selector de rol y restauración de sesión.
- Refuerza la restauración de sesión eliminando el token y volviendo a login cuando `/auth/me` falla.
- Evita fallback a `localhost` en producción y declara `EXPO_PUBLIC_API_URL` en el perfil `production` de EAS.
- Estabiliza el parseo de parámetros dinámicos de vivienda en tabs y pantallas hijas.

## Testing
- `npm test -- --runInBand`
- `npm run lint`
- `npx tsc --noEmit`

## Changelog
- `docs/changelog/issue-252-auth-navegacion-api.md`