### PR TITLE
Update infraestructura y documentación de despliegue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,10 +13,21 @@ POSTGRES_DB=roomies
 # Usa una cadena larga y aleatoria en producción (openssl rand -hex 32)
 JWT_SECRET=cambia_este_secreto
 
+# Backend publico
+# Docker local: http://localhost:3001
+# Railway: https://<tu-servicio>.up.railway.app
+BACKEND_URL=http://localhost:3001
+
 # — IP local (solo necesario para Docker + Expo Go en dispositivo físico) —
 # ipconfig → IPv4 del adaptador Wi-Fi  /  ifconfig en Mac/Linux
 # No es necesario si usas el servidor de desarrollo de Railway
 HOST_IP=192.168.1.X
+
+# API consumida por Expo
+# Docker + Expo Go en dispositivo fisico: usa la IP LAN de tu maquina.
+# Android emulator puede usar http://10.0.2.2:3001/api.
+# Web/local en la misma maquina puede usar http://localhost:3001/api.
+EXPO_PUBLIC_API_URL=http://192.168.1.X:3001/api
 
 # — Mapbox Geocoding —
 # Obtén tu token en https://account.mapbox.com
@@ -25,8 +36,24 @@ EXPO_PUBLIC_MAPBOX_TOKEN=pk.ey...
 # — Google OAuth —
 # Web Client ID de Google Cloud Console → Credenciales → OAuth 2.0
 GOOGLE_CLIENT_ID=xxxxxxxxxxxx.apps.googleusercontent.com
+EXPO_PUBLIC_GOOGLE_CLIENT_ID=xxxxxxxxxxxx.apps.googleusercontent.com
+EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID=xxxxxxxxxxxx.apps.googleusercontent.com
+EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=
+
+# Email (opcional en local; requerido para verificar correo real)
+EMAIL_USER=tu_correo@gmail.com
+EMAIL_PASS=xxxx_xxxx_xxxx_xxxx
+
+# Cloudinary (opcional para arrancar; requerido para subidas reales)
+CLOUDINARY_CLOUD_NAME=tu_cloud_name
+CLOUDINARY_API_KEY=tu_api_key
+CLOUDINARY_API_SECRET=tu_api_secret
 
 # — Expo Access Token —
 # expo.dev → avatar → Access Tokens → Create Token
 # Necesario para que Docker autentique el CLI de Expo como tu cuenta (@usuario)
 EXPO_TOKEN=tu_expo_access_token_aqui
+
+# Base de datos demo (opcional)
+# true reinicia la BD del contenedor y ejecuta seed al arrancar backend.
+RESET_DB=false

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -456,29 +456,35 @@ Cada subcarpeta tiene su propio `.env.example` con todos los campos documentados
 
 ---
 
-## Docker
+## Railway, Expo Go y Docker
 
-```bash
-# Primera vez o tras cambios en dependencias
-docker-compose down -v
-docker-compose build --no-cache backend
-docker-compose up
+El testeo funcional diario se hace levantando Expo Go contra Railway desarrollo:
 
-# Uso habitual
-docker-compose up
-docker-compose down
-```
+1. `frontend/.env` apunta a `EXPO_PUBLIC_API_URL=https://roomies-dev.up.railway.app/api`.
+2. Se ejecuta `npx expo start --clear` en `frontend`.
+3. La app se abre desde Expo Go.
 
-El backend en Docker ejecuta al arrancar:
+El backend usa dos servicios Railway: desarrollo para pruebas y produccion para releases. `backend/Dockerfile` existe para que Railway construya la imagen del backend.
 
-1. `npx prisma db push --accept-data-loss` — aplica el schema
-2. `npx prisma generate` — regenera el cliente
-3. `npx prisma db seed` — carga datos de prueba
-4. `npm run dev` — arranca el servidor con nodemon
+El `backend/Dockerfile` ejecuta:
+
+1. `npm run build` durante la construccion de la imagen.
+2. `npm start` al arrancar el contenedor.
+
+`npm start` ejecuta `npx prisma db push --accept-data-loss` y `node dist/index.js`.
+
+`docker-compose.yml` queda como apoyo opcional para revisar infraestructura local. En ese modo, el servicio backend sobreescribe el comando de la imagen Railway y ejecuta:
+
+1. `npx prisma generate` - regenera el cliente despues del bind mount.
+2. `npx prisma db push --accept-data-loss` - aplica el schema.
+3. `npm run dev` - arranca el servidor con nodemon.
+
+Si `RESET_DB=true`, sustituye el `db push --accept-data-loss` por `db push --force-reset` y ejecuta `npx prisma db seed` antes de arrancar.
 
 **Puertos**: PostgreSQL en `5433:5432`, backend en `3001:3000`, frontend en `8080:8080`.
 
 > El puerto 8080 se usa en lugar de 8081 para evitar conflictos con reglas de firewall de Windows.
+> El frontend del compose lee `EXPO_PUBLIC_API_URL` desde `.env`; para Expo Go en movil fisico debe apuntar a `http://<HOST_IP>:3001/api`.
 
 ---
 
@@ -659,6 +665,14 @@ Usuarios de prueba creados por `prisma db seed`:
   - `casero/vivienda/[id]/(tabs)/opciones.tsx` centraliza la configuracion de modulos de vivienda.
   - `perfil.tsx` muestra `Propietario` para usuarios `CASERO` y elimina el bloque redundante de rol.
   - `inquilino/(tabs)/gastos.tsx` separa pendientes entre companeros y pendientes con casero, elimina textos temporales, muestra estado vacio real y ajusta el FAB para no cubrir contenido.
+
+## Update 2026-04-12 - Epica 16 issue 256
+
+- `docker-compose.yml` deja de fijar la API del frontend a produccion y consume `EXPO_PUBLIC_API_URL` desde `.env`.
+- `backend/Dockerfile` queda orientado a Railway: compila con `npm run build` y arranca con `npm start`.
+- `docker-compose.yml` mantiene un comando de desarrollo propio para regenerar Prisma Client y arrancar con nodemon solo cuando se use Compose.
+- `.env.example`, `backend/.env.example` y `frontend/.env.example` documentan variables obligatorias, opcionales, URLs locales y tokens por entorno.
+- `docs/infra/setup-despliegue.md` concentra el flujo Railway desarrollo + Expo Go, Dockerfile, Compose auxiliar y comandos de build/test/lint.
 
 ## Update 2026-04-10 - Cobros, mensualidades y push (Epica 12)
 

--- a/README.md
+++ b/README.md
@@ -59,26 +59,42 @@ Aplicacion movil para gestionar pisos compartidos. Conecta a caseros e inquilino
 | Desarrollo | `https://roomies-dev.up.railway.app/api` |
 | Produccion | `https://roomies-production-c884.up.railway.app/api` |
 
-## Levantar el proyecto con Docker
+## Testeo habitual con Expo Go y Railway dev
 
 ### Prerrequisitos
 
-- Docker Desktop
+- Node.js 20+
+- Expo Go instalado en el movil
+- Backend desplegado en Railway desarrollo
 
 ### Pasos
 
-1. Copia `.env.example` a `.env` y rellena `HOST_IP`.
-2. Levanta los servicios:
+1. Copia `frontend/.env.example` a `frontend/.env`.
+2. Usa Railway desarrollo como API:
 
-```bash
-docker-compose up --build
+```env
+EXPO_PUBLIC_API_URL=https://roomies-dev.up.railway.app/api
 ```
 
-| Servicio | Puerto | Descripcion |
-|---|---|---|
-| `db` | 5433 | PostgreSQL 15 |
-| `backend` | 3001 | API Express |
-| `frontend` | 8080 | Metro Bundler |
+3. Arranca Expo con cache limpia:
+
+```bash
+cd frontend
+npm install
+npx expo start --clear
+```
+
+4. Abre el QR con Expo Go.
+
+> Hay dos entornos Railway: desarrollo para pruebas funcionales y produccion para releases.
+
+## Docker y Railway
+
+El `backend/Dockerfile` se usa para que Railway construya la imagen del backend. El contenedor compila con `npm run build`; al arrancar ejecuta `npm start`, que aplica `prisma db push --accept-data-loss` y levanta `dist/index.js`.
+
+`docker-compose.yml` queda como apoyo para revisar infraestructura local si hace falta, pero no es el flujo habitual de testeo.
+
+Consulta `docs/infra/setup-despliegue.md` para el detalle completo de variables, URLs por entorno y despliegue.
 
 ### Usuarios de prueba
 
@@ -95,6 +111,7 @@ docker-compose up --build
 cd backend
 npm install
 cp .env.example .env
+npx prisma generate
 npx prisma db push
 npx prisma db seed
 npm run dev
@@ -140,4 +157,5 @@ Los tests cargan valores de entorno de prueba y no necesitan `.env` privados. El
 | Setup backend | `docs/backend/setup.md` |
 | API REST | `docs/backend/api.md` |
 | Setup frontend | `docs/frontend/setup.md` |
+| Infraestructura y despliegue | `docs/infra/setup-despliegue.md` |
 | Changelog tecnico | `docs/changelog/` |

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,3 +1,7 @@
 node_modules
 dist
 .env
+.env.local
+.env.*.local
+coverage
+npm-debug.*

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,6 +13,12 @@ DATABASE_URL="postgresql://postgres:postgres@localhost:5433/roomies"
 # Usa una cadena larga y aleatoria en producción (openssl rand -hex 32)
 JWT_SECRET=cambia_este_secreto_en_produccion
 
+# URL publica del backend.
+# Local sin Docker: http://localhost:3000
+# Docker Compose: http://localhost:3001
+# Railway: https://<tu-servicio>.up.railway.app
+BACKEND_URL=http://localhost:3000
+
 # — Google OAuth —
 # Web Client ID de Google Cloud Console → Credenciales → OAuth 2.0
 # Mismo valor que EXPO_PUBLIC_GOOGLE_CLIENT_ID en frontend/.env
@@ -21,11 +27,13 @@ GOOGLE_CLIENT_ID=xxxxxxxxxxxx.apps.googleusercontent.com
 # — Email (SMTP) —
 # Cuenta Gmail con contraseña de aplicación (Google → Seguridad → Verificación en 2 pasos → Contraseñas de app)
 # ⚠ En Railway (producción) los puertos SMTP están bloqueados — usar servicio HTTP o bypass
+# Opcional para arrancar en local, requerido para verificacion real por correo.
 EMAIL_USER=tu_correo@gmail.com
 EMAIL_PASS=xxxx_xxxx_xxxx_xxxx
 
 # Cloudinary
 # Dashboard -> API Environment details
+# Opcional para arrancar; requerido para inventario, justificantes y facturas con adjuntos.
 CLOUDINARY_CLOUD_NAME=tu_cloud_name
 CLOUDINARY_API_KEY=tu_api_key
 CLOUDINARY_API_SECRET=tu_api_secret

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,10 +7,9 @@ RUN npm install
 
 COPY . .
 
-RUN npx prisma generate
+RUN npm run build
 
 EXPOSE 3000
 
-# Aplica el schema a la DB y arranca el servidor de desarrollo
-# Si la variable RESET_DB es "true", formatea la BD y ejecuta el seed. Si no, solo actualiza el esquema.
-CMD ["sh", "-c", "if [ \"$RESET_DB\" = \"true\" ]; then until npx prisma db push --force-reset; do echo 'DB not ready, retrying...'; sleep 3; done && npx prisma db seed; else until npx prisma db push --accept-data-loss; do echo 'DB not ready, retrying...'; sleep 3; done; fi && npm run dev"]
+# Railway usa esta imagen compilada; npm start aplica el schema y arranca dist/index.js.
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,10 +19,18 @@ services:
     build: ./backend
     ports:
       - "3001:3000"
+    command: sh -c "npx prisma generate && if [ \"${RESET_DB:-false}\" = \"true\" ]; then until npx prisma db push --force-reset; do echo 'DB not ready, retrying...'; sleep 3; done && npx prisma db seed; else until npx prisma db push --accept-data-loss; do echo 'DB not ready, retrying...'; sleep 3; done; fi && npm run dev"
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
       JWT_SECRET: ${JWT_SECRET}
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
+      BACKEND_URL: ${BACKEND_URL:-http://localhost:3001}
+      EMAIL_USER: ${EMAIL_USER:-}
+      EMAIL_PASS: ${EMAIL_PASS:-}
+      CLOUDINARY_CLOUD_NAME: ${CLOUDINARY_CLOUD_NAME:-}
+      CLOUDINARY_API_KEY: ${CLOUDINARY_API_KEY:-}
+      CLOUDINARY_API_SECRET: ${CLOUDINARY_API_SECRET:-}
+      RESET_DB: ${RESET_DB:-false}
     depends_on:
       db:
         condition: service_healthy
@@ -36,9 +44,12 @@ services:
       - "8080:8080"
     command: npx expo start --host lan --port 8080 --clear
     environment:
-      EXPO_PUBLIC_API_URL: https://roomies-production-c884.up.railway.app/api
+      EXPO_PUBLIC_API_URL: ${EXPO_PUBLIC_API_URL:-https://roomies-dev.up.railway.app/api}
       REACT_NATIVE_PACKAGER_HOSTNAME: ${HOST_IP}
       EXPO_PUBLIC_MAPBOX_TOKEN: ${EXPO_PUBLIC_MAPBOX_TOKEN}
+      EXPO_PUBLIC_GOOGLE_CLIENT_ID: ${EXPO_PUBLIC_GOOGLE_CLIENT_ID:-}
+      EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID: ${EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID:-}
+      EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID: ${EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID:-}
       EXPO_TOKEN: ${EXPO_TOKEN}
     depends_on:
       - backend

--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -2,7 +2,23 @@
 
 Base URL: `http://localhost:3000/api`
 
+En Docker Compose, la API queda publicada en `http://localhost:3001/api`.
+
 ---
+
+## Salud (`/`)
+
+### GET `/ping`
+
+Comprueba que el servidor Express esta vivo.
+
+**Auth requerida:** No
+
+**Respuesta `200`:**
+
+```text
+pong
+```
 
 ## Autenticación (`/auth`)
 

--- a/docs/backend/setup.md
+++ b/docs/backend/setup.md
@@ -3,7 +3,7 @@
 ## Requisitos
 
 - Node.js 20+
-- Una instancia de Prisma Postgres en local (`npx prisma dev`)
+- PostgreSQL local, PostgreSQL de Docker Compose o Prisma Postgres (`npx prisma dev`)
 
 ## Instalacion
 
@@ -29,14 +29,21 @@ CLOUDINARY_API_SECRET=<tu_api_secret>
 
 ## Primer uso (base de datos vacia)
 
-Con `npx prisma dev` corriendo en otra terminal:
+Con `DATABASE_URL` apuntando a una base disponible:
 
 ```bash
 cd backend
-npx prisma migrate dev --name init
+npx prisma generate
+npx prisma db push
 ```
 
-Esto crea todas las tablas en la base de datos.
+Esto genera el cliente en `src/generated/prisma` y crea o actualiza las tablas segun `prisma/schema.prisma`. El repo no versiona migraciones SQL; para desarrollo y despliegue se usa `prisma db push`.
+
+Seed opcional para datos de demo:
+
+```bash
+npx prisma db seed
+```
 
 ## Arrancar en desarrollo
 
@@ -64,6 +71,17 @@ GET http://localhost:3000/ping  ->  pong
 | `npm run test:watch` | Ejecuta Vitest en modo watch |
 | `npm run test:coverage` | Ejecuta Vitest y genera cobertura en `coverage/` |
 
+## Variables obligatorias y opcionales
+
+| Variable | Obligatoria | Descripcion |
+|---|---|---|
+| `DATABASE_URL` | Si | Conexion PostgreSQL usada por Prisma. |
+| `JWT_SECRET` | Si | Firma de JWT. Usa una cadena larga y aleatoria. |
+| `GOOGLE_CLIENT_ID` | Si | Web Client ID validado por `google-auth-library`. |
+| `BACKEND_URL` | Si para correos reales | Base publica usada en enlaces de verificacion. Tiene fallback local. |
+| `EMAIL_USER` / `EMAIL_PASS` | Opcional local | SMTP para enviar magic links de verificacion. |
+| `CLOUDINARY_CLOUD_NAME` / `CLOUDINARY_API_KEY` / `CLOUDINARY_API_SECRET` | Opcional para arrancar | Requerido para subir inventario, justificantes y facturas. |
+
 ## Tests
 
 El backend usa Vitest + Supertest. La app Express vive en `src/app.ts` y se importa desde los tests sin llamar a `app.listen()` ni arrancar cron jobs reales.
@@ -79,7 +97,7 @@ Estos valores permiten importar controladores, rutas y Prisma sin depender de `.
 
 ## Despliegue en Railway
 
-Railway gestiona el build y el arranque automaticamente usando los scripts de `package.json`. En este proyecto el backend se despliega con `backend/Dockerfile`, y el contenedor ejecuta `prisma db push` antes de levantar la app.
+El backend se prueba y despliega en Railway. En este proyecto Railway usa `backend/Dockerfile` para construir la imagen; el Dockerfile compila con `npm run build` y el contenedor arranca con `npm start`.
 
 ### 1. Base de datos
 
@@ -106,11 +124,18 @@ En el servicio del backend anade:
 
 ### 4. Build y arranque automatico
 
-Railway ejecuta:
+Railway ejecuta con el Dockerfile del backend:
 
 ```text
-npm run build   -> prisma generate + tsc
-npm start       -> prisma db push + node dist/index.js
+RUN npm run build
+npm start
+```
+
+El script `npm start` ejecuta:
+
+```text
+npx prisma db push --accept-data-loss
+node dist/index.js
 ```
 
 ### 5. Cron jobs incluidos en el arranque

--- a/docs/changelog/Epica16/epica-16-issue-256-infra-despliegue.md
+++ b/docs/changelog/Epica16/epica-16-issue-256-infra-despliegue.md
@@ -1,0 +1,24 @@
+# Issue #256 - Infraestructura, entornos, despliegue y documentacion
+
+## Objetivo
+
+Dejar documentado y alineado el flujo real para instalar, ejecutar, probar y desplegar Roomies, reduciendo sorpresas entre desarrollo local, Docker Compose y Railway.
+
+## Cambios
+
+- `docker-compose.yml`: el frontend deja de apuntar siempre a produccion y toma `EXPO_PUBLIC_API_URL` desde `.env`; se pasan al backend las variables de email, Cloudinary, `BACKEND_URL` y `RESET_DB`.
+- `backend/Dockerfile`: queda orientado a Railway, compila con `npm run build` y arranca con `npm start`.
+- `docker-compose.yml`: mantiene un comando propio de desarrollo para regenerar Prisma Client y arrancar con nodemon si se revisa infraestructura local.
+- `.env.example`, `backend/.env.example` y `frontend/.env.example`: se documentan URLs locales, Google OAuth, Cloudinary, SMTP, `BACKEND_URL`, `EXPO_PUBLIC_API_URL` y `RESET_DB`.
+- `docs/infra/setup-despliegue.md`: nueva guia centralizada del flujo Railway desarrollo + Expo Go, variables, Dockerfile, Compose auxiliar, build/test/lint y Railway.
+- `README.md`, `docs/backend/setup.md`, `docs/frontend/setup.md`, `docs/backend/api.md` y `CONTEXT.md`: se alinean con los scripts y endpoints actuales.
+
+## Verificacion
+
+- `npm run build` en `backend`.
+- `npm test` en `backend`.
+- `npm run lint` en `frontend` (sin errores; quedan warnings preexistentes de hooks/variables sin uso).
+- `npm test` en `frontend`.
+- `docker compose config --quiet`.
+
+No se levanto `docker-compose up --build` para evitar dejar servicios de larga duracion corriendo durante la implementacion.

--- a/docs/frontend/setup.md
+++ b/docs/frontend/setup.md
@@ -5,6 +5,7 @@
 - Node.js 20+
 - Expo Go o una build nativa para probar la app
 - Cuenta en `expo.dev` si vas a generar builds con EAS
+- Backend desplegado en Railway desarrollo para testeo funcional diario
 
 ## Variables de entorno
 
@@ -12,9 +13,9 @@ Copia `frontend/.env.example` a `frontend/.env`.
 
 | Entorno | URL |
 |---|---|
-| Desarrollo | `https://roomies-dev.up.railway.app/api` |
+| Testeo diario | `https://roomies-dev.up.railway.app/api` |
 | Produccion | `https://roomies-production-c884.up.railway.app/api` |
-| Local | `http://<TU_IP>:3001/api` |
+| Local auxiliar | `http://localhost:3001/api` o `http://<TU_IP>:3001/api` |
 
 ```env
 EXPO_PUBLIC_API_URL=https://roomies-dev.up.railway.app/api
@@ -27,25 +28,37 @@ EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=<ios_client_id>
 
 > Las variables `EXPO_PUBLIC_*` se hornean en el bundle. Si cambian, reinicia Metro con `npx expo start --clear`.
 
-## Instalacion y arranque
+Variables obligatorias para flujos completos:
 
-### Desarrollo local
+| Variable | Obligatoria | Uso |
+|---|---|---|
+| `EXPO_PUBLIC_API_URL` | Si | Base URL de la API con sufijo `/api`. |
+| `EXPO_PUBLIC_MAPBOX_TOKEN` | Si para crear viviendas con autocompletado | Geocoding de Mapbox. |
+| `EXPO_PUBLIC_GOOGLE_CLIENT_ID` | Si para Google OAuth | Client ID web compartido con backend. |
+| `EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID` | Recomendado | Client ID Android para builds nativas. |
+| `EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID` | Opcional | Client ID iOS si se genera build iOS. |
+
+## Instalacion y testeo con Expo Go
+
+El flujo habitual es levantar solo Expo y consumir Railway desarrollo:
 
 ```bash
 cd frontend
 npm install
-npx expo start
+npx expo start --clear
 ```
 
-### Con Docker Compose
+Abre el QR desde Expo Go. No hace falta levantar backend ni base de datos local para pruebas funcionales habituales.
 
-Desde la raiz del repo:
+### Docker Compose auxiliar
+
+Docker Compose no es el flujo habitual de testeo. Si se necesita revisar integracion local de contenedores, desde la raiz del repo:
 
 ```bash
 docker-compose up --build
 ```
 
-Metro queda accesible para Expo Go en el puerto configurado por el contenedor.
+Metro queda accesible para Expo Go en `http://localhost:8080`. El compose lee `EXPO_PUBLIC_API_URL` desde el `.env` raiz; para un movil fisico debe apuntar al host LAN, por ejemplo `http://192.168.1.50:3001/api`, no a `localhost`.
 
 ## Tests y calidad
 
@@ -53,6 +66,7 @@ Frontend usa Jest Expo 54 + React Native Testing Library.
 
 ```bash
 cd frontend
+npm install
 npm test
 npm run test:watch
 npm run test:coverage

--- a/docs/infra/setup-despliegue.md
+++ b/docs/infra/setup-despliegue.md
@@ -1,0 +1,161 @@
+# Infraestructura, entornos y despliegue
+
+## Objetivo
+
+Esta guia concentra el flujo real de testeo con Expo Go contra Railway desarrollo, las variables de entorno, Dockerfile de Railway y despliegue de Roomies. Debe mantenerse alineada con:
+
+- `docker-compose.yml`
+- `.env.example`
+- `backend/.env.example`
+- `frontend/.env.example`
+- `backend/package.json`
+- `frontend/package.json`
+
+## Puertos y URLs
+
+| Servicio | URL habitual |
+|---|---|
+| Backend Railway desarrollo | `https://roomies-dev.up.railway.app/api` |
+| Backend Railway produccion | `https://roomies-production-c884.up.railway.app/api` |
+| Expo local para Expo Go | Metro generado por `npx expo start --clear` |
+
+URLs auxiliares si se revisa infraestructura local:
+
+| Servicio | Ejecucion manual | Docker Compose |
+|---|---:|---:|
+| PostgreSQL | `localhost:5433` | `localhost:5433 -> db:5432` |
+| Backend API | `http://localhost:3000` | `http://localhost:3001` |
+| Frontend Expo/Metro | `http://localhost:8081` por defecto de Expo | `http://localhost:8080` |
+
+## Variables de entorno
+
+### Frontend `.env` para Expo Go
+
+El flujo normal de testeo usa `frontend/.env` con Railway desarrollo:
+
+```env
+EXPO_PUBLIC_API_URL=https://roomies-dev.up.railway.app/api
+EXPO_PUBLIC_MAPBOX_TOKEN=pk.ey...
+EXPO_PUBLIC_GOOGLE_CLIENT_ID=<web_client_id>
+EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID=<android_client_id>
+EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=
+```
+
+| Variable | Obligatoria | Uso |
+|---|---|---|
+| `EXPO_PUBLIC_API_URL` | Si | API Railway desarrollo para testeo diario o produccion para builds release. |
+| `EXPO_PUBLIC_MAPBOX_TOKEN` | Si para autocompletado | Token publico de Mapbox. |
+| `EXPO_PUBLIC_GOOGLE_CLIENT_ID` | Si para Google OAuth | Web Client ID usado por Expo. |
+| `EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID` | Recomendado | Client ID Android. |
+| `EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID` | Opcional | Client ID iOS. |
+
+Cualquier cambio requiere reiniciar Metro con cache limpia:
+
+```bash
+npx expo start --clear
+```
+
+## Testeo diario
+
+1. Comprueba que los cambios de backend esten desplegados en Railway desarrollo.
+2. En `frontend/.env`, apunta a:
+
+```env
+EXPO_PUBLIC_API_URL=https://roomies-dev.up.railway.app/api
+```
+
+3. Arranca Expo:
+
+```bash
+cd frontend
+npx expo start --clear
+```
+
+4. Abre la app desde Expo Go y valida contra Railway desarrollo.
+
+## Docker Compose opcional
+
+`docker-compose.yml` no es el flujo habitual de testeo. Queda para revisar integracion local si alguna vez hace falta levantar PostgreSQL, backend y Metro en contenedores.
+
+Si se usa, copia `.env.example` a `.env`, ajusta las variables y ejecuta:
+
+```bash
+docker-compose up --build
+```
+
+El servicio `backend` de Compose sobreescribe el comando de la imagen de Railway para trabajar en modo desarrollo:
+
+1. `npx prisma generate`
+2. `npx prisma db push --accept-data-loss`
+3. `npm run dev`
+
+Si `RESET_DB=true`, ejecuta `npx prisma db push --force-reset` y `npx prisma db seed` antes de arrancar.
+
+## Backend local opcional
+
+No se usa para testeo funcional diario, pero sirve para compilar o depurar una incidencia concreta:
+
+```bash
+cd backend
+npm install
+cp .env.example .env
+npx prisma generate
+npx prisma db push
+npm run dev
+```
+
+## Build, tests y calidad
+
+Backend:
+
+```bash
+cd backend
+npm run build
+npm test
+```
+
+Frontend:
+
+```bash
+cd frontend
+npm run lint
+npm test
+```
+
+## Despliegue
+
+### Backend Railway
+
+El backend se despliega con `backend/Dockerfile`; Railway lo usa para construir la imagen. Configura el servicio con root directory `/backend` y variables:
+
+- `DATABASE_URL`
+- `JWT_SECRET`
+- `GOOGLE_CLIENT_ID`
+- `BACKEND_URL`
+- `EMAIL_USER`
+- `EMAIL_PASS`
+- `CLOUDINARY_CLOUD_NAME`
+- `CLOUDINARY_API_KEY`
+- `CLOUDINARY_API_SECRET`
+
+El Dockerfile ejecuta `npm run build`. Al arrancar, `npm start` aplica `npx prisma db push --accept-data-loss` y levanta `node dist/index.js`.
+
+### Frontend EAS
+
+`frontend/eas.json` define perfiles `preview` y `production` con URL de produccion. Para cambiar entorno de build, ajusta `EXPO_PUBLIC_API_URL` y los client IDs de Google en el perfil correspondiente.
+
+```bash
+cd frontend
+eas build --platform android --profile preview
+```
+
+## Archivos ignorados
+
+No versionar secretos ni artefactos locales:
+
+- `.env`, `.env.local`, `.env.*.local`
+- `node_modules/`
+- `backend/dist/`
+- `coverage/`
+- `frontend/.expo/`, `frontend/dist/`, `frontend/web-build/`
+- carpetas nativas generadas `frontend/ios` y `frontend/android`

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,3 +1,9 @@
 node_modules
 .expo
 .env
+.env.local
+.env.*.local
+dist
+web-build
+coverage
+npm-debug.*

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -12,6 +12,10 @@
 
 # Desarrollo local (Docker Compose en la misma máquina/red)
 #EXPO_PUBLIC_API_URL=http://192.168.1.X:3001/api
+# Android emulator:
+#EXPO_PUBLIC_API_URL=http://10.0.2.2:3001/api
+# Web/local en la misma maquina:
+#EXPO_PUBLIC_API_URL=http://localhost:3001/api
 
 EXPO_PUBLIC_API_URL=https://roomies-dev.up.railway.app/api
 


### PR DESCRIPTION
## Summary
- Alinea el flujo de testeo con Expo Go contra Railway desarrollo.
- Actualiza Dockerfile para construir la imagen del backend usada por Railway.
- Ajusta Docker Compose como soporte auxiliar local, no como flujo principal de pruebas.
- Documenta variables de entorno, URLs por entorno, setup, build y despliegue.
- Actualiza changelog en `docs/changelog/Epica16/epica-16-issue-256-infra-despliegue.md`.

## Testing
- `npm run build` en `backend`.
- `npm test` en `backend`.
- `npm run lint` en `frontend`.
- `npm test` en `frontend`.
- `docker compose config --quiet`.