### PR TITLE
Add [Épica 16] suite de regresión final y checklist de release

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -674,6 +674,12 @@ Usuarios de prueba creados por `prisma db seed`:
 - `.env.example`, `backend/.env.example` y `frontend/.env.example` documentan variables obligatorias, opcionales, URLs locales y tokens por entorno.
 - `docs/infra/setup-despliegue.md` concentra el flujo Railway desarrollo + Expo Go, Dockerfile, Compose auxiliar y comandos de build/test/lint.
 
+## Update 2026-04-12 - Epica 16 issue 257
+
+- `backend/tests/release-regression.test.ts` cubre una regresion final de rutas principales protegidas, payloads publicos de auth y cron de recordatorios tolerante a fallos de proveedor externo.
+- `frontend/app/__tests__/navigation-smoke.test.tsx` valida las tabs principales de casero, inquilino y detalle de vivienda, incluyendo ocultacion de modulos desactivados.
+- `docs/release/epica-16-regresion-final.md` centraliza checklist manual de release, matriz archivo -> issue -> estado, cobertura automatica por flujo y riesgos residuales.
+
 ## Update 2026-04-10 - Cobros, mensualidades y push (Epica 12)
 
 - Backend:

--- a/backend/tests/release-regression.test.ts
+++ b/backend/tests/release-regression.test.ts
@@ -1,0 +1,110 @@
+import assert from 'node:assert/strict';
+import request from 'supertest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const prisma = vi.hoisted(() => ({
+  deuda: {
+    findMany: vi.fn(),
+  },
+}));
+
+const enviarNotificacion = vi.hoisted(() => vi.fn());
+
+vi.mock('../src/lib/prisma', () => ({ prisma }));
+vi.mock('../src/services/push.service', () => ({ enviarNotificacion }));
+
+const app = (await import('../src/app')).default;
+const { enviarRecordatoriosMorosos } = await import('../src/cron/recordatorios.cron');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+type MetodoHttp = 'get' | 'post' | 'patch' | 'put' | 'delete';
+
+const rutasProtegidas: Array<{
+  metodo: MetodoHttp;
+  ruta: string;
+  flujo: string;
+}> = [
+  { metodo: 'get', ruta: '/api/auth/me', flujo: 'restauracion de sesion' },
+  { metodo: 'patch', ruta: '/api/auth/rol', flujo: 'seleccion de rol' },
+  { metodo: 'get', ruta: '/api/viviendas', flujo: 'casero lista viviendas' },
+  { metodo: 'post', ruta: '/api/viviendas', flujo: 'casero crea vivienda' },
+  { metodo: 'get', ruta: '/api/viviendas/1', flujo: 'casero consulta vivienda' },
+  { metodo: 'post', ruta: '/api/viviendas/1/habitaciones', flujo: 'casero crea habitacion' },
+  { metodo: 'post', ruta: '/api/inquilino/unirse', flujo: 'inquilino se une con codigo' },
+  { metodo: 'get', ruta: '/api/inquilino/vivienda', flujo: 'inquilino consulta vivienda' },
+  { metodo: 'delete', ruta: '/api/inquilino/habitacion', flujo: 'inquilino abandona vivienda' },
+  { metodo: 'get', ruta: '/api/incidencias', flujo: 'incidencias listar' },
+  { metodo: 'post', ruta: '/api/incidencias', flujo: 'incidencias crear' },
+  { metodo: 'patch', ruta: '/api/incidencias/1/estado', flujo: 'incidencias editar estado' },
+  { metodo: 'get', ruta: '/api/anuncios', flujo: 'tablon listar' },
+  { metodo: 'post', ruta: '/api/anuncios', flujo: 'tablon crear' },
+  { metodo: 'delete', ruta: '/api/anuncios/1', flujo: 'tablon eliminar' },
+  { metodo: 'get', ruta: '/api/viviendas/1/limpieza/zonas', flujo: 'limpieza listar zonas' },
+  { metodo: 'post', ruta: '/api/viviendas/1/limpieza/zonas', flujo: 'limpieza crear zona' },
+  { metodo: 'post', ruta: '/api/viviendas/1/limpieza/generar', flujo: 'limpieza generar turno' },
+  { metodo: 'patch', ruta: '/api/viviendas/1/limpieza/turnos/1/hecho', flujo: 'limpieza marcar estado' },
+  { metodo: 'get', ruta: '/api/viviendas/1/gastos', flujo: 'gastos listar' },
+  { metodo: 'post', ruta: '/api/viviendas/1/gastos', flujo: 'gastos crear y repartir' },
+  { metodo: 'get', ruta: '/api/viviendas/1/deudas', flujo: 'deudas listar' },
+  { metodo: 'patch', ruta: '/api/viviendas/1/deudas/1/saldar', flujo: 'deudas saldar' },
+  { metodo: 'get', ruta: '/api/viviendas/1/cobros', flujo: 'cobros consultar' },
+  { metodo: 'get', ruta: '/api/viviendas/1/gastos-recurrentes', flujo: 'mensualidades listar' },
+  { metodo: 'post', ruta: '/api/viviendas/1/gastos-recurrentes', flujo: 'mensualidades crear' },
+  { metodo: 'get', ruta: '/api/viviendas/1/inventario', flujo: 'inventario listar' },
+  { metodo: 'post', ruta: '/api/viviendas/1/inventario', flujo: 'inventario crear item' },
+  { metodo: 'patch', ruta: '/api/inventario/1/conformidad', flujo: 'inventario conformidad' },
+  { metodo: 'patch', ruta: '/api/usuarios/me/push-token', flujo: 'push token actual' },
+  { metodo: 'put', ruta: '/api/usuarios/push-token', flujo: 'push token legacy' },
+];
+
+const ejecutarRuta = (metodo: MetodoHttp, ruta: string) => request(app)[metodo](ruta);
+
+describe('regresion final backend', () => {
+  test.each(rutasProtegidas)('$flujo exige autenticacion y no devuelve 404', async ({ metodo, ruta }) => {
+    const response = await ejecutarRuta(metodo, ruta);
+
+    expect(response.status).toBe(401);
+    expect(response.body.error).toMatch(/token/i);
+  });
+
+  test.each([
+    ['/api/auth/register', 'registro'],
+    ['/api/auth/login', 'login'],
+    ['/api/auth/google', 'login google'],
+  ])('%s valida payload publico de %s', async (ruta) => {
+    const response = await request(app).post(ruta).send({});
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toMatch(/invalid/i);
+  });
+
+  test('el cron de recordatorios sigue procesando deudas aunque falle un envio externo', async () => {
+    prisma.deuda.findMany.mockResolvedValueOnce([
+      {
+        id: 1,
+        importe: 25,
+        deudor: { expo_push_token: 'ExponentPushToken[uno]' },
+        acreedor: { id: 10, nombre: 'Ada', apellidos: 'Lovelace' },
+      },
+      {
+        id: 2,
+        importe: 10.5,
+        deudor: { expo_push_token: 'ExponentPushToken[dos]' },
+        acreedor: { id: 11, nombre: 'Grace', apellidos: null },
+      },
+    ]);
+    enviarNotificacion.mockRejectedValueOnce(new Error('expo caido'));
+    enviarNotificacion.mockResolvedValueOnce(undefined);
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await enviarRecordatoriosMorosos();
+
+    assert.equal(enviarNotificacion.mock.calls.length, 2);
+    assert.equal(enviarNotificacion.mock.calls[0][0], 'ExponentPushToken[uno]');
+    assert.equal(enviarNotificacion.mock.calls[1][0], 'ExponentPushToken[dos]');
+    consoleError.mockRestore();
+  });
+});

--- a/docs/changelog/Epica16/epica-16-issue-257-regresion-release.md
+++ b/docs/changelog/Epica16/epica-16-issue-257-regresion-release.md
@@ -1,0 +1,22 @@
+# Issue #257 - Regresion final y checklist de release
+
+## Objetivo
+
+Cerrar la Epica 16 con una suite de regresion final, checklist manual de producto, matriz de trazabilidad por archivo e informe de riesgos residuales.
+
+## Cambios
+
+- `backend/tests/release-regression.test.ts`: nueva suite smoke de rutas principales protegidas, validacion de payloads publicos de auth y prueba de cron de recordatorios que no se detiene si falla un envio externo.
+- `frontend/app/__tests__/navigation-smoke.test.tsx`: nueva suite smoke de tabs principales para casero, inquilino y detalle de vivienda, incluyendo ocultacion de modulos desactivados.
+- `docs/release/epica-16-regresion-final.md`: checklist manual de release, matriz final archivo -> issue responsable -> estado, cobertura automatica por flujo y riesgos residuales.
+- `docs/changelog/Epica16/epica-16-issue-257-regresion-release.md`: changelog del cierre de epica.
+
+## Verificacion esperada
+
+- `npm test` en `backend`.
+- `npm run build` en `backend`.
+- `npm test` en `frontend`.
+- `npm run lint` en `frontend`.
+- `docker compose config --quiet` desde la raiz.
+
+Los resultados finales deben adjuntarse en la PR junto al checklist manual de `docs/release/epica-16-regresion-final.md`.

--- a/docs/release/epica-16-regresion-final.md
+++ b/docs/release/epica-16-regresion-final.md
@@ -1,0 +1,95 @@
+# Epica 16 - Regresion final y checklist de release
+
+## Objetivo
+
+Cerrar la revision integral de calidad con una comprobacion transversal de los flujos principales, dejando trazabilidad entre archivos revisados, issues responsables, estado y riesgos residuales.
+
+## Scripts acordados
+
+| Area | Comando | Objetivo |
+|---|---|---|
+| Backend | `npm test` | Ejecuta Vitest, Supertest y smoke tests finales de rutas/cron. |
+| Backend | `npm run build` | Regenera Prisma Client y compila TypeScript. |
+| Frontend | `npm test` | Ejecuta Jest Expo y smoke tests finales de navegacion. |
+| Frontend | `npm run lint` | Revisa reglas Expo/ESLint. |
+| Infra | `docker compose config --quiet` | Valida la configuracion Compose sin levantar servicios. |
+
+## Checklist manual de producto
+
+Usar Railway desarrollo como backend y Expo Go o build nativa segun el modulo a revisar. Marcar cada punto en la PR con OK, N/A o issue de seguimiento.
+
+| Flujo | Validacion manual minima | Estado |
+|---|---|---|
+| Registro | Crear usuario manual con email nuevo y verificar que vuelve al login sin token filtrado. | Pendiente PR |
+| Login | Login correcto por rol y error visible con credenciales invalidas. | Pendiente PR |
+| Logout | Cerrar sesion desde perfil y confirmar vuelta a `/`. | Pendiente PR |
+| Restauracion de sesion | Reabrir app con token valido e invalido; validar dashboard por rol y limpieza de token invalido. | Pendiente PR |
+| Casero crea vivienda | Crear vivienda con dormitorios y zonas comunes; comprobar lista y detalle. | Pendiente PR |
+| Casero crea habitacion | Crear y editar dormitorio con precio privado; crear zona comun sin precio. | Pendiente PR |
+| Inquilino se une con codigo | Canjear codigo sin prefijo `ROOM-`; verificar que no se expone el nuevo codigo. | Pendiente PR |
+| Consulta de vivienda | Casero ve su vivienda; inquilino ve su habitacion, zonas comunes y no ve precios/codigos privados ajenos. | Pendiente PR |
+| Incidencias | Crear, listar, abrir detalle y cambiar estado solo con permisos backend. | Pendiente PR |
+| Tablon | Crear, listar y eliminar anuncio cuando el rol/pertenencia lo permite. | Pendiente PR |
+| Limpieza | Configurar zona, generar turnos y marcar turno como hecho con modulo activo. | Pendiente PR |
+| Gastos | Crear gasto, revisar reparto, listar deuda y saldar como deudor. | Pendiente PR |
+| Inventario | Crear item, verlo como inquilino y marcar conformidad. | Pendiente PR |
+| Push | Registrar token en build compatible; confirmar que fallos de proveedor no bloquean login/anuncios. | Pendiente PR |
+| Cron | Ejecutar/revisar cron de mensualidades y recordatorios con logs controlados y sin romper si Expo falla. | Pendiente PR |
+
+## Cobertura automatica de regresion
+
+| Flujo minimo | Cobertura automatica |
+|---|---|
+| Registro, login y Google OAuth | `backend/tests/release-regression.test.ts` valida payloads invalidos en rutas publicas; `frontend/app/__tests__/index.test.tsx` cubre login correcto/error. |
+| Logout y restauracion de sesion | `frontend/app/__tests__/_layout.test.tsx` cubre restauracion y limpieza de token; logout queda en checklist manual. |
+| Casero crea vivienda y habitacion | `backend/tests/release-regression.test.ts` valida rutas protegidas de vivienda/habitacion; checklist manual cubre persistencia real. |
+| Inquilino se une con codigo | `backend/tests/multitenant-security.test.ts` cubre burn-after-reading; `backend/tests/release-regression.test.ts` cubre ruta. |
+| Consulta sin datos privados | `backend/tests/multitenant-security.test.ts` cubre precio/codigo privado; smoke final cubre rutas. |
+| Incidencias | `backend/tests/operational-modules.test.ts`, `frontend/app/incidencia/__tests__/detalle.test.tsx` y smoke final. |
+| Tablon | `backend/tests/multitenant-security.test.ts`, `backend/tests/operational-modules.test.ts` y smoke final. |
+| Limpieza | `backend/tests/limpieza.service.test.ts`, `backend/tests/operational-modules.test.ts` y smoke final. |
+| Gastos/deudas/cobros | `backend/tests/economico.test.ts` y smoke final. |
+| Inventario | `backend/tests/operational-modules.test.ts` y smoke final. |
+| Push y cron | `backend/tests/operational-modules.test.ts` cubre push fire-and-forget; `backend/tests/release-regression.test.ts` cubre cron tolerante a fallo externo. |
+| Navegacion principal | `frontend/app/__tests__/navigation-smoke.test.tsx` cubre tabs de casero, inquilino y vivienda. |
+
+## Matriz final archivo -> issue -> estado
+
+| Alcance | Archivos | Issue responsable | Estado |
+|---|---|---|---|
+| Infra de tests | `backend/package.json`, `frontend/package.json`, `backend/tests/setup.ts`, `frontend/jest.setup.js` | #246 | Cubierto |
+| App Express testeable | `backend/src/app.ts`, `backend/src/index.ts` | #246 | Cubierto |
+| Auth backend | `backend/src/controllers/auth.controller.ts`, `backend/src/routes/auth.routes.ts`, `backend/src/middlewares/auth.middleware.ts`, `backend/src/schemas/auth.schema.ts`, `backend/src/services/email.service.ts` | #247 | Cubierto |
+| Sesion frontend | `frontend/app/_layout.tsx`, `frontend/app/index.tsx`, `frontend/app/registro.tsx`, `frontend/app/rol.tsx`, `frontend/services/auth.service.ts`, `frontend/utils/authRoutes.ts`, `frontend/utils/notifications.ts` | #252 | Cubierto |
+| Usuarios y push token | `backend/src/controllers/user.controller.ts`, `backend/src/routes/user.routes.ts`, `frontend/utils/notifications.ts` | #247 / #252 | Cubierto |
+| Multi-tenant viviendas | `backend/src/controllers/vivienda.controller.ts`, `backend/src/routes/vivienda.routes.ts`, `backend/src/controllers/inquilino.controller.ts`, `backend/src/routes/inquilino.routes.ts`, `backend/src/utils/generarCodigo.ts` | #248 | Cubierto |
+| Parametros dinamicos | `frontend/hooks/useViviendaIdParam.ts`, `frontend/utils/viviendaParams.ts`, `frontend/utils/viviendaModules.ts` | #248 / #252 | Cubierto |
+| Prisma y seed | `backend/prisma/schema.prisma`, `backend/prisma/seed.ts`, `backend/prisma.config.ts` | #249 | Cubierto |
+| Gastos y deudas | `backend/src/controllers/gasto.controller.ts`, `backend/src/controllers/gasto-recurrente.controller.ts`, `backend/src/controllers/deuda.controller.ts`, `backend/src/controllers/cobros.controller.ts`, `backend/src/services/gasto.service.ts`, `backend/src/routes/gasto.routes.ts`, `backend/src/routes/gasto-recurrente.routes.ts`, `backend/src/routes/deuda.routes.ts` | #250 | Cubierto |
+| Cron economico | `backend/src/services/cron.service.ts`, `backend/src/cron/mensualidades.cron.ts`, `backend/src/cron/recordatorios.cron.ts` | #250 / #257 | Cubierto |
+| Limpieza | `backend/src/controllers/limpieza.controller.ts`, `backend/src/services/limpieza.service.ts`, `backend/src/routes/limpieza.routes.ts`, `frontend/app/casero/vivienda/[id]/(tabs)/limpieza.tsx`, `frontend/app/inquilino/(tabs)/limpieza.tsx` | #251 | Cubierto |
+| Inventario | `backend/src/controllers/inventario.controller.ts`, `backend/src/routes/inventario.routes.ts`, `backend/src/config/cloudinary.config.ts`, `frontend/app/casero/(tabs)/inventario.tsx`, `frontend/app/inquilino/(tabs)/inventario.tsx` | #251 | Cubierto |
+| Incidencias | `backend/src/controllers/incidencia.controller.ts`, `backend/src/routes/incidencia.routes.ts`, `frontend/app/incidencia/[id].tsx`, `frontend/app/inquilino/nueva-incidencia.tsx`, tabs de incidencias del casero | #251 / #254 | Cubierto |
+| Tablon | `backend/src/controllers/anuncio.controller.ts`, `backend/src/routes/anuncio.routes.ts`, `frontend/app/casero/(tabs)/tablon.tsx`, `frontend/app/casero/vivienda/[id]/(tabs)/tablon.tsx`, `frontend/app/inquilino/(tabs)/tablon.tsx`, `frontend/app/tablon/[viviendaId].tsx` | #251 / #254 | Cubierto |
+| Pantallas casero | `frontend/app/casero/**`, `frontend/styles/casero/**`, `frontend/components/casero/**` | #253 | Cubierto |
+| Pantallas inquilino | `frontend/app/inquilino/**`, `frontend/styles/inquilino/**` | #254 | Cubierto |
+| Sistema visual | `frontend/constants/theme.ts`, `frontend/constants/toastConfig.tsx`, `frontend/components/common/**`, `frontend/styles/**`, `docs/frontend/visual-quality.md` | #255 | Cubierto |
+| Infra/despliegue | `docker-compose.yml`, `.env.example`, `backend/.env.example`, `frontend/.env.example`, `backend/Dockerfile`, `frontend/app.json`, `frontend/eas.json`, `README.md`, `docs/infra/setup-despliegue.md` | #256 | Cubierto |
+| Documentacion backend/frontend | `docs/backend/**`, `docs/frontend/**`, `CONTEXT.md` | #256 / #257 | Cubierto |
+| Regresion final | `backend/tests/release-regression.test.ts`, `frontend/app/__tests__/navigation-smoke.test.tsx`, `docs/release/epica-16-regresion-final.md` | #257 | Cubierto |
+
+## Riesgos residuales
+
+| Riesgo | Decision |
+|---|---|
+| Push real no se valida en Expo Go. | Documentado: requiere build nativa o development build. Checklist manual obliga a validarlo en entorno compatible antes de release. |
+| Tests smoke no sustituyen E2E con base real. | Decision documentada: se cubren rutas, permisos y servicios criticos con mocks; persistencia real queda en checklist manual contra Railway desarrollo. |
+| Mojibake historico visible en algunos textos/docs. | Revisado en #255 y documentado como deuda de limpieza continua si aparece en areas no tocadas. |
+| Importes usan `Float` en Prisma. | Revisado en #250; no se migra en esta epica por riesgo de cambio de datos, se mantiene test de centimos y decision documentada. |
+| Docker Compose no se levanta durante la suite automatica. | Se valida `docker compose config --quiet`; levantar servicios queda como paso manual opcional por coste y duracion. |
+
+## Resumen para PR
+
+- Backend: smoke final de rutas principales protegidas, validacion de payloads publicos de auth y cron de recordatorios tolerante a fallos externos.
+- Frontend: smoke final de navegacion principal para tabs de casero, inquilino y detalle de vivienda.
+- Release: checklist manual, matriz final de trazabilidad por archivo/issue y riesgos residuales documentados.

--- a/frontend/app/__tests__/navigation-smoke.test.tsx
+++ b/frontend/app/__tests__/navigation-smoke.test.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
+import CaseroTabsLayout from '../casero/(tabs)/_layout';
+import InquilinoTabsLayout from '../inquilino/(tabs)/_layout';
+import ViviendaTabsLayout from '../casero/vivienda/[id]/(tabs)/_layout';
+
+const mockApiGet = jest.fn();
+const mockBack = jest.fn();
+const mockCreateElement = React.createElement;
+const mockFragment = React.Fragment;
+const mockUseEffect = React.useEffect;
+const mockScreens: { name: string; options: Record<string, unknown> }[] = [];
+
+jest.mock('expo-router', () => {
+  function MockTabs({ children }: { children: React.ReactNode }) {
+    return mockCreateElement(mockFragment, null, children);
+  }
+
+  MockTabs.Screen = function MockTabsScreen({
+    name,
+    options,
+  }: {
+    name: string;
+    options: Record<string, unknown>;
+  }) {
+    mockScreens.push({ name, options });
+    return null;
+  };
+
+  return {
+    Tabs: MockTabs,
+    useRouter: () => ({ back: mockBack }),
+    usePathname: () => '/casero/vivienda/42/limpieza',
+    useLocalSearchParams: () => ({ id: '42' }),
+    useFocusEffect: (callback: () => void | (() => void)) => {
+      mockUseEffect(() => callback(), [callback]);
+    },
+  };
+});
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: function MockIonicons() {
+    return null;
+  },
+}));
+
+jest.mock('@/services/api', () => ({
+  get: (...args: unknown[]) => mockApiGet(...args),
+}));
+
+function ultimaScreen(nombre: string) {
+  const screen = [...mockScreens].reverse().find((item) => item.name === nombre);
+  if (!screen) {
+    throw new Error(`No se renderizo la tab ${nombre}`);
+  }
+
+  return screen;
+}
+
+describe('smoke navegacion principal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockScreens.length = 0;
+  });
+
+  it('renderiza tabs del casero y oculta modulos sin viviendas activas', async () => {
+    mockApiGet.mockResolvedValueOnce({
+      data: [{ mod_gastos: true, mod_inventario: false }],
+    });
+
+    render(<CaseroTabsLayout />);
+
+    await waitFor(() => {
+      expect(mockApiGet).toHaveBeenCalledWith('/viviendas');
+    });
+    expect(ultimaScreen('viviendas').options.title).toBe('Viviendas');
+    expect(ultimaScreen('cobros').options.href).toBeUndefined();
+    expect(ultimaScreen('inventario').options.href).toBeNull();
+    expect(ultimaScreen('tablon').options.href).toBeNull();
+    expect(ultimaScreen('perfil').options.title).toBe('Perfil');
+  });
+
+  it('renderiza tabs del inquilino segun modulos de su vivienda', async () => {
+    mockApiGet.mockResolvedValueOnce({
+      data: {
+        vivienda: {
+          mod_limpieza: true,
+          mod_gastos: true,
+          mod_inventario: false,
+        },
+      },
+    });
+
+    render(<InquilinoTabsLayout />);
+
+    await waitFor(() => {
+      expect(mockApiGet).toHaveBeenCalledWith('/inquilino/vivienda');
+    });
+    expect(ultimaScreen('inicio').options.title).toBe('Vivienda');
+    expect(ultimaScreen('tablon').options.href).toBeUndefined();
+    expect(ultimaScreen('limpieza').options.href).toBeUndefined();
+    expect(ultimaScreen('gastos').options.href).toBeUndefined();
+    expect(ultimaScreen('inventario').options.href).toBeNull();
+    expect(ultimaScreen('perfil').options.title).toBe('Perfil');
+  });
+
+  it('renderiza tabs internos de vivienda usando el id estable de la ruta', async () => {
+    mockApiGet.mockResolvedValueOnce({
+      data: {
+        mod_limpieza: false,
+        mod_gastos: true,
+        mod_inventario: true,
+      },
+    });
+
+    render(<ViviendaTabsLayout />);
+
+    await waitFor(() => {
+      expect(mockApiGet).toHaveBeenCalledWith('/viviendas/42');
+    });
+    expect(ultimaScreen('index').options.title).toBe('Resumen');
+    expect(ultimaScreen('incidencias').options.title).toBe('Incidencias');
+    expect(ultimaScreen('tablon').options.title).toBe('Tablón');
+    expect(ultimaScreen('limpieza').options.href).toBeNull();
+    expect(ultimaScreen('opciones').options.title).toBe('Opciones');
+  });
+});


### PR DESCRIPTION
## Summary
* Añade smoke tests finales de backend para rutas principales, auth pública y cron tolerante a fallos externos.
* Añade smoke tests de frontend para navegación principal de casero, inquilino y detalle de vivienda.
* Documenta checklist manual de release, matriz archivo -> issue -> estado y riesgos residuales.
* Actualiza contexto y changelog en `docs/changelog/Epica16/epica-16-issue-257-regresion-release.md`.

## Testing
* `npm test` en `backend`.
* `npm run build` en `backend`.
* `npm test` en `frontend`.
* `npm run lint` en `frontend`.
* `docker compose config --quiet`.