### PR TITLE
Add exportación de limpiezas a Excel

### DIFF
--- a/backend/src/controllers/limpieza.controller.ts
+++ b/backend/src/controllers/limpieza.controller.ts
@@ -2,6 +2,106 @@ import express from 'express';
 import { prisma } from '../lib/prisma';
 import { generarTurnosSemanales } from '../services/limpieza.service';
 
+type EstadoTurnoExport = 'PENDIENTE' | 'HECHO' | 'NO_HECHO';
+
+const ESTADOS_EXPORTABLES = new Set<EstadoTurnoExport>(['PENDIENTE', 'HECHO', 'NO_HECHO']);
+const CABECERAS_EXPORTACION = [
+  'Vivienda',
+  'Habitacion o zona',
+  'Fecha inicio',
+  'Fecha fin',
+  'Estado',
+  'Responsable asignado',
+  'Completado por',
+  'Observaciones',
+  'Fecha de validacion',
+];
+
+const normalizarFechaDia = (valor: unknown, finalDia = false) => {
+  if (typeof valor !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(valor)) return null;
+  const fecha = new Date(`${valor}T${finalDia ? '23:59:59.999' : '00:00:00.000'}`);
+  return Number.isNaN(fecha.getTime()) ? null : fecha;
+};
+
+const obtenerSemanaDesdeFecha = (valor: unknown) => {
+  const base = normalizarFechaDia(valor);
+  if (!base) return null;
+
+  const offset = (base.getDay() + 6) % 7;
+  const lunes = new Date(base);
+  lunes.setDate(base.getDate() - offset);
+  lunes.setHours(0, 0, 0, 0);
+
+  const domingo = new Date(lunes);
+  domingo.setDate(lunes.getDate() + 6);
+  domingo.setHours(23, 59, 59, 999);
+
+  return { inicio: lunes, fin: domingo };
+};
+
+const formatearFechaCsv = (fecha: Date | string | null | undefined) => {
+  if (!fecha) return '';
+  const fechaObj = typeof fecha === 'string' ? new Date(fecha) : fecha;
+  if (Number.isNaN(fechaObj.getTime())) return '';
+
+  return fechaObj.toLocaleDateString('es-ES', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+};
+
+const nombreCompleto = (usuario: { nombre: string; apellidos: string | null }) =>
+  `${usuario.nombre}${usuario.apellidos ? ` ${usuario.apellidos}` : ''}`;
+
+const escaparCsv = (valor: unknown) => {
+  const texto = String(valor ?? '');
+  const seguro = /^[=+\-@]/.test(texto) ? `'${texto}` : texto;
+  return `"${seguro.replace(/"/g, '""')}"`;
+};
+
+const limpiarNombreArchivo = (valor: string) =>
+  valor
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48);
+
+const generarCsvLimpiezas = (
+  filas: Array<{
+    vivienda: string;
+    zonaHabitacion: string;
+    fechaInicio: Date;
+    fechaFin: Date;
+    estado: string;
+    responsable: string;
+    completadoPor: string;
+  }>,
+) => {
+  const lineas = [
+    CABECERAS_EXPORTACION.map(escaparCsv).join(';'),
+    ...filas.map((fila) =>
+      [
+        fila.vivienda,
+        fila.zonaHabitacion,
+        formatearFechaCsv(fila.fechaInicio),
+        formatearFechaCsv(fila.fechaFin),
+        fila.estado,
+        fila.responsable,
+        fila.completadoPor,
+        '',
+        '',
+      ]
+        .map(escaparCsv)
+        .join(';'),
+    ),
+  ];
+
+  return `\uFEFF${lineas.join('\r\n')}`;
+};
+
 const verificarPropiedadVivienda = async (viviendaId: number, caseroId: number) => {
   const vivienda = await prisma.vivienda.findUnique({ where: { id: viviendaId } });
   if (!vivienda || vivienda.casero_id !== caseroId) return null;
@@ -235,6 +335,111 @@ export const obtenerTurnos: express.RequestHandler = async (req, res) => {
   });
 
   res.json(turnos);
+};
+
+export const exportarTurnos: express.RequestHandler = async (req, res) => {
+  const viviendaId = parseInt(req.params['id'] as string, 10);
+  const usuarioId = req.usuario!.id;
+
+  const vivienda = await prisma.vivienda.findFirst({
+    where: {
+      id: viviendaId,
+      OR: [
+        { casero_id: usuarioId },
+        { habitaciones: { some: { inquilino_id: usuarioId } } },
+      ],
+    },
+    select: { id: true, alias_nombre: true },
+  });
+
+  if (!vivienda) {
+    res.status(403).json({ error: 'No tienes acceso a esta vivienda.' });
+    return;
+  }
+
+  const estado = typeof req.query['estado'] === 'string' ? req.query['estado'].toUpperCase() : undefined;
+  if (estado && !ESTADOS_EXPORTABLES.has(estado as EstadoTurnoExport)) {
+    res.status(400).json({ error: 'estado no valido para exportar limpiezas.' });
+    return;
+  }
+
+  const fechaDesde = normalizarFechaDia(req.query['fechaDesde']);
+  const fechaHasta = normalizarFechaDia(req.query['fechaHasta'], true);
+  const semana = !fechaDesde && !fechaHasta ? obtenerSemanaDesdeFecha(req.query['fecha']) : null;
+
+  if (req.query['fecha'] && !semana) {
+    res.status(400).json({ error: 'Usa fecha con formato YYYY-MM-DD.' });
+    return;
+  }
+
+  if ((req.query['fechaDesde'] && !fechaDesde) || (req.query['fechaHasta'] && !fechaHasta)) {
+    res.status(400).json({ error: 'Usa fechas con formato YYYY-MM-DD.' });
+    return;
+  }
+
+  const inicio = fechaDesde ?? semana?.inicio;
+  const fin = fechaHasta ?? semana?.fin;
+
+  if (inicio && fin && inicio > fin) {
+    res.status(400).json({ error: 'fechaDesde no puede ser posterior a fechaHasta.' });
+    return;
+  }
+
+  const turnos = await prisma.turnoLimpieza.findMany({
+    where: {
+      zona: { vivienda_id: viviendaId },
+      ...(estado ? { estado: estado as EstadoTurnoExport } : {}),
+      ...(inicio || fin
+        ? {
+            fecha_inicio: {
+              ...(inicio ? { gte: inicio } : {}),
+              ...(fin ? { lte: fin } : {}),
+            },
+          }
+        : {}),
+    },
+    include: {
+      zona: { select: { nombre: true } },
+      usuario: {
+        select: {
+          nombre: true,
+          apellidos: true,
+          habitacion: { select: { nombre: true, vivienda_id: true } },
+        },
+      },
+    },
+    orderBy: [{ fecha_inicio: 'asc' }, { usuario: { nombre: 'asc' } }, { zona: { nombre: 'asc' } }],
+  });
+
+  if (turnos.length === 0) {
+    res.status(404).json({ error: 'No hay limpiezas para exportar con los filtros actuales.' });
+    return;
+  }
+
+  const filas = turnos.map((turno) => {
+    const responsable = nombreCompleto(turno.usuario);
+    const habitacion =
+      turno.usuario.habitacion?.vivienda_id === viviendaId ? turno.usuario.habitacion.nombre : null;
+
+    return {
+      vivienda: vivienda.alias_nombre,
+      zonaHabitacion: habitacion ? `${habitacion} - ${turno.zona.nombre}` : turno.zona.nombre,
+      fechaInicio: turno.fecha_inicio,
+      fechaFin: turno.fecha_fin,
+      estado: turno.estado,
+      responsable,
+      completadoPor: turno.estado === 'HECHO' ? responsable : '',
+    };
+  });
+
+  const csv = generarCsvLimpiezas(filas);
+  const fechaExportacion = new Date().toISOString().slice(0, 10);
+  const viviendaSlug = limpiarNombreArchivo(vivienda.alias_nombre) || `vivienda-${vivienda.id}`;
+  const nombreArchivo = `limpiezas-${viviendaSlug}-${fechaExportacion}.csv`;
+
+  res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+  res.setHeader('Content-Disposition', `attachment; filename="${nombreArchivo}"`);
+  res.status(200).send(csv);
 };
 
 export const marcarTurnoHecho: express.RequestHandler = async (req, res) => {

--- a/backend/src/routes/limpieza.routes.ts
+++ b/backend/src/routes/limpieza.routes.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import { verificarToken } from '../middlewares/auth.middleware';
 import { protegerModuloVivienda } from '../middlewares/module.guard';
-import { crearZona, listarZonas, actualizarZona, eliminarZona, asignarZonaFija, quitarAsignacionFija, generarTurnos, obtenerTurnos, marcarTurnoHecho } from '../controllers/limpieza.controller';
+import { crearZona, listarZonas, actualizarZona, eliminarZona, asignarZonaFija, quitarAsignacionFija, generarTurnos, obtenerTurnos, exportarTurnos, marcarTurnoHecho } from '../controllers/limpieza.controller';
 
 const router = express.Router();
 const limpiezaActiva = protegerModuloVivienda('limpieza');
@@ -14,6 +14,7 @@ router.post('/:id/limpieza/zonas/:zonaId/asignacion', verificarToken, limpiezaAc
 router.delete('/:id/limpieza/zonas/:zonaId/asignacion', verificarToken, limpiezaActiva, quitarAsignacionFija);
 router.post('/:id/limpieza/generar', verificarToken, limpiezaActiva, generarTurnos);
 router.get('/:id/limpieza/turnos', verificarToken, limpiezaActiva, obtenerTurnos);
+router.get('/:id/limpieza/turnos/export', verificarToken, limpiezaActiva, exportarTurnos);
 router.patch('/:id/limpieza/turnos/:turnoId/hecho', verificarToken, limpiezaActiva, marcarTurnoHecho);
 
 export default router;

--- a/backend/tests/operational-modules.test.ts
+++ b/backend/tests/operational-modules.test.ts
@@ -53,6 +53,11 @@ const prisma = vi.hoisted(() => ({
       throw new Error('Unexpected prisma call: incidencia.update');
     },
   },
+  turnoLimpieza: {
+    findMany: async (_args: unknown): Promise<unknown> => {
+      throw new Error('Unexpected prisma call: turnoLimpieza.findMany');
+    },
+  },
 }));
 
 const enviarNotificacionPush = vi.hoisted(() => vi.fn());
@@ -71,6 +76,7 @@ const {
 } = await import('../src/controllers/inventario.controller');
 const { crearAnuncio } = await import('../src/controllers/anuncio.controller');
 const { actualizarEstadoIncidencia } = await import('../src/controllers/incidencia.controller');
+const { exportarTurnos } = await import('../src/controllers/limpieza.controller');
 
 function resetPrisma() {
   enviarNotificacionPush.mockReset();
@@ -90,6 +96,7 @@ function resetPrisma() {
   });
   prisma.incidencia.findUnique = async () => null;
   prisma.incidencia.update = async (args: unknown) => ({ id: 1, ...(args as { data: unknown }).data });
+  prisma.turnoLimpieza.findMany = async () => [];
 }
 
 beforeEach(() => {
@@ -123,6 +130,11 @@ function res() {
     statusCode: 200,
     body: undefined as unknown,
     sent: false,
+    headers: {} as Record<string, string>,
+    setHeader(name: string, value: string) {
+      this.headers[name.toLowerCase()] = value;
+      return this;
+    },
     status(code: number) {
       this.statusCode = code;
       return this;
@@ -223,6 +235,76 @@ describe('inventario', () => {
 
     assert.equal(response.statusCode, 500);
     assert.match((response.body as { error: string }).error, /cloudinary/i);
+  });
+});
+
+describe('exportacion de limpieza', () => {
+  test('no exporta turnos de viviendas ajenas', async () => {
+    let findManyCalled = false;
+    prisma.vivienda.findFirst = async () => null;
+    prisma.turnoLimpieza.findMany = async () => {
+      findManyCalled = true;
+      return [];
+    };
+
+    const response = await invoke(
+      exportarTurnos,
+      req({ usuario: { id: 99, rol: 'CASERO' }, params: { id: '10' } }),
+    );
+
+    assert.equal(response.statusCode, 403);
+    assert.equal(findManyCalled, false);
+  });
+
+  test('genera csv con cabeceras, filtros y nombre descargable', async () => {
+    let filtros: unknown;
+    prisma.vivienda.findFirst = async () => ({ id: 10, alias_nombre: 'Piso Centro' });
+    prisma.turnoLimpieza.findMany = async (args: unknown) => {
+      filtros = args;
+      return [
+        {
+          id: 1,
+          fecha_inicio: new Date('2026-04-13T00:00:00.000Z'),
+          fecha_fin: new Date('2026-04-19T23:59:59.999Z'),
+          estado: 'HECHO',
+          zona: { nombre: 'Cocina' },
+          usuario: {
+            nombre: 'Ada',
+            apellidos: 'Lovelace',
+            habitacion: { nombre: 'Habitacion A', vivienda_id: 10 },
+          },
+        },
+      ];
+    };
+
+    const response = await invoke(
+      exportarTurnos,
+      req({
+        usuario: { id: 99, rol: 'CASERO' },
+        params: { id: '10' },
+        query: { fecha: '2026-04-14', estado: 'hecho' },
+      }),
+    );
+
+    assert.equal(response.statusCode, 200);
+    assert.match(response.headers['content-type'], /text\/csv/);
+    assert.match(response.headers['content-disposition'], /limpiezas-piso-centro-/);
+    assert.match(response.body as string, /"Vivienda";"Habitacion o zona";"Fecha inicio"/);
+    assert.match(response.body as string, /"Piso Centro";"Habitacion A - Cocina"/);
+    assert.equal((filtros as { where: { estado: string } }).where.estado, 'HECHO');
+  });
+
+  test('responde claro si no hay turnos para los filtros actuales', async () => {
+    prisma.vivienda.findFirst = async () => ({ id: 10, alias_nombre: 'Piso Centro' });
+    prisma.turnoLimpieza.findMany = async () => [];
+
+    const response = await invoke(
+      exportarTurnos,
+      req({ usuario: { id: 99, rol: 'CASERO' }, params: { id: '10' } }),
+    );
+
+    assert.equal(response.statusCode, 404);
+    assert.match((response.body as { error: string }).error, /no hay limpiezas/i);
   });
 });
 

--- a/backend/tests/release-regression.test.ts
+++ b/backend/tests/release-regression.test.ts
@@ -45,6 +45,7 @@ const rutasProtegidas: Array<{
   { metodo: 'get', ruta: '/api/viviendas/1/limpieza/zonas', flujo: 'limpieza listar zonas' },
   { metodo: 'post', ruta: '/api/viviendas/1/limpieza/zonas', flujo: 'limpieza crear zona' },
   { metodo: 'post', ruta: '/api/viviendas/1/limpieza/generar', flujo: 'limpieza generar turno' },
+  { metodo: 'get', ruta: '/api/viviendas/1/limpieza/turnos/export', flujo: 'limpieza exportar turnos' },
   { metodo: 'patch', ruta: '/api/viviendas/1/limpieza/turnos/1/hecho', flujo: 'limpieza marcar estado' },
   { metodo: 'get', ruta: '/api/viviendas/1/gastos', flujo: 'gastos listar' },
   { metodo: 'post', ruta: '/api/viviendas/1/gastos', flujo: 'gastos crear y repartir' },

--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -1843,6 +1843,38 @@ Devuelve los turnos de la semana indicada (o de la semana actual si no se especi
 
 ---
 
+### GET `/viviendas/:id/limpieza/turnos/export`
+
+Exporta los turnos de limpieza visibles para el usuario autenticado en CSV compatible con Excel.
+
+**Auth requerida:** Sí — `Authorization: Bearer <token>`
+
+**Acceso:** Casero de la vivienda **o** inquilino con habitación en ella.
+
+**Query params opcionales:**
+
+| Param | Tipo | Descripcion |
+|---|---|---|
+| `fecha` | `YYYY-MM-DD` | Exporta la semana de esa fecha (lunes a domingo). |
+| `fechaDesde` | `YYYY-MM-DD` | Inicio de rango historico. |
+| `fechaHasta` | `YYYY-MM-DD` | Fin de rango historico. |
+| `estado` | `PENDIENTE` \| `HECHO` \| `NO_HECHO` | Filtra por estado. |
+
+**Respuestas:**
+
+| Código | Descripción |
+|---|---|
+| `200` | Devuelve `text/csv; charset=utf-8` con `Content-Disposition` de descarga. |
+| `400` | Filtros no validos. |
+| `403` | El usuario no pertenece a la vivienda o el modulo esta desactivado. |
+| `404` | No hay limpiezas para exportar con los filtros actuales. |
+
+**Cabeceras del CSV:**
+
+`Vivienda`, `Habitacion o zona`, `Fecha inicio`, `Fecha fin`, `Estado`, `Responsable asignado`, `Completado por`, `Observaciones`, `Fecha de validacion`.
+
+---
+
 ### PATCH `/viviendas/:id/limpieza/turnos/:turnoId/hecho`
 
 Marca un turno como `HECHO`. No tiene body.

--- a/docs/changelog/Epica17/epica-17-issue-282-exportar-limpiezas.md
+++ b/docs/changelog/Epica17/epica-17-issue-282-exportar-limpiezas.md
@@ -1,0 +1,19 @@
+# Epica 17 - Issue 282 - Exportar limpiezas a Excel
+
+## Objetivo
+
+Permitir exportar los turnos de limpieza visibles para el usuario en un archivo CSV compatible con Excel, respetando permisos de vivienda, modulo activo y filtros de la pantalla.
+
+## Cambios
+
+- Backend: nuevo `GET /api/viviendas/:id/limpieza/turnos/export` protegido por token y `mod_limpieza`.
+- Backend: exportacion CSV con cabeceras comprensibles, nombre de archivo con fecha y soporte de filtros `fecha`, `fechaDesde`, `fechaHasta` y `estado`.
+- Backend: respuesta `404` clara cuando no hay limpiezas para exportar y validacion `400` para filtros invalidos.
+- Frontend casero: boton `Exportar` en el calendario de limpieza y filtro por estado para exportar el listado actual.
+- Frontend casero: descarga web mediante Blob y guardado/comparticion nativa mediante `expo-file-system` y `Share`.
+- Tests: cobertura de permiso multitenant, CSV generado y ausencia de datos para exportacion.
+
+## Notas
+
+- El formato elegido es CSV porque Excel lo abre correctamente y evita introducir una dependencia pesada de XLSX.
+- El modelo actual de limpieza no guarda observaciones ni fecha de validacion; esas columnas quedan preparadas en el CSV para mantener el contrato de exportacion estable.

--- a/frontend/app/casero/vivienda/[id]/(tabs)/limpieza.tsx
+++ b/frontend/app/casero/vivienda/[id]/(tabs)/limpieza.tsx
@@ -9,8 +9,10 @@ import {
   Platform,
   Alert,
   ScrollView,
+  Share,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { File, Paths } from 'expo-file-system';
 import Toast from 'react-native-toast-message';
 import { Theme } from '@/constants/theme';
 import { useState, useEffect } from 'react';
@@ -119,6 +121,14 @@ type Turno = {
   usuario: { id: number; nombre: string; apellidos: string | null };
 };
 
+type EstadoFiltro = 'TODOS' | Turno['estado'];
+
+const FILTROS_ESTADO: { label: string; value: EstadoFiltro }[] = [
+  { label: 'Todos', value: 'TODOS' },
+  { label: 'Pendientes', value: 'PENDIENTE' },
+  { label: 'Hechos', value: 'HECHO' },
+];
+
 // ─────────────────────────────────────────────────────────────────────────────
 
 export default function LimpiezaCaseroTab() {
@@ -148,6 +158,8 @@ export default function LimpiezaCaseroTab() {
   // — Calendario state —
   const [turnos, setTurnos] = useState<Turno[]>([]);
   const [loadingTurnos, setLoadingTurnos] = useState(false);
+  const [exportando, setExportando] = useState(false);
+  const [filtroEstado, setFiltroEstado] = useState<EstadoFiltro>('TODOS');
   const [fechaObjetivo, setFechaObjetivo] = useState<Date>(() => {
     const hoy = new Date();
     const offset = (hoy.getDay() + 6) % 7;
@@ -206,6 +218,93 @@ export default function LimpiezaCaseroTab() {
       Toast.show({ type: 'error', text1: 'No se pudieron cargar los turnos.' });
     } finally {
       setLoadingTurnos(false);
+    }
+  };
+
+  const obtenerNombreArchivoExport = (contentDisposition?: string) => {
+    const match = contentDisposition?.match(/filename="?([^";]+)"?/i);
+    return match?.[1] ?? `limpiezas-${new Date().toISOString().slice(0, 10)}.csv`;
+  };
+
+  const guardarArchivoCsv = async (contenido: string, nombreArchivo: string) => {
+    if (Platform.OS === 'web' && typeof document !== 'undefined') {
+      const blob = new Blob([contenido], { type: 'text/csv;charset=utf-8' });
+      const url = URL.createObjectURL(blob);
+      const enlace = document.createElement('a');
+      enlace.href = url;
+      enlace.download = nombreArchivo;
+      enlace.click();
+      URL.revokeObjectURL(url);
+      return;
+    }
+
+    const archivo = new File(Paths.cache, nombreArchivo);
+    archivo.create({ overwrite: true });
+    archivo.write(contenido);
+
+    await Share.share({
+      title: nombreArchivo,
+      url: Platform.OS === 'android' ? archivo.contentUri : archivo.uri,
+      message: Platform.OS === 'android' ? archivo.contentUri : undefined,
+    });
+  };
+
+  const obtenerMensajeErrorExport = (error: any) => {
+    const data = error.response?.data;
+    if (typeof data === 'string') {
+      try {
+        const parseado = JSON.parse(data);
+        return parseado.error ?? 'No se pudieron exportar las limpiezas.';
+      } catch {
+        return 'No se pudieron exportar las limpiezas.';
+      }
+    }
+
+    return data?.error ?? 'No se pudieron exportar las limpiezas.';
+  };
+
+  const exportarTurnos = async () => {
+    if (!id) return;
+
+    const turnosFiltrados = turnos.filter((turno) =>
+      filtroEstado === 'TODOS' ? true : turno.estado === filtroEstado
+    );
+
+    if (turnosFiltrados.length === 0) {
+      Toast.show({
+        type: 'info',
+        text1: 'No hay limpiezas para exportar',
+        text2: 'Cambia la semana o el filtro de estado.',
+      });
+      return;
+    }
+
+    setExportando(true);
+    try {
+      const fechaParam = fechaObjetivo.toISOString().split('T')[0];
+      const { data, headers } = await api.get<string>(`/viviendas/${id}/limpieza/turnos/export`, {
+        params: {
+          fecha: fechaParam,
+          ...(filtroEstado !== 'TODOS' ? { estado: filtroEstado } : {}),
+        },
+        responseType: 'text',
+        transformResponse: [(response) => response],
+      });
+      const nombreArchivo = obtenerNombreArchivoExport(headers['content-disposition'] as string | undefined);
+
+      await guardarArchivoCsv(data, nombreArchivo);
+      Toast.show({
+        type: 'success',
+        text1: 'Exportacion lista',
+        text2: 'El archivo CSV se puede abrir con Excel.',
+      });
+    } catch (err: any) {
+      Toast.show({
+        type: 'error',
+        text1: obtenerMensajeErrorExport(err),
+      });
+    } finally {
+      setExportando(false);
     }
   };
 
@@ -405,7 +504,10 @@ export default function LimpiezaCaseroTab() {
       return <ActivityIndicator style={{ flex: 1, marginTop: 40 }} size="large" color={Theme.colors.primary} />;
     }
 
-    const turnosPorUsuario = turnos.reduce<
+    const turnosFiltrados = turnos.filter((turno) =>
+      filtroEstado === 'TODOS' ? true : turno.estado === filtroEstado
+    );
+    const turnosFiltradosPorUsuario = turnosFiltrados.reduce<
       Record<number, { usuario: Turno['usuario']; items: Turno[] }>
     >((acc, t) => {
       if (!acc[t.usuario_id]) acc[t.usuario_id] = { usuario: t.usuario, items: [] };
@@ -421,12 +523,32 @@ export default function LimpiezaCaseroTab() {
             <Text style={styles.calendarioGestion}>Gestión</Text>
             <Text style={styles.calendarioTitulo}>Limpieza</Text>
           </View>
-          <Pressable
-            style={({ pressed }) => [styles.calendarioBtnConfig, pressed && { opacity: 0.7 }]}
-            onPress={() => setVistaActual('CONFIG')}
-          >
-            <Text style={styles.calendarioBtnConfigTexto}>Configurar Zonas</Text>
-          </Pressable>
+          <View style={styles.calendarioActions}>
+            <Pressable
+              style={({ pressed }) => [
+                styles.calendarioBtnExport,
+                (pressed || exportando) && { opacity: 0.7 },
+                turnosFiltrados.length === 0 && styles.calendarioBtnDisabled,
+              ]}
+              onPress={exportarTurnos}
+              disabled={exportando || turnosFiltrados.length === 0}
+            >
+              {exportando ? (
+                <ActivityIndicator size="small" color={Theme.colors.primary} />
+              ) : (
+                <Ionicons name="download-outline" size={16} color={Theme.colors.primary} />
+              )}
+              <Text style={styles.calendarioBtnExportTexto}>
+                {exportando ? 'Exportando' : 'Exportar'}
+              </Text>
+            </Pressable>
+            <Pressable
+              style={({ pressed }) => [styles.calendarioBtnConfig, pressed && { opacity: 0.7 }]}
+              onPress={() => setVistaActual('CONFIG')}
+            >
+              <Text style={styles.calendarioBtnConfigTexto}>Configurar</Text>
+            </Pressable>
+          </View>
         </View>
 
         {/* ── Navegación de semana ── */}
@@ -439,6 +561,29 @@ export default function LimpiezaCaseroTab() {
             <Text style={styles.semanaNavTexto}>›</Text>
           </Pressable>
         </View>
+
+        {turnos.length > 0 && (
+          <View style={styles.filtroEstadoRow}>
+            {FILTROS_ESTADO.map((filtro) => {
+              const activo = filtroEstado === filtro.value;
+              return (
+                <Pressable
+                  key={filtro.value}
+                  style={({ pressed }) => [
+                    styles.filtroEstadoChip,
+                    activo && styles.filtroEstadoChipActivo,
+                    pressed && { opacity: 0.75 },
+                  ]}
+                  onPress={() => setFiltroEstado(filtro.value)}
+                >
+                  <Text style={[styles.filtroEstadoTexto, activo && styles.filtroEstadoTextoActivo]}>
+                    {filtro.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        )}
 
         {turnos.length === 0 ? (
           <View style={styles.emptyContainer}>
@@ -455,8 +600,16 @@ export default function LimpiezaCaseroTab() {
               style={{ marginTop: Theme.spacing.md, minWidth: 180 }}
             />
           </View>
+        ) : turnosFiltrados.length === 0 ? (
+          <View style={styles.emptyContainer}>
+            <View style={styles.emptyIconBox}>
+              <Ionicons name="filter-outline" size={40} color={Theme.colors.success} />
+            </View>
+            <Text style={styles.emptyTitulo}>Sin resultados</Text>
+            <Text style={styles.emptySubtitulo}>No hay turnos de limpieza con el filtro seleccionado.</Text>
+          </View>
         ) : (
-          Object.values(turnosPorUsuario).map((grupo) => (
+          Object.values(turnosFiltradosPorUsuario).map((grupo) => (
             <View key={grupo.usuario.id} style={styles.userCard}>
               {/* Avatar + nombre */}
               <View style={styles.userCardHeader}>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "expo-crypto": "~15.0.8",
         "expo-device": "~8.0.10",
         "expo-document-picker": "~14.0.8",
+        "expo-file-system": "~19.0.21",
         "expo-font": "~14.0.11",
         "expo-haptics": "~15.0.8",
         "expo-image": "~3.0.11",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "expo-crypto": "~15.0.8",
     "expo-device": "~8.0.10",
     "expo-document-picker": "~14.0.8",
+    "expo-file-system": "~19.0.21",
     "expo-font": "~14.0.11",
     "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",

--- a/frontend/styles/casero/vivienda/limpieza.styles.ts
+++ b/frontend/styles/casero/vivienda/limpieza.styles.ts
@@ -331,6 +331,29 @@ export const styles = StyleSheet.create({
     fontWeight: '600',
     color: Theme.colors.primary,
   },
+  calendarioActions: {
+    alignItems: 'flex-end',
+    gap: Theme.spacing.sm,
+  },
+  calendarioBtnExport: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Theme.spacing.xs,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    backgroundColor: Theme.colors.surface,
+    borderRadius: Theme.radius.md,
+    borderWidth: 1,
+    borderColor: Theme.colors.primary + '33',
+  },
+  calendarioBtnExportTexto: {
+    fontSize: Theme.typography.label,
+    fontWeight: '700',
+    color: Theme.colors.primary,
+  },
+  calendarioBtnDisabled: {
+    opacity: 0.45,
+  },
 
   // — Navegación de semana ──────────────────────────────────────────────────
   semanaNav: {
@@ -367,6 +390,33 @@ export const styles = StyleSheet.create({
   },
 
   // — Card de usuario (calendario) ──────────────────────────────────────────
+  filtroEstadoRow: {
+    flexDirection: 'row',
+    gap: Theme.spacing.sm,
+    marginBottom: Theme.spacing.lg,
+  },
+  filtroEstadoChip: {
+    flex: 1,
+    alignItems: 'center',
+    paddingVertical: 10,
+    paddingHorizontal: Theme.spacing.sm,
+    borderRadius: Theme.radius.full,
+    backgroundColor: Theme.colors.surface,
+    borderWidth: 1,
+    borderColor: Theme.colors.border,
+  },
+  filtroEstadoChipActivo: {
+    backgroundColor: Theme.colors.primary + '18',
+    borderColor: Theme.colors.primary,
+  },
+  filtroEstadoTexto: {
+    fontSize: Theme.typography.label,
+    fontWeight: '700',
+    color: Theme.colors.textSecondary,
+  },
+  filtroEstadoTextoActivo: {
+    color: Theme.colors.primary,
+  },
   userCard: {
     backgroundColor: Theme.colors.surface,
     borderRadius: 24,


### PR DESCRIPTION
## Summary
- Añade exportación CSV compatible con Excel para turnos de limpieza visibles por usuario.
- Respeta permisos de vivienda, módulo de limpieza activo y filtros de fecha/estado.
- Incorpora acción de exportar en la UI del calendario de limpieza del casero.
- Actualiza documentación de API y changelog.

## Testing
- `npm test` en `backend`
- `npm run build` en `backend`
- `npm run lint` en `frontend`
- `npx tsc --noEmit` en `frontend`
- `npm test` en `frontend`