### PR TITLE
Fix [Épica 17] exportación completa de limpiezas

### DIFF
--- a/backend/src/controllers/limpieza.controller.ts
+++ b/backend/src/controllers/limpieza.controller.ts
@@ -7,14 +7,14 @@ type EstadoTurnoExport = 'PENDIENTE' | 'HECHO' | 'NO_HECHO';
 const ESTADOS_EXPORTABLES = new Set<EstadoTurnoExport>(['PENDIENTE', 'HECHO', 'NO_HECHO']);
 const CABECERAS_EXPORTACION = [
   'Vivienda',
-  'Habitacion o zona',
+  'Habitación o zona',
   'Fecha inicio',
   'Fecha fin',
   'Estado',
   'Responsable asignado',
   'Completado por',
   'Observaciones',
-  'Fecha de validacion',
+  'Fecha de validación',
 ];
 
 const normalizarFechaDia = (valor: unknown, finalDia = false) => {
@@ -359,7 +359,7 @@ export const exportarTurnos: express.RequestHandler = async (req, res) => {
 
   const estado = typeof req.query['estado'] === 'string' ? req.query['estado'].toUpperCase() : undefined;
   if (estado && !ESTADOS_EXPORTABLES.has(estado as EstadoTurnoExport)) {
-    res.status(400).json({ error: 'estado no valido para exportar limpiezas.' });
+    res.status(400).json({ error: 'estado no válido para exportar limpiezas.' });
     return;
   }
 

--- a/backend/tests/operational-modules.test.ts
+++ b/backend/tests/operational-modules.test.ts
@@ -289,7 +289,7 @@ describe('exportacion de limpieza', () => {
     assert.equal(response.statusCode, 200);
     assert.match(response.headers['content-type'], /text\/csv/);
     assert.match(response.headers['content-disposition'], /limpiezas-piso-centro-/);
-    assert.match(response.body as string, /"Vivienda";"Habitacion o zona";"Fecha inicio"/);
+    assert.match(response.body as string, /"Vivienda";"Habitación o zona";"Fecha inicio"/);
     assert.match(response.body as string, /"Piso Centro";"Habitacion A - Cocina"/);
     assert.equal((filtros as { where: { estado: string } }).where.estado, 'HECHO');
   });

--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -1856,8 +1856,8 @@ Exporta los turnos de limpieza visibles para el usuario autenticado en CSV compa
 | Param | Tipo | Descripcion |
 |---|---|---|
 | `fecha` | `YYYY-MM-DD` | Exporta la semana de esa fecha (lunes a domingo). |
-| `fechaDesde` | `YYYY-MM-DD` | Inicio de rango historico. |
-| `fechaHasta` | `YYYY-MM-DD` | Fin de rango historico. |
+| `fechaDesde` | `YYYY-MM-DD` | Inicio de rango histórico. |
+| `fechaHasta` | `YYYY-MM-DD` | Fin de rango histórico. |
 | `estado` | `PENDIENTE` \| `HECHO` \| `NO_HECHO` | Filtra por estado. |
 
 **Respuestas:**
@@ -1865,13 +1865,13 @@ Exporta los turnos de limpieza visibles para el usuario autenticado en CSV compa
 | Código | Descripción |
 |---|---|
 | `200` | Devuelve `text/csv; charset=utf-8` con `Content-Disposition` de descarga. |
-| `400` | Filtros no validos. |
-| `403` | El usuario no pertenece a la vivienda o el modulo esta desactivado. |
+| `400` | Filtros no válidos. |
+| `403` | El usuario no pertenece a la vivienda o el módulo está desactivado. |
 | `404` | No hay limpiezas para exportar con los filtros actuales. |
 
 **Cabeceras del CSV:**
 
-`Vivienda`, `Habitacion o zona`, `Fecha inicio`, `Fecha fin`, `Estado`, `Responsable asignado`, `Completado por`, `Observaciones`, `Fecha de validacion`.
+`Vivienda`, `Habitación o zona`, `Fecha inicio`, `Fecha fin`, `Estado`, `Responsable asignado`, `Completado por`, `Observaciones`, `Fecha de validación`.
 
 ---
 

--- a/docs/changelog/Epica17/epica-17-issue-282-exportar-limpiezas.md
+++ b/docs/changelog/Epica17/epica-17-issue-282-exportar-limpiezas.md
@@ -2,23 +2,25 @@
 
 ## Objetivo
 
-Permitir exportar los turnos de limpieza visibles para el usuario en un archivo CSV compatible con Excel, respetando permisos de vivienda, modulo activo y filtros de la pantalla.
+Permitir exportar los turnos de limpieza visibles para el usuario en un archivo CSV compatible con Excel, respetando permisos de vivienda, módulo activo y filtros de la pantalla.
 
 ## Cambios
 
 - Backend: nuevo `GET /api/viviendas/:id/limpieza/turnos/export` protegido por token y `mod_limpieza`.
-- Backend: exportacion CSV con cabeceras comprensibles, nombre de archivo con fecha y soporte de filtros `fecha`, `fechaDesde`, `fechaHasta` y `estado`.
-- Backend: respuesta `404` clara cuando no hay limpiezas para exportar y validacion `400` para filtros invalidos.
-- Frontend casero: boton `Exportar` en el calendario de limpieza y filtro por estado para exportar el listado actual.
-- Frontend casero: descarga web mediante Blob y guardado/comparticion nativa mediante `expo-file-system` y `Share`.
-- Tests: cobertura de permiso multitenant, CSV generado y ausencia de datos para exportacion.
+- Backend: exportación CSV con cabeceras comprensibles, nombre de archivo con fecha y soporte de filtros `fecha`, `fechaDesde`, `fechaHasta` y `estado`.
+- Backend: respuesta `404` clara cuando no hay limpiezas para exportar y validación `400` para filtros inválidos.
+- Frontend casero: botón `Exportar` en el calendario de limpieza y filtro por estado para exportar el listado actual.
+- Frontend casero: descarga web mediante Blob y guardado/compartición nativa mediante `expo-file-system` y `Share`.
+- Tests: cobertura de permiso multitenant, CSV generado y ausencia de datos para exportación.
 
 ## Notas
 
 - El formato elegido es CSV porque Excel lo abre correctamente y evita introducir una dependencia pesada de XLSX.
-- El modelo actual de limpieza no guarda observaciones ni fecha de validacion; esas columnas quedan preparadas en el CSV para mantener el contrato de exportacion estable.
+- El modelo actual de limpieza no guarda observaciones ni fecha de validación; esas columnas quedan preparadas en el CSV para mantener el contrato de exportación estable.
 
 ## Fix posterior
 
-- El frontend usa fechas locales `YYYY-MM-DD` al cargar y exportar turnos para evitar saltos de semana por conversion UTC.
+- El frontend usa fechas locales `YYYY-MM-DD` al cargar y exportar turnos para evitar saltos de semana por conversión UTC.
 - En Android, el CSV se guarda mediante Storage Access Framework para que el usuario elija carpeta y el archivo quede accesible.
+- La acción de exportar ya no se limita a la semana visible: exporta el calendario completo de la vivienda, aplicando solo el filtro de estado si el usuario lo selecciona.
+- Las cabeceras del CSV usan español con acentos, incluyendo `Habitación o zona` y `Fecha de validación`.

--- a/frontend/app/casero/vivienda/[id]/(tabs)/limpieza.tsx
+++ b/frontend/app/casero/vivienda/[id]/(tabs)/limpieza.tsx
@@ -291,25 +291,10 @@ export default function LimpiezaCaseroTab() {
   const exportarTurnos = async () => {
     if (!id) return;
 
-    const turnosFiltrados = turnos.filter((turno) =>
-      filtroEstado === 'TODOS' ? true : turno.estado === filtroEstado
-    );
-
-    if (turnosFiltrados.length === 0) {
-      Toast.show({
-        type: 'info',
-        text1: 'No hay limpiezas para exportar',
-        text2: 'Cambia la semana o el filtro de estado.',
-      });
-      return;
-    }
-
     setExportando(true);
     try {
-      const fechaParam = formatearFechaParam(fechaObjetivo);
       const { data, headers } = await api.get<string>(`/viviendas/${id}/limpieza/turnos/export`, {
         params: {
-          fecha: fechaParam,
           ...(filtroEstado !== 'TODOS' ? { estado: filtroEstado } : {}),
         },
         responseType: 'text',
@@ -320,7 +305,7 @@ export default function LimpiezaCaseroTab() {
       await guardarArchivoCsv(data, nombreArchivo);
       Toast.show({
         type: 'success',
-        text1: 'Exportacion lista',
+        text1: 'Calendario exportado',
         text2: Platform.OS === 'android' ? 'Archivo CSV guardado.' : 'El archivo CSV se puede abrir con Excel.',
       });
     } catch (err: any) {
@@ -553,10 +538,9 @@ export default function LimpiezaCaseroTab() {
               style={({ pressed }) => [
                 styles.calendarioBtnExport,
                 (pressed || exportando) && { opacity: 0.7 },
-                turnosFiltrados.length === 0 && styles.calendarioBtnDisabled,
               ]}
               onPress={exportarTurnos}
-              disabled={exportando || turnosFiltrados.length === 0}
+              disabled={exportando}
             >
               {exportando ? (
                 <ActivityIndicator size="small" color={Theme.colors.primary} />
@@ -564,7 +548,7 @@ export default function LimpiezaCaseroTab() {
                 <Ionicons name="download-outline" size={16} color={Theme.colors.primary} />
               )}
               <Text style={styles.calendarioBtnExportTexto}>
-                {exportando ? 'Exportando' : 'Exportar'}
+                {exportando ? 'Exportando' : 'Exportar todo'}
               </Text>
             </Pressable>
             <Pressable


### PR DESCRIPTION
## Summary
- Corrige la exportación de limpiezas para descargar el calendario completo de la vivienda, no solo la semana visible.
- Mantiene el filtro de estado sobre todo el histórico exportado.
- Ajusta fechas locales para evitar saltos por conversión UTC y mejora el guardado del CSV en Android.
- Normaliza cabeceras y mensajes en español con acentos, incluyendo `Habitación o zona` y `Fecha de validación`.

## Testing
- `frontend npx tsc --noEmit`
- `frontend npm test`
- `backend npm test`
- `backend npm test -- operational-modules.test.ts`