### PR TITLE
Fix exportación simple de limpiezas

### DIFF
--- a/backend/src/controllers/limpieza.controller.ts
+++ b/backend/src/controllers/limpieza.controller.ts
@@ -86,6 +86,12 @@ const generarCsvLimpiezas = (
   return `\uFEFF${lineas.join('\r\n')}`;
 };
 
+const generarBufferCsvExcel = (csv: string) =>
+  Buffer.concat([
+    Buffer.from([0xff, 0xfe]),
+    Buffer.from(csv.replace(/^\uFEFF/, ''), 'utf16le'),
+  ]);
+
 const verificarPropiedadVivienda = async (viviendaId: number, caseroId: number) => {
   const vivienda = await prisma.vivienda.findUnique({ where: { id: viviendaId } });
   if (!vivienda || vivienda.casero_id !== caseroId) return null;
@@ -413,8 +419,8 @@ export const exportarTurnos: express.RequestHandler = async (req, res) => {
   if (req.query['formato'] === 'base64') {
     res.status(200).json({
       nombreArchivo,
-      mimeType: 'text/csv; charset=utf-8',
-      contenidoBase64: Buffer.from(csv, 'utf8').toString('base64'),
+      mimeType: 'text/csv',
+      contenidoBase64: generarBufferCsvExcel(csv).toString('base64'),
     });
     return;
   }

--- a/backend/tests/operational-modules.test.ts
+++ b/backend/tests/operational-modules.test.ts
@@ -317,7 +317,7 @@ describe('exportacion de limpieza', () => {
 
     assert.equal(response.statusCode, 200);
     const body = response.body as { contenidoBase64: string; nombreArchivo: string };
-    const csv = Buffer.from(body.contenidoBase64, 'base64').toString('utf8');
+    const csv = Buffer.from(body.contenidoBase64, 'base64').subarray(2).toString('utf16le');
     assert.match(body.nombreArchivo, /limpiezas-piso-centro-/);
     assert.match(csv, /"Baño 1";"Ada Lovelace";"13\/04\/2026"/);
   });

--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -1859,7 +1859,7 @@ Exporta los turnos de limpieza visibles para el usuario autenticado en CSV compa
 | `fechaDesde` | `YYYY-MM-DD` | Inicio de rango histórico. |
 | `fechaHasta` | `YYYY-MM-DD` | Fin de rango histórico. |
 | `estado` | `PENDIENTE` \| `HECHO` \| `NO_HECHO` | Filtra por estado. |
-| `formato` | `base64` | Devuelve JSON con el archivo codificado en base64 para preservar acentos en móvil. |
+| `formato` | `base64` | Devuelve JSON con el archivo CSV codificado en base64 y bytes compatibles con Excel para preservar acentos en móvil. |
 
 **Respuestas:**
 

--- a/docs/changelog/Epica17/epica-17-issue-282-exportar-limpiezas.md
+++ b/docs/changelog/Epica17/epica-17-issue-282-exportar-limpiezas.md
@@ -24,4 +24,4 @@ Permitir exportar los turnos de limpieza visibles para el usuario en un archivo 
 - En Android, el CSV se guarda mediante Storage Access Framework para que el usuario elija carpeta y el archivo quede accesible.
 - La acción de exportar ya no se limita a la semana visible: exporta el calendario completo de la vivienda, aplicando solo el filtro de estado si el usuario lo selecciona.
 - La vista exportada queda reducida a `Zona a limpiar`, `Inquilino` y `Fecha`.
-- El frontend descarga el archivo en base64 para escribir bytes UTF-8 exactos y evitar errores como `BaÃ±o`.
+- El frontend descarga el archivo en base64 para escribir bytes compatibles con Excel y evitar errores como `BaÃ±o`.


### PR DESCRIPTION
## Summary
- Simplifica la exportación de limpiezas a las columnas `Zona a limpiar`, `Inquilino` y `Fecha`.
- Exporta el calendario completo en CSV en lugar de limitarlo a una semana.
- Corrige la codificación de acentos para evitar textos corruptos como `HabitaciÃ³n` o `BaÃ±o`.
- Ajusta el `mimeType` para conservar la extensión `.csv` en móvil.
- Actualiza documentación y changelog.

## Testing
- `backend npm run build`
- `backend npm test -- operational-modules.test.ts`
- `frontend npx tsc --noEmit`
- `frontend npm test`
- `frontend npm run lint`