### PR TITLE
[Épica 16] Refactor separación de cobros por actor

### DIFF
--- a/backend/prisma/migrations/20260417184000_add_tipo_gasto/migration.sql
+++ b/backend/prisma/migrations/20260417184000_add_tipo_gasto/migration.sql
@@ -1,0 +1,18 @@
+CREATE TYPE "TipoGasto" AS ENUM (
+  'ENTRE_COMPANEROS',
+  'FACTURA_PUNTUAL',
+  'FACTURA_MENSUAL',
+  'CARGO_RECURRENTE'
+);
+
+ALTER TABLE "Gasto"
+ADD COLUMN "tipo" "TipoGasto" NOT NULL DEFAULT 'ENTRE_COMPANEROS';
+
+ALTER TABLE "GastoRecurrente"
+ADD COLUMN "tipo" "TipoGasto" NOT NULL DEFAULT 'FACTURA_MENSUAL';
+
+UPDATE "Gasto"
+SET "tipo" = 'FACTURA_PUNTUAL'
+FROM "Vivienda"
+WHERE "Gasto"."vivienda_id" = "Vivienda"."id"
+  AND "Gasto"."pagador_id" = "Vivienda"."casero_id";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -48,6 +48,13 @@ enum EstadoDeuda {
   PAGADA
 }
 
+enum TipoGasto {
+  ENTRE_COMPANEROS
+  FACTURA_PUNTUAL
+  FACTURA_MENSUAL
+  CARGO_RECURRENTE
+}
+
 enum EstadoItem {
   NUEVO
   BUENO
@@ -151,6 +158,7 @@ model Gasto {
   id             Int      @id @default(autoincrement())
   concepto       String
   importe        Float
+  tipo           TipoGasto @default(ENTRE_COMPANEROS)
   factura_url    String?
   fecha_creacion DateTime @default(now())
   pagador_id     Int
@@ -164,6 +172,7 @@ model GastoRecurrente {
   id          Int      @id @default(autoincrement())
   concepto    String
   importe     Float
+  tipo        TipoGasto @default(FACTURA_MENSUAL)
   dia_del_mes Int
   vivienda_id Int
   vivienda    Vivienda @relation(fields: [vivienda_id], references: [id])

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -3,6 +3,7 @@ import {
   RolUsuario,
   TipoHabitacion,
   EstadoDeuda,
+  TipoGasto,
 } from "../src/generated/prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 import bcrypt from "bcrypt";
@@ -64,6 +65,7 @@ async function crearGastoConDeudas({
   fechaCreacion,
   pagadorId,
   viviendaId,
+  tipo,
   deudas,
 }: {
   concepto: string;
@@ -71,12 +73,14 @@ async function crearGastoConDeudas({
   fechaCreacion: Date;
   pagadorId: number;
   viviendaId: number;
+  tipo: TipoGasto;
   deudas: ParticipanteDeuda[];
 }) {
   return prisma.gasto.create({
     data: {
       concepto,
       importe,
+      tipo,
       fecha_creacion: fechaCreacion,
       pagador_id: pagadorId,
       vivienda_id: viviendaId,
@@ -320,6 +324,7 @@ async function main() {
     fechaCreacion: dayOfMonth(3),
     pagadorId: ana.id,
     viviendaId: vivienda.id,
+    tipo: TipoGasto.ENTRE_COMPANEROS,
     deudas: [
       { deudorId: bruno.id, importe: 30 },
       { deudorId: carmen.id, importe: 30, estado: EstadoDeuda.PAGADA },
@@ -340,6 +345,7 @@ async function main() {
     fechaCreacion: dayOfMonth(8),
     pagadorId: bruno.id,
     viviendaId: vivienda.id,
+    tipo: TipoGasto.ENTRE_COMPANEROS,
     deudas: [
       { deudorId: ana.id, importe: 18, estado: EstadoDeuda.PAGADA },
       { deudorId: carmen.id, importe: 18 },
@@ -353,6 +359,7 @@ async function main() {
     fechaCreacion: dayOfMonth(5),
     pagadorId: casero.id,
     viviendaId: vivienda.id,
+    tipo: TipoGasto.FACTURA_PUNTUAL,
     deudas: [
       {
         deudorId: ana.id,
@@ -374,6 +381,7 @@ async function main() {
     fechaCreacion: dayOfMonth(9),
     pagadorId: casero.id,
     viviendaId: vivienda.id,
+    tipo: TipoGasto.FACTURA_PUNTUAL,
     deudas: [
       { deudorId: ana.id, importe: 22 },
       { deudorId: bruno.id, importe: 22 },
@@ -389,6 +397,7 @@ async function main() {
     fechaCreacion: dayOfMonth(16, 1),
     pagadorId: casero.id,
     viviendaId: vivienda.id,
+    tipo: TipoGasto.FACTURA_PUNTUAL,
     deudas: [
       { deudorId: ana.id, importe: 16, estado: EstadoDeuda.PAGADA },
       { deudorId: bruno.id, importe: 16, estado: EstadoDeuda.PAGADA },
@@ -403,6 +412,7 @@ async function main() {
       {
         concepto: "Alquiler mensual",
         importe: 1800,
+        tipo: TipoGasto.FACTURA_MENSUAL,
         dia_del_mes: 1,
         vivienda_id: vivienda.id,
         pagador_id: casero.id,
@@ -411,6 +421,7 @@ async function main() {
       {
         concepto: "Internet fibra",
         importe: 60,
+        tipo: TipoGasto.FACTURA_MENSUAL,
         dia_del_mes: 5,
         vivienda_id: vivienda.id,
         pagador_id: casero.id,
@@ -419,6 +430,7 @@ async function main() {
       {
         concepto: "Cuota limpieza portal",
         importe: 35,
+        tipo: TipoGasto.CARGO_RECURRENTE,
         dia_del_mes: 15,
         vivienda_id: vivienda.id,
         pagador_id: casero.id,

--- a/backend/src/controllers/cobros.controller.ts
+++ b/backend/src/controllers/cobros.controller.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import { prisma } from '../lib/prisma';
+import { TIPOS_GASTO_CASERO } from '../services/gasto.service';
 
 const obtenerParamNumerico = (valor: string | string[] | undefined) => {
   const normalizado = Array.isArray(valor) ? valor[0] : valor;
@@ -55,6 +56,7 @@ export const listarCobrosVivienda: express.RequestHandler = async (req, res) => 
       acreedor_id: usuarioId,
       gasto: {
         vivienda_id: viviendaId,
+        tipo: { in: [...TIPOS_GASTO_CASERO] },
         fecha_creacion: {
           gte: inicioMes,
           lt: inicioMesSiguiente,
@@ -74,6 +76,7 @@ export const listarCobrosVivienda: express.RequestHandler = async (req, res) => 
           id: true,
           concepto: true,
           importe: true,
+          tipo: true,
           factura_url: true,
           fecha_creacion: true,
         },
@@ -112,6 +115,7 @@ export const listarCobrosVivienda: express.RequestHandler = async (req, res) => 
       importe: deuda.importe,
       estado: deuda.estado,
       justificante_url: deuda.justificante_url,
+      categoria: 'CASERO',
       gasto: deuda.gasto,
       deudor: {
         id: deuda.deudor.id,

--- a/backend/src/controllers/gasto-recurrente.controller.ts
+++ b/backend/src/controllers/gasto-recurrente.controller.ts
@@ -72,6 +72,7 @@ export const crearGastoRecurrente: express.RequestHandler = async (req, res) => 
     data: {
       concepto: concepto.trim(),
       importe,
+      tipo: 'FACTURA_MENSUAL',
       dia_del_mes,
       vivienda_id: viviendaId,
       pagador_id: pagadorId,

--- a/backend/src/controllers/gasto.controller.ts
+++ b/backend/src/controllers/gasto.controller.ts
@@ -5,6 +5,7 @@ import {
   crearGastoDividido,
   normalizarImporteMonetario,
   repartirImporteEnCentimos,
+  TIPOS_GASTO_CASERO,
   usuarioEsCaseroDeVivienda,
   usuarioPerteneceAVivienda,
 } from '../services/gasto.service';
@@ -75,7 +76,11 @@ export const listarGastos: express.RequestHandler = async (req, res) => {
     return;
   }
 
-  const pertenece = await usuarioPuedeAccederAVivienda(viviendaId, usuarioId);
+  const [habitacion, viviendaCasero] = await Promise.all([
+    usuarioPerteneceAVivienda(viviendaId, usuarioId),
+    usuarioEsCaseroDeVivienda(viviendaId, usuarioId),
+  ]);
+  const pertenece = Boolean(habitacion || viviendaCasero);
 
   if (!pertenece) {
     res.status(403).json({ error: 'No perteneces a esta vivienda.' });
@@ -83,11 +88,27 @@ export const listarGastos: express.RequestHandler = async (req, res) => {
   }
 
   const gastos = await prisma.gasto.findMany({
-    where: { vivienda_id: viviendaId },
+    where: {
+      vivienda_id: viviendaId,
+      ...(viviendaCasero
+        ? { tipo: { in: [...TIPOS_GASTO_CASERO] } }
+        : {
+            OR: [
+              { pagador_id: usuarioId },
+              { deudas: { some: { OR: [{ deudor_id: usuarioId }, { acreedor_id: usuarioId }] } } },
+            ],
+          }),
+    },
     orderBy: { fecha_creacion: 'desc' },
     include: {
       pagador: { select: { id: true, nombre: true, apellidos: true } },
-      deudas: true,
+      deudas: viviendaCasero
+        ? true
+        : {
+            where: {
+              OR: [{ deudor_id: usuarioId }, { acreedor_id: usuarioId }],
+            },
+          },
     },
   });
 
@@ -118,12 +139,19 @@ export const listarDeudas: express.RequestHandler = async (req, res) => {
     include: {
       deudor:   { select: { id: true, nombre: true, apellidos: true } },
       acreedor: { select: { id: true, nombre: true, apellidos: true } },
-      gasto:    { select: { concepto: true, factura_url: true } },
+      gasto:    { select: { concepto: true, tipo: true, factura_url: true } },
     },
     orderBy: { id: 'desc' },
   });
 
-  res.status(200).json(deudas);
+  res.status(200).json(
+    deudas.map((deuda) => ({
+      ...deuda,
+      categoria: TIPOS_GASTO_CASERO.includes(deuda.gasto.tipo as (typeof TIPOS_GASTO_CASERO)[number])
+        ? 'CASERO'
+        : 'COMPANEROS',
+    })),
+  );
 };
 
 export const saldarDeuda: express.RequestHandler = async (req, res) => {
@@ -246,6 +274,7 @@ export const crearGasto: express.RequestHandler = async (req, res) => {
 
   try {
     const facturaUrl = obtenerUrlArchivo(req.file);
+    const tipoGasto = req.usuario!.rol === 'CASERO' ? 'FACTURA_PUNTUAL' : 'ENTRE_COMPANEROS';
 
     if (req.file && !facturaUrl) {
       res.status(500).json({ error: 'No se pudo obtener la URL de la factura subida.' });
@@ -255,6 +284,7 @@ export const crearGasto: express.RequestHandler = async (req, res) => {
     const gasto = await crearGastoDividido({
       concepto,
       importe: importeNormalizado,
+      tipo: tipoGasto,
       viviendaId,
       pagadorId,
       implicadosIds,
@@ -339,12 +369,12 @@ export const actualizarGasto: express.RequestHandler = async (req, res) => {
   }
 
   const gasto = await prisma.gasto.findFirst({
-    where: { id: gastoId, vivienda_id: viviendaId },
+    where: { id: gastoId, vivienda_id: viviendaId, tipo: { in: [...TIPOS_GASTO_CASERO] } },
     include: { deudas: true },
   });
 
   if (!gasto) {
-    res.status(404).json({ error: 'Gasto no encontrado.' });
+    res.status(404).json({ error: 'Factura no encontrada para esta vivienda.' });
     return;
   }
 
@@ -424,11 +454,11 @@ export const subirFacturaGasto: express.RequestHandler = async (req, res) => {
   }
 
   const gasto = await prisma.gasto.findFirst({
-    where: { id: gastoId, vivienda_id: viviendaId },
+    where: { id: gastoId, vivienda_id: viviendaId, tipo: { in: [...TIPOS_GASTO_CASERO] } },
   });
 
   if (!gasto) {
-    res.status(404).json({ error: 'Gasto no encontrado.' });
+    res.status(404).json({ error: 'Factura no encontrada para esta vivienda.' });
     return;
   }
 

--- a/backend/src/cron/mensualidades.cron.ts
+++ b/backend/src/cron/mensualidades.cron.ts
@@ -26,6 +26,7 @@ export const procesarMensualidadesDelDia = async () => {
       await crearGastoDividido({
         concepto: gastoRecurrente.concepto,
         importe: gastoRecurrente.importe,
+        tipo: gastoRecurrente.tipo,
         viviendaId: gastoRecurrente.vivienda_id,
         pagadorId: gastoRecurrente.pagador_id,
       });

--- a/backend/src/cron/recordatorios.cron.ts
+++ b/backend/src/cron/recordatorios.cron.ts
@@ -1,6 +1,7 @@
 import cron from 'node-cron';
 import { EstadoDeuda } from '../generated/prisma/client';
 import { prisma } from '../lib/prisma';
+import { TIPOS_GASTO_CASERO } from '../services/gasto.service';
 import { enviarNotificacion } from '../services/push.service';
 
 let cronRecordatoriosMorososIniciado = false;
@@ -41,6 +42,11 @@ export const enviarRecordatoriosMorosos = async () => {
           apellidos: true,
         },
       },
+      gasto: {
+        select: {
+          tipo: true,
+        },
+      },
     },
   });
 
@@ -59,12 +65,18 @@ export const enviarRecordatoriosMorosos = async () => {
     }
 
     const nombreAcreedor = formatearNombre(deuda.acreedor.nombre, deuda.acreedor.apellidos);
+    const categoria = TIPOS_GASTO_CASERO.includes(
+      deuda.gasto?.tipo as (typeof TIPOS_GASTO_CASERO)[number],
+    )
+      ? 'casero'
+      : 'companeros';
     const mensaje = `Tienes un pago de ${formatearImporte(deuda.importe)} con ${nombreAcreedor} pendiente de realizar`;
 
     try {
       await enviarNotificacion(token, 'Pago pendiente', mensaje, {
         deudaId: deuda.id,
         acreedorId: deuda.acreedor.id,
+        categoria,
         tipo: 'recordatorio_deuda_pendiente',
       });
     } catch (error) {

--- a/backend/src/services/gasto.service.ts
+++ b/backend/src/services/gasto.service.ts
@@ -1,8 +1,21 @@
 import { prisma } from '../lib/prisma';
 
+export const TIPOS_GASTO_CASERO = [
+  'FACTURA_PUNTUAL',
+  'FACTURA_MENSUAL',
+  'CARGO_RECURRENTE',
+] as const;
+
+export const TIPOS_GASTO_COMPANEROS = ['ENTRE_COMPANEROS'] as const;
+
+export type TipoGastoRoomies =
+  | (typeof TIPOS_GASTO_CASERO)[number]
+  | (typeof TIPOS_GASTO_COMPANEROS)[number];
+
 type CrearGastoDivididoInput = {
   concepto: string;
   importe: number;
+  tipo?: TipoGastoRoomies;
   viviendaId: number;
   pagadorId: number;
   implicadosIds?: number[];
@@ -64,6 +77,7 @@ export const repartirImporteEnCentimos = (importe: number, participantesIds: num
 export const crearGastoDividido = async ({
   concepto,
   importe,
+  tipo = 'ENTRE_COMPANEROS',
   viviendaId,
   pagadorId,
   implicadosIds,
@@ -136,6 +150,7 @@ export const crearGastoDividido = async ({
       data: {
         concepto,
         importe: importeNormalizado,
+        tipo,
         factura_url: facturaUrl ?? null,
         fecha_creacion: fecha,
         pagador_id: pagadorId,
@@ -171,6 +186,7 @@ export const crearGastoDividido = async ({
     data: {
       concepto,
       importe: importeNormalizado,
+      tipo,
       factura_url: facturaUrl ?? null,
       fecha_creacion: fecha,
       pagador_id: pagadorId,

--- a/backend/tests/economico.test.ts
+++ b/backend/tests/economico.test.ts
@@ -26,11 +26,17 @@ const prisma = vi.hoisted(() => ({
     create: async (_args: unknown): Promise<unknown> => {
       throw new Error('Unexpected prisma call: gasto.create');
     },
+    findMany: async (_args: unknown): Promise<unknown> => {
+      throw new Error('Unexpected prisma call: gasto.findMany');
+    },
     findFirst: async (_args: unknown): Promise<unknown> => {
       throw new Error('Unexpected prisma call: gasto.findFirst');
     },
   },
   deuda: {
+    findMany: async (_args: unknown): Promise<unknown> => {
+      throw new Error('Unexpected prisma call: deuda.findMany');
+    },
     findFirst: async (_args: unknown): Promise<unknown> => {
       throw new Error('Unexpected prisma call: deuda.findFirst');
     },
@@ -46,15 +52,26 @@ const prisma = vi.hoisted(() => ({
 vi.mock('../src/lib/prisma', () => ({ prisma }));
 
 const { crearGastoDividido } = await import('../src/services/gasto.service');
-const { actualizarGasto, saldarDeuda } = await import('../src/controllers/gasto.controller');
+const {
+  actualizarGasto,
+  listarGastos,
+  saldarDeuda,
+} = await import('../src/controllers/gasto.controller');
+const { listarCobrosVivienda } = await import('../src/controllers/cobros.controller');
 
-let ultimoGastoCreate: { data: { deudas: { create: unknown[] }; importe: number } } | null = null;
+let ultimoGastoCreate: {
+  data: { deudas: { create: unknown[] }; importe: number; tipo?: string };
+} | null = null;
 let deudaUpdateCalls: unknown[] = [];
+let ultimoGastoFindMany: unknown = null;
+let ultimaDeudaFindMany: unknown = null;
 let transactionCalled = false;
 
 function resetPrisma() {
   ultimoGastoCreate = null;
   deudaUpdateCalls = [];
+  ultimoGastoFindMany = null;
+  ultimaDeudaFindMany = null;
   transactionCalled = false;
 
   prisma.vivienda.findUnique = async () => ({ casero_id: 99 });
@@ -79,7 +96,15 @@ function resetPrisma() {
       })),
     };
   };
+  prisma.gasto.findMany = async (args: unknown) => {
+    ultimoGastoFindMany = args;
+    return [];
+  };
   prisma.gasto.findFirst = async () => null;
+  prisma.deuda.findMany = async (args: unknown) => {
+    ultimaDeudaFindMany = args;
+    return [];
+  };
   prisma.deuda.findFirst = async () => null;
   prisma.deuda.update = async (args: unknown) => {
     deudaUpdateCalls.push(args);
@@ -163,6 +188,19 @@ describe('modulo economico', () => {
 
     assert.deepEqual(importesCreados(), [3.34, 3.33, 3.33]);
     assert.equal(suma(importesCreados()), 10);
+    assert.equal(ultimoGastoCreate?.data.tipo, 'ENTRE_COMPANEROS');
+  });
+
+  test('marca las facturas del casero con tipo explicito', async () => {
+    await crearGastoDividido({
+      concepto: 'Factura luz',
+      importe: 90,
+      tipo: 'FACTURA_PUNTUAL',
+      viviendaId: 1,
+      pagadorId: 99,
+    });
+
+    assert.equal(ultimoGastoCreate?.data.tipo, 'FACTURA_PUNTUAL');
   });
 
   test('acepta reparto manual correcto con cuota cero sin crear deuda de importe cero', async () => {
@@ -256,6 +294,72 @@ describe('modulo economico', () => {
 
     assert.equal(res.statusCode, 403);
     assert.deepEqual(deudaUpdateCalls, []);
+  });
+
+  test('el casero solo lista gastos de facturacion propia, no gastos entre companeros', async () => {
+    prisma.vivienda.findFirst = async () => ({ id: 1, casero_id: 99 });
+
+    const res = await invoke(
+      listarGastos,
+      request({
+        usuario: { id: 99, rol: 'CASERO' },
+        params: { viviendaId: '1' },
+      }),
+    );
+
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(
+      (ultimoGastoFindMany as { where: { tipo: { in: string[] } } }).where.tipo.in,
+      ['FACTURA_PUNTUAL', 'FACTURA_MENSUAL', 'CARGO_RECURRENTE'],
+    );
+  });
+
+  test('el inquilino solo recibe gastos y deudas donde participa', async () => {
+    prisma.habitacion.findFirst = async () => ({ id: 1 });
+
+    const res = await invoke(
+      listarGastos,
+      request({
+        usuario: { id: 2, rol: 'INQUILINO' },
+        params: { viviendaId: '1' },
+      }),
+    );
+
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual((ultimoGastoFindMany as { where: unknown }).where, {
+      vivienda_id: 1,
+      OR: [
+        { pagador_id: 2 },
+        { deudas: { some: { OR: [{ deudor_id: 2 }, { acreedor_id: 2 }] } } },
+      ],
+    });
+    assert.deepEqual(
+      (ultimoGastoFindMany as { include: { deudas: { where: unknown } } }).include.deudas.where,
+      { OR: [{ deudor_id: 2 }, { acreedor_id: 2 }] },
+    );
+  });
+
+  test('el dashboard de cobros excluye gastos entre companeros por tipo', async () => {
+    prisma.vivienda.findUnique = async () => ({
+      id: 1,
+      alias_nombre: 'Piso Centro',
+      direccion: 'Calle Luna 1',
+      casero_id: 99,
+    });
+
+    const res = await invoke(
+      listarCobrosVivienda,
+      request({
+        usuario: { id: 99, rol: 'CASERO' },
+        params: { viviendaId: '1' },
+      }),
+    );
+
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(
+      (ultimaDeudaFindMany as { where: { gasto: { tipo: { in: string[] } } } }).where.gasto.tipo.in,
+      ['FACTURA_PUNTUAL', 'FACTURA_MENSUAL', 'CARGO_RECURRENTE'],
+    );
   });
 
   test('el deudor puede saldar su propia deuda pendiente', async () => {

--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -1086,12 +1086,14 @@ Todos los endpoints de esta seccion estan protegidos por `mod_gastos`. Si el mod
 
 ### GET `/viviendas/:viviendaId/gastos`
 
-Lista los gastos de una vivienda con su pagador y el array de `deudas[]` generado para cada gasto.
+Lista los gastos de una vivienda con su pagador y el array de `deudas[]` generado para cada gasto, filtrando por actor y origen del cobro.
 
 **Auth requerida:** Si - `Authorization: Bearer <token>`
 
 **Reglas de acceso:**
 - Debes pertenecer a la vivienda (`CASERO` propietario o `INQUILINO` con habitacion asignada).
+- El casero solo recibe gastos de facturacion propia: `FACTURA_PUNTUAL`, `FACTURA_MENSUAL` y `CARGO_RECURRENTE`.
+- El inquilino solo recibe gastos donde participa como pagador, deudor o acreedor; las deudas embebidas se reducen a su relacion directa.
 
 **Respuestas:**
 
@@ -1103,6 +1105,7 @@ Lista los gastos de una vivienda con su pagador y el array de `deudas[]` generad
 
 **Campos relevantes por gasto:**
 - `pagador { id, nombre, apellidos }`
+- `tipo`: `ENTRE_COMPANEROS`, `FACTURA_PUNTUAL`, `FACTURA_MENSUAL` o `CARGO_RECURRENTE`
 - `factura_url` cuando existe factura original subida a Cloudinary
 - `deudas[]` con `id`, `deudor_id`, `acreedor_id`, `importe`, `estado` y `justificante_url`
 
@@ -1110,7 +1113,7 @@ Lista los gastos de una vivienda con su pagador y el array de `deudas[]` generad
 
 ### POST `/viviendas/:viviendaId/gastos`
 
-Crea un gasto puntual y reparte automaticamente la deuda entre los inquilinos activos de la vivienda. Tambien permite registrar facturas puntuales del casero con adjunto y reparto manual.
+Crea un gasto puntual y reparte automaticamente la deuda entre los inquilinos activos de la vivienda. Si lo crea un inquilino, se guarda como `ENTRE_COMPANEROS`; si lo crea el casero, se guarda como `FACTURA_PUNTUAL`.
 
 **Auth requerida:** Si - `Authorization: Bearer <token>`
 
@@ -1145,7 +1148,7 @@ Crea un gasto puntual y reparte automaticamente la deuda entre los inquilinos ac
 
 ### PATCH `/viviendas/:viviendaId/gastos/:gastoId`
 
-Edita una factura mensual o gasto ya generado.
+Edita una factura mensual, factura puntual o cargo recurrente ya generado por el casero. No permite gestionar gastos `ENTRE_COMPANEROS`.
 
 **Auth requerida:** Si - `Authorization: Bearer <token>`
 
@@ -1176,7 +1179,7 @@ Edita una factura mensual o gasto ya generado.
 
 ### POST `/viviendas/:viviendaId/gastos/:gastoId/factura`
 
-Sube o reemplaza la imagen de factura adjunta a un gasto.
+Sube o reemplaza la imagen de factura adjunta a una factura o cargo del casero. No permite adjuntar facturas a gastos `ENTRE_COMPANEROS`.
 
 **Auth requerida:** Si - `Authorization: Bearer <token>`
 
@@ -1222,7 +1225,8 @@ Lista las deudas de la vivienda donde el usuario autenticado participa como deud
 **Incluye:**
 - `deudor { id, nombre, apellidos }`
 - `acreedor { id, nombre, apellidos }`
-- `gasto { concepto, factura_url }`
+- `categoria`: `CASERO` para facturas/cargos del propietario y `COMPANEROS` para gastos comunes entre inquilinos
+- `gasto { concepto, tipo, factura_url }`
 
 ---
 
@@ -1250,7 +1254,7 @@ Marca una deuda como `PAGADA`.
 
 ### GET `/viviendas/:viviendaId/gastos-recurrentes`
 
-Lista las mensualidades configuradas para una vivienda.
+Lista las mensualidades configuradas para una vivienda. Es un flujo exclusivo del casero.
 
 **Auth requerida:** Si - `Authorization: Bearer <token>`
 
@@ -1275,7 +1279,7 @@ Lista las mensualidades configuradas para una vivienda.
 
 ### POST `/viviendas/:viviendaId/gastos-recurrentes`
 
-Crea una mensualidad recurrente para la vivienda. Es un flujo de casero; el inquilino no puede crear ni listar gastos recurrentes.
+Crea una mensualidad recurrente para la vivienda como `FACTURA_MENSUAL`. Es un flujo de casero; el inquilino no puede crear ni listar gastos recurrentes.
 
 **Auth requerida:** Si - `Authorization: Bearer <token>`
 
@@ -1307,9 +1311,9 @@ Devuelve el dashboard financiero mensual del casero para una vivienda.
 - Solo el `CASERO` propietario de la vivienda puede consultar este endpoint.
 
 **Comportamiento:**
-- Filtra deudas del mes actual donde el usuario autenticado es el acreedor.
+- Filtra deudas del mes actual donde el usuario autenticado es el acreedor y el gasto pertenece al flujo del casero (`FACTURA_PUNTUAL`, `FACTURA_MENSUAL`, `CARGO_RECURRENTE`).
 - Calcula `total_pagado_mes`, `total_pendiente` y `total_deudas`.
-- Devuelve detalle por deuda con `deudor`, `gasto` (`id`, `concepto`, `importe`, `factura_url`, `fecha_creacion`) y `justificante_url`.
+- Devuelve detalle por deuda con `deudor`, `categoria: CASERO`, `gasto` (`id`, `concepto`, `importe`, `tipo`, `factura_url`, `fecha_creacion`) y `justificante_url`.
 
 **Respuestas:**
 

--- a/docs/changelog/Epica16/epica-16-issue-270-separar-cobros.md
+++ b/docs/changelog/Epica16/epica-16-issue-270-separar-cobros.md
@@ -1,0 +1,22 @@
+# Epica 16 - Issue 270 - Separacion de cobros por actor
+
+## Objetivo
+Separar la logica de cobros del casero, deudas del inquilino y movimientos entre companeros para que cada usuario consulte y gestione solo el flujo economico que le corresponde.
+
+## Cambios
+- Se anade `TipoGasto` al modelo Prisma con `ENTRE_COMPANEROS`, `FACTURA_PUNTUAL`, `FACTURA_MENSUAL` y `CARGO_RECURRENTE`.
+- Se incluye migracion SQL para tipar datos existentes: los gastos pagados por el casero pasan a `FACTURA_PUNTUAL` y el resto queda como `ENTRE_COMPANEROS`.
+- Los gastos creados por inquilinos quedan marcados como `ENTRE_COMPANEROS`; las facturas puntuales del casero quedan como `FACTURA_PUNTUAL`.
+- Las mensualidades recurrentes se guardan y generan como `FACTURA_MENSUAL`.
+- El dashboard de cobros del casero filtra por tipos del casero y deja fuera los gastos entre companeros.
+- La lista de gastos del inquilino restringe los movimientos y deudas embebidas a su participacion directa.
+- La API de deudas devuelve `categoria` para distinguir `CASERO` y `COMPANEROS` sin inferir por IDs en frontend.
+- La seed demo marca explicitamente gastos entre inquilinos, facturas puntuales y recurrentes.
+
+## Verificacion
+- Tests unitarios de tipo por defecto en gastos entre companeros.
+- Tests unitarios de factura del casero con tipo explicito.
+- Tests unitarios de filtros del casero, del inquilino y del dashboard de cobros.
+
+## Riesgos conocidos
+- La clasificacion historica asume que los gastos cuyo pagador es el casero pertenecen al flujo de facturacion del propietario.

--- a/frontend/app/casero/(tabs)/cobros.tsx
+++ b/frontend/app/casero/(tabs)/cobros.tsx
@@ -63,10 +63,12 @@ type DeudaCobro = {
   importe: number;
   estado: 'PENDIENTE' | 'PAGADA';
   justificante_url: string | null;
+  categoria?: 'CASERO';
   gasto: {
     id: number;
     concepto: string;
     importe: number;
+    tipo?: 'FACTURA_PUNTUAL' | 'FACTURA_MENSUAL' | 'CARGO_RECURRENTE';
     factura_url: string | null;
     fecha_creacion: string;
   };

--- a/frontend/app/inquilino/(tabs)/gastos.tsx
+++ b/frontend/app/inquilino/(tabs)/gastos.tsx
@@ -36,15 +36,21 @@ type Deuda = {
   importe: number;
   estado: 'PENDIENTE' | 'PAGADA';
   justificante_url: string | null;
+  categoria?: 'CASERO' | 'COMPANEROS';
   deudor: UsuarioBasico;
   acreedor: UsuarioBasico;
-  gasto: { concepto: string; factura_url: string | null };
+  gasto: {
+    concepto: string;
+    tipo?: 'ENTRE_COMPANEROS' | 'FACTURA_PUNTUAL' | 'FACTURA_MENSUAL' | 'CARGO_RECURRENTE';
+    factura_url: string | null;
+  };
 };
 
 type Gasto = {
   id: number;
   concepto: string;
   importe: number;
+  tipo?: 'ENTRE_COMPANEROS' | 'FACTURA_PUNTUAL' | 'FACTURA_MENSUAL' | 'CARGO_RECURRENTE';
   fecha_creacion: string;
   pagador_id: number;
   pagador: UsuarioBasico;
@@ -195,8 +201,18 @@ export default function GastosInquilinoTab() {
   const esDeudaMia = (deuda: Deuda) =>
     miId !== null && (deuda.deudor_id === miId || deuda.acreedor_id === miId);
   const esDeudaEntreCompaneros = (deuda: Deuda) =>
-    idsCompaneros.has(deuda.deudor_id) && idsCompaneros.has(deuda.acreedor_id);
+    deuda.categoria
+      ? deuda.categoria === 'COMPANEROS'
+      : deuda.gasto.tipo
+        ? deuda.gasto.tipo === 'ENTRE_COMPANEROS'
+        : idsCompaneros.has(deuda.deudor_id) && idsCompaneros.has(deuda.acreedor_id);
 
+  const gastosEntreCompaneros = gastos.filter(
+    (gasto) =>
+      gasto.tipo !== 'FACTURA_PUNTUAL' &&
+      gasto.tipo !== 'FACTURA_MENSUAL' &&
+      gasto.tipo !== 'CARGO_RECURRENTE',
+  );
   const deudasRelacionadas = deudas.filter(esDeudaMia);
   const deudasPendientes = deudasRelacionadas.filter((deuda) => deuda.estado === 'PENDIENTE');
   const deudasPendientesCompaneros = deudasPendientes.filter(esDeudaEntreCompaneros);
@@ -790,7 +806,7 @@ export default function GastosInquilinoTab() {
           </>
         )}
 
-        {!errorCarga && (gastos.length === 0 ? (
+        {!errorCarga && (gastosEntreCompaneros.length === 0 ? (
           <View style={styles.emptyContainer}>
             <View style={styles.emptyIconBox}>
               <Ionicons name="wallet-outline" size={40} color={Theme.colors.primary} />
@@ -804,7 +820,7 @@ export default function GastosInquilinoTab() {
         ) : (
           <>
             <Text style={[styles.seccionTitulo, styles.seccionTituloSolo]}>Movimientos</Text>
-            {gastos.map((gasto) => (
+            {gastosEntreCompaneros.map((gasto) => (
               <View key={gasto.id} style={styles.gastoCard}>
                 <AvatarInitials nombre={gasto.pagador.nombre} apellidos={gasto.pagador.apellidos} size={46} />
                 <View style={styles.gastoInfo}>


### PR DESCRIPTION
## Objetivo
Separar los cobros del casero, las deudas del inquilino y los movimientos entre compañeros para evitar mezclar facturación privada con gastos compartidos.

## Cambios principales
* Añadido `TipoGasto` en Prisma para distinguir `ENTRE_COMPANEROS`, `FACTURA_PUNTUAL`, `FACTURA_MENSUAL` y `CARGO_RECURRENTE`.
* Incorporada migración SQL para clasificar datos existentes según el pagador del gasto.
* Filtrados los endpoints de gastos, deudas y cobros por actor, origen y participación real del usuario.
* Actualizados cron de mensualidades, recordatorios push, seed y pruebas económicas para conservar la nueva categoría.
* Documentada la nueva separación en la API backend.

## UI / UX
* Ajustada la lectura frontend de `tipo` y `categoria` para separar movimientos del casero y entre compañeros sin inferencias por IDs.

## Changelog
* `docs/changelog/Epica16/epica-16-issue-270-separar-cobros.md`

## Testing
* `npx prisma validate --schema prisma/schema.prisma`
* `npm run build` en backend
* `npm test -- economico.test.ts`
* `npm test` en backend
* `npm run lint` en frontend