### PR TITLE
Add edición trazable de facturas mensuales

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -77,6 +77,7 @@ model Usuario {
   turnos_limpieza    TurnoLimpieza[]
   asignaciones_fijas AsignacionLimpiezaFija[]
   gastos_pagados     Gasto[]
+  gastos_modificados Gasto[]                  @relation("ModificadorGasto")
   gastos_recurrentes_pagados GastoRecurrente[]
   deudas_a_pagar     Deuda[]                  @relation("DeudorDeuda")
   deudas_a_cobrar    Deuda[]                  @relation("AcreedorDeuda")
@@ -148,16 +149,19 @@ model Anuncio {
 // ── Módulo de gastos y balances ───────────────────────────────────────────────
 
 model Gasto {
-  id             Int      @id @default(autoincrement())
-  concepto       String
-  importe        Float
-  factura_url    String?
-  fecha_creacion DateTime @default(now())
-  pagador_id     Int
-  pagador        Usuario  @relation(fields: [pagador_id], references: [id])
-  vivienda_id    Int
-  vivienda       Vivienda @relation(fields: [vivienda_id], references: [id])
-  deudas         Deuda[]
+  id                 Int       @id @default(autoincrement())
+  concepto           String
+  importe            Float
+  factura_url        String?
+  fecha_creacion     DateTime  @default(now())
+  fecha_modificacion DateTime?
+  pagador_id         Int
+  pagador            Usuario   @relation(fields: [pagador_id], references: [id])
+  modificado_por_id  Int?
+  modificado_por     Usuario?  @relation("ModificadorGasto", fields: [modificado_por_id], references: [id], onDelete: SetNull)
+  vivienda_id        Int
+  vivienda           Vivienda  @relation(fields: [vivienda_id], references: [id])
+  deudas             Deuda[]
 }
 
 model GastoRecurrente {

--- a/backend/src/controllers/cobros.controller.ts
+++ b/backend/src/controllers/cobros.controller.ts
@@ -76,6 +76,14 @@ export const listarCobrosVivienda: express.RequestHandler = async (req, res) => 
           importe: true,
           factura_url: true,
           fecha_creacion: true,
+          fecha_modificacion: true,
+          modificado_por: {
+            select: {
+              id: true,
+              nombre: true,
+              apellidos: true,
+            },
+          },
         },
       },
     },

--- a/backend/src/controllers/gasto.controller.ts
+++ b/backend/src/controllers/gasto.controller.ts
@@ -295,6 +295,8 @@ export const actualizarGasto: express.RequestHandler = async (req, res) => {
     concepto?: string;
     importe?: number;
     fecha_creacion?: Date;
+    fecha_modificacion?: Date;
+    modificado_por_id?: number;
   } = {};
 
   if (concepto !== undefined) {
@@ -348,17 +350,21 @@ export const actualizarGasto: express.RequestHandler = async (req, res) => {
     return;
   }
 
-  const importeCambia =
-    datosActualizacion.importe !== undefined &&
-    Number(datosActualizacion.importe.toFixed(2)) !== Number(gasto.importe.toFixed(2));
   const hayPagosRegistrados = gasto.deudas.some((deuda) => deuda.estado === 'PAGADA');
 
-  if (importeCambia && hayPagosRegistrados) {
+  if (hayPagosRegistrados) {
     res.status(400).json({
-      error: 'El importe no puede modificarse porque ya existen pagos registrados.',
+      error: 'Esta factura no puede modificarse porque ya existen pagos registrados.',
     });
     return;
   }
+
+  datosActualizacion.fecha_modificacion = new Date();
+  datosActualizacion.modificado_por_id = usuarioId;
+
+  const importeCambia =
+    datosActualizacion.importe !== undefined &&
+    Number(datosActualizacion.importe.toFixed(2)) !== Number(gasto.importe.toFixed(2));
 
   const gastoActualizado = await prisma.$transaction(async (tx) => {
     if (importeCambia && gasto.deudas.length > 0) {
@@ -383,6 +389,7 @@ export const actualizarGasto: express.RequestHandler = async (req, res) => {
       data: datosActualizacion,
       include: {
         pagador: { select: { id: true, nombre: true, apellidos: true } },
+        modificado_por: { select: { id: true, nombre: true, apellidos: true } },
         deudas: true,
       },
     });
@@ -425,10 +432,18 @@ export const subirFacturaGasto: express.RequestHandler = async (req, res) => {
 
   const gasto = await prisma.gasto.findFirst({
     where: { id: gastoId, vivienda_id: viviendaId },
+    include: { deudas: true },
   });
 
   if (!gasto) {
     res.status(404).json({ error: 'Gasto no encontrado.' });
+    return;
+  }
+
+  if (gasto.deudas.some((deuda) => deuda.estado === 'PAGADA')) {
+    res.status(400).json({
+      error: 'Esta factura no puede modificarse porque ya existen pagos registrados.',
+    });
     return;
   }
 
@@ -441,9 +456,14 @@ export const subirFacturaGasto: express.RequestHandler = async (req, res) => {
 
   const gastoActualizado = await prisma.gasto.update({
     where: { id: gasto.id },
-    data: { factura_url: secureUrl },
+    data: {
+      factura_url: secureUrl,
+      fecha_modificacion: new Date(),
+      modificado_por_id: usuarioId,
+    },
     include: {
       pagador: { select: { id: true, nombre: true, apellidos: true } },
+      modificado_por: { select: { id: true, nombre: true, apellidos: true } },
       deudas: true,
     },
   });

--- a/backend/tests/economico.test.ts
+++ b/backend/tests/economico.test.ts
@@ -300,6 +300,30 @@ describe('modulo economico', () => {
     assert.equal(transactionCalled, false);
   });
 
+  test('bloquea editar cualquier dato de una factura con pagos registrados', async () => {
+    prisma.vivienda.findFirst = async () => ({ id: 1, casero_id: 99 });
+    prisma.gasto.findFirst = async () => ({
+      id: 12,
+      importe: 100,
+      deudas: [{ id: 20, deudor_id: 2, estado: 'PAGADA' }],
+    });
+
+    const res = await invoke(
+      actualizarGasto,
+      request({
+        usuario: { id: 99, rol: 'CASERO' },
+        params: { viviendaId: '1', gastoId: '12' },
+        body: { concepto: 'Mensualidad revisada' },
+      }),
+    );
+
+    assert.equal(res.statusCode, 400);
+    assert.deepEqual(res.body, {
+      error: 'Esta factura no puede modificarse porque ya existen pagos registrados.',
+    });
+    assert.equal(transactionCalled, false);
+  });
+
   test('edita importes abiertos redistribuyendo en centimos exactos', async () => {
     prisma.vivienda.findFirst = async () => ({ id: 1, casero_id: 99 });
     prisma.gasto.findFirst = async () => ({
@@ -325,5 +349,7 @@ describe('modulo economico', () => {
       { where: { id: 20 }, data: { importe: 5.01 } },
       { where: { id: 21 }, data: { importe: 5 } },
     ]);
+    assert.equal((res.body as { modificado_por_id: number }).modificado_por_id, 99);
+    assert.ok((res.body as { fecha_modificacion: Date }).fecha_modificacion instanceof Date);
   });
 });

--- a/docs/changelog/Epica14/epica-14-issue-271-editar-facturas-mensuales.md
+++ b/docs/changelog/Epica14/epica-14-issue-271-editar-facturas-mensuales.md
@@ -1,0 +1,14 @@
+# Issue #271 - Editar facturas mensuales
+
+## Cambios
+
+- `backend/prisma/schema.prisma`: `Gasto` registra `fecha_modificacion` y el usuario `modificado_por` que edito la factura.
+- `backend/src/controllers/gasto.controller.ts`: una factura con cobros pagados queda bloqueada para cambios de concepto, importe, fecha o adjunto; las facturas abiertas actualizan las deudas pendientes cuando cambia el importe.
+- `backend/src/controllers/cobros.controller.ts`: el dashboard de cobros expone la trazabilidad de la ultima modificacion.
+- `frontend/app/casero/(tabs)/cobros.tsx`: el casero puede editar concepto, importe, fecha y adjunto de facturas abiertas, ve cuando se modificaron y recibe feedback cuando una factura esta bloqueada.
+
+## Validacion
+
+- `npm test` en `backend`.
+- `npm run build` en `backend`.
+- `npm run lint` en `frontend`.

--- a/frontend/app/casero/(tabs)/cobros.tsx
+++ b/frontend/app/casero/(tabs)/cobros.tsx
@@ -69,6 +69,12 @@ type DeudaCobro = {
     importe: number;
     factura_url: string | null;
     fecha_creacion: string;
+    fecha_modificacion: string | null;
+    modificado_por: {
+      id: number;
+      nombre: string;
+      apellidos: string | null;
+    } | null;
   };
   deudor: {
     id: number;
@@ -98,6 +104,12 @@ type FacturaEmitida = {
   importe: number;
   factura_url: string | null;
   fecha_creacion: string;
+  fecha_modificacion: string | null;
+  modificado_por: {
+    id: number;
+    nombre: string;
+    apellidos: string | null;
+  } | null;
   deudas: DeudaCobro[];
 };
 
@@ -107,6 +119,12 @@ type GastoActualizadoResponse = {
   importe: number;
   factura_url: string | null;
   fecha_creacion: string;
+  fecha_modificacion: string | null;
+  modificado_por: {
+    id: number;
+    nombre: string;
+    apellidos: string | null;
+  } | null;
   deudas: {
     id: number;
     importe: number;
@@ -187,6 +205,7 @@ export default function CaseroCobrosScreen() {
   const [facturaVisualizando, setFacturaVisualizando] = useState<FacturaEmitida | null>(null);
   const [conceptoEditado, setConceptoEditado] = useState('');
   const [importeEditado, setImporteEditado] = useState('');
+  const [fechaEditada, setFechaEditada] = useState('');
   const [guardandoFactura, setGuardandoFactura] = useState(false);
   const [subiendoFactura, setSubiendoFactura] = useState(false);
   const [inquilinosActivos, setInquilinosActivos] = useState<InquilinoActivo[]>([]);
@@ -346,6 +365,8 @@ export default function CaseroCobrosScreen() {
         importe: deuda.gasto.importe,
         factura_url: deuda.gasto.factura_url,
         fecha_creacion: deuda.gasto.fecha_creacion,
+        fecha_modificacion: deuda.gasto.fecha_modificacion,
+        modificado_por: deuda.gasto.modificado_por,
         deudas: [deuda],
       });
     });
@@ -587,9 +608,21 @@ export default function CaseroCobrosScreen() {
   };
 
   const abrirEditorFactura = (factura: FacturaEmitida) => {
+    const pagosRegistrados = factura.deudas.some((deuda) => deuda.estado === 'PAGADA');
+
+    if (pagosRegistrados) {
+      Toast.show({
+        type: 'info',
+        text1: 'Factura bloqueada',
+        text2: 'Ya hay pagos registrados y no se puede modificar.',
+      });
+      return;
+    }
+
     setFacturaEditando(factura);
     setConceptoEditado(factura.concepto);
     setImporteEditado(String(factura.importe).replace('.', ','));
+    setFechaEditada(factura.fecha_creacion.slice(0, 10));
   };
 
   const cerrarEditorFactura = () => {
@@ -600,6 +633,7 @@ export default function CaseroCobrosScreen() {
     setFacturaEditando(null);
     setConceptoEditado('');
     setImporteEditado('');
+    setFechaEditada('');
   };
 
   const guardarFactura = async () => {
@@ -609,6 +643,7 @@ export default function CaseroCobrosScreen() {
 
     const conceptoNormalizado = conceptoEditado.trim();
     const importeNormalizado = Number(importeEditado.replace(',', '.'));
+    const fechaNormalizada = fechaEditada.trim();
 
     if (!conceptoNormalizado) {
       Toast.show({ type: 'error', text1: 'El concepto no puede estar vacío.' });
@@ -620,10 +655,16 @@ export default function CaseroCobrosScreen() {
       return;
     }
 
+    if (!fechaNormalizada || Number.isNaN(new Date(fechaNormalizada).getTime())) {
+      Toast.show({ type: 'error', text1: 'Introduce una fecha válida.' });
+      return;
+    }
+
     setGuardandoFactura(true);
     try {
-      const payload: { concepto: string; importe?: number } = {
+      const payload: { concepto: string; fecha: string; importe?: number } = {
         concepto: conceptoNormalizado,
+        fecha: fechaNormalizada,
       };
 
       if (!facturaTienePagos) {
@@ -640,6 +681,7 @@ export default function CaseroCobrosScreen() {
       setFacturaEditando(null);
       setConceptoEditado('');
       setImporteEditado('');
+      setFechaEditada('');
       Toast.show({ type: 'success', text1: 'Factura actualizada.' });
     } catch (error: any) {
       Toast.show({
@@ -674,6 +716,8 @@ export default function CaseroCobrosScreen() {
             importe: gasto.importe,
             factura_url: gasto.factura_url,
             fecha_creacion: gasto.fecha_creacion,
+            fecha_modificacion: gasto.fecha_modificacion,
+            modificado_por: gasto.modificado_por,
           },
         };
       });
@@ -741,6 +785,8 @@ export default function CaseroCobrosScreen() {
           ? {
               ...facturaActual,
               factura_url: data.factura_url,
+              fecha_modificacion: data.fecha_modificacion,
+              modificado_por: data.modificado_por,
             }
           : facturaActual,
       );
@@ -1229,6 +1275,13 @@ export default function CaseroCobrosScreen() {
                 keyboardType="decimal-pad"
                 editable={!facturaTienePagos}
               />
+              <CustomInput
+                label="Periodo / fecha"
+                value={fechaEditada}
+                onChangeText={setFechaEditada}
+                placeholder="2026-04-11"
+                editable={!facturaTienePagos}
+              />
             </View>
 
             <View style={styles.invoicePhotoBlock}>
@@ -1360,13 +1413,28 @@ function FacturaCard({
           </Text>
         </View>
         <Pressable
-          style={styles.invoiceEditButton}
+          style={[
+            styles.invoiceEditButton,
+            pagosRegistrados && styles.invoiceEditButtonDisabled,
+          ]}
           onPress={() => onEditar(factura)}
           accessibilityRole="button"
           accessibilityLabel={`Editar factura ${factura.concepto}`}
+          accessibilityState={{ disabled: pagosRegistrados }}
         >
-          <Ionicons name="create-outline" size={18} color={Theme.colors.primary} />
-          <Text style={styles.invoiceEditText}>Editar</Text>
+          <Ionicons
+            name={pagosRegistrados ? 'lock-closed-outline' : 'create-outline'}
+            size={18}
+            color={pagosRegistrados ? Theme.colors.textMuted : Theme.colors.primary}
+          />
+          <Text
+            style={[
+              styles.invoiceEditText,
+              pagosRegistrados && styles.invoiceEditTextDisabled,
+            ]}
+          >
+            {pagosRegistrados ? 'Bloqueada' : 'Editar'}
+          </Text>
         </Pressable>
       </View>
 
@@ -1382,6 +1450,13 @@ function FacturaCard({
           <Ionicons name="image-outline" size={15} color={Theme.colors.info} />
           <Text style={styles.receiptLinkText}>Ver factura</Text>
         </Pressable>
+      )}
+
+      {factura.fecha_modificacion && factura.modificado_por && (
+        <Text style={styles.invoiceTrace}>
+          Editada el {formatearFecha(factura.fecha_modificacion)} por{' '}
+          {nombreCompleto(factura.modificado_por.nombre, factura.modificado_por.apellidos)}
+        </Text>
       )}
     </View>
   );

--- a/frontend/styles/casero/cobros.styles.ts
+++ b/frontend/styles/casero/cobros.styles.ts
@@ -213,10 +213,16 @@ export const styles = StyleSheet.create({
     gap: Theme.spacing.xs,
     flexShrink: 0,
   },
+  invoiceEditButtonDisabled: {
+    backgroundColor: Theme.colors.surface2,
+  },
   invoiceEditText: {
     fontSize: Theme.typography.caption,
     fontWeight: '800',
     color: Theme.colors.primary,
+  },
+  invoiceEditTextDisabled: {
+    color: Theme.colors.textMuted,
   },
   invoiceFooter: {
     flexDirection: 'row',
@@ -238,6 +244,12 @@ export const styles = StyleSheet.create({
     color: Theme.colors.textSecondary,
     textAlign: 'right',
     flexShrink: 1,
+  },
+  invoiceTrace: {
+    fontSize: Theme.typography.caption,
+    fontWeight: '700',
+    color: Theme.colors.textTertiary,
+    lineHeight: 18,
   },
   debtCard: {
     backgroundColor: Theme.colors.surface,


### PR DESCRIPTION
## Objetivo
Permitir que el casero edite facturas mensuales abiertas manteniendo trazabilidad y bloqueando cambios cuando ya existen pagos registrados.

## Cambios principales
* Añadida trazabilidad en `Gasto` con fecha de modificación y usuario modificador.
* Bloqueada la edición de facturas con deudas pagadas desde el backend, incluyendo datos y adjuntos.
* Mantenida la redistribución de deudas pendientes cuando cambia el importe de una factura editable.
* Expuesta la trazabilidad en el dashboard de cobros.

## UI / UX
* Actualizado el flujo de Cobros para mostrar facturas bloqueadas, feedback claro y edición de concepto, importe, fecha y adjunto en facturas abiertas.
* Ajustados estados visuales con tokens de `Theme.ts` y estilos existentes.

## Changelog
* `docs/changelog/Epica14/epica-14-issue-271-editar-facturas-mensuales.md`

## Testing
* `npm test` en `backend`.
* `npm run build` en `backend`.
* `npm run lint` en `frontend`.