### PR TITLE
Add acordeón de facturas pasadas

### DIFF
--- a/docs/changelog/Epica16/epica-16-issue-272-acordeon-facturas-pasadas.md
+++ b/docs/changelog/Epica16/epica-16-issue-272-acordeon-facturas-pasadas.md
@@ -1,0 +1,15 @@
+# Epica 16 - Issue 272 - Acordeon para facturas pasadas
+
+## Objetivo
+Ordenar el listado acumulativo de facturas emitidas para que las facturas actuales o con cobros pendientes sigan visibles y el historico cerrado quede agrupado por mes.
+
+## Cambios
+- Se anade `AccordionSection` como componente comun reutilizable para listados acumulativos plegables.
+- El dashboard de cobros del casero prioriza facturas del mes actual o con deudas pendientes.
+- Las facturas pasadas con todas sus deudas pagadas se agrupan por mes y ano en acordeones plegados por defecto.
+- El acordeon expone estado accesible expandido/colapsado y conserva labels tactiles claros.
+- Se anaden tests del comportamiento de plegado y accesibilidad basica del acordeon.
+
+## Verificacion
+- `frontend`: `npm test -- --runInBand`.
+- `frontend`: `npm run lint` sin errores; persisten warnings previos en pantallas no tocadas.

--- a/frontend/app/casero/(tabs)/cobros.tsx
+++ b/frontend/app/casero/(tabs)/cobros.tsx
@@ -17,6 +17,7 @@ import { Image } from 'expo-image';
 import * as ImagePicker from 'expo-image-picker';
 import { useFocusEffect, useRouter } from 'expo-router';
 import Toast from 'react-native-toast-message';
+import { AccordionSection } from '@/components/common/AccordionSection';
 import { CustomButton } from '@/components/common/CustomButton';
 import { CustomInput } from '@/components/common/CustomInput';
 import { LoadingScreen } from '@/components/common/LoadingScreen';
@@ -122,6 +123,13 @@ type RepartoFacturaPuntualLinea = {
   automatico: boolean;
 };
 
+type GrupoFacturas = {
+  key: string;
+  titulo: string;
+  total: number;
+  facturas: FacturaEmitida[];
+};
+
 const formatearImporte = (importe: number) =>
   importe.toLocaleString('es-ES', { style: 'currency', currency: 'EUR' });
 
@@ -131,6 +139,53 @@ const formatearFecha = (fechaIso: string) =>
     month: 'short',
     year: 'numeric',
   });
+
+const formatearMesFacturas = (fechaIso: string) => {
+  const fecha = new Date(fechaIso);
+
+  return fecha.toLocaleDateString('es-ES', {
+    month: 'long',
+    year: 'numeric',
+  });
+};
+
+const obtenerClaveMes = (fechaIso: string) => {
+  const fecha = new Date(fechaIso);
+  const mes = String(fecha.getMonth() + 1).padStart(2, '0');
+
+  return `${fecha.getFullYear()}-${mes}`;
+};
+
+const perteneceAlMesActual = (fechaIso: string) => {
+  const fecha = new Date(fechaIso);
+  const ahora = new Date();
+
+  return fecha.getMonth() === ahora.getMonth() && fecha.getFullYear() === ahora.getFullYear();
+};
+
+const agruparFacturasPorMes = (facturas: FacturaEmitida[]) => {
+  const grupos = new Map<string, GrupoFacturas>();
+
+  facturas.forEach((factura) => {
+    const key = obtenerClaveMes(factura.fecha_creacion);
+    const grupo = grupos.get(key);
+
+    if (grupo) {
+      grupo.facturas.push(factura);
+      grupo.total += factura.importe;
+      return;
+    }
+
+    grupos.set(key, {
+      key,
+      titulo: formatearMesFacturas(factura.fecha_creacion),
+      total: factura.importe,
+      facturas: [factura],
+    });
+  });
+
+  return Array.from(grupos.values()).sort((a, b) => b.key.localeCompare(a.key));
+};
 
 const obtenerIniciales = (nombre: string, apellidos: string | null) =>
   `${nombre[0] ?? ''}${apellidos?.[0] ?? ''}`.toUpperCase();
@@ -203,6 +258,7 @@ export default function CaseroCobrosScreen() {
   const [facturaAdjuntaPuntual, setFacturaAdjuntaPuntual] =
     useState<DocumentPicker.DocumentPickerAsset | null>(null);
   const [guardandoFacturaPuntual, setGuardandoFacturaPuntual] = useState(false);
+  const [gruposFacturasExpandidos, setGruposFacturasExpandidos] = useState<Record<string, boolean>>({});
 
   const deudasPendientes = useMemo(
     () => resumen?.deudas.filter((deuda) => deuda.estado === 'PENDIENTE') ?? [],
@@ -356,6 +412,26 @@ export default function CaseroCobrosScreen() {
       (a, b) => new Date(b.fecha_creacion).getTime() - new Date(a.fecha_creacion).getTime(),
     );
   }, [resumen]);
+  const facturasPrioritarias = useMemo(
+    () =>
+      facturasEmitidas.filter(
+        (factura) =>
+          perteneceAlMesActual(factura.fecha_creacion) ||
+          factura.deudas.some((deuda) => deuda.estado === 'PENDIENTE'),
+      ),
+    [facturasEmitidas],
+  );
+  const gruposFacturasPasadas = useMemo(
+    () =>
+      agruparFacturasPorMes(
+        facturasEmitidas.filter(
+          (factura) =>
+            !perteneceAlMesActual(factura.fecha_creacion) &&
+            factura.deudas.every((deuda) => deuda.estado === 'PAGADA'),
+        ),
+      ),
+    [facturasEmitidas],
+  );
 
   const facturaTienePagos = facturaEditando?.deudas.some((deuda) => deuda.estado === 'PAGADA') ?? false;
 
@@ -592,6 +668,13 @@ export default function CaseroCobrosScreen() {
     setFacturaEditando(factura);
     setConceptoEditado(factura.concepto);
     setImporteEditado(String(factura.importe).replace('.', ','));
+  };
+
+  const alternarGrupoFacturas = (grupoKey: string) => {
+    setGruposFacturasExpandidos((actual) => ({
+      ...actual,
+      [grupoKey]: !actual[grupoKey],
+    }));
   };
 
   const cerrarEditorFactura = () => {
@@ -879,7 +962,7 @@ export default function CaseroCobrosScreen() {
             <View style={styles.sectionHeader}>
               <Text style={styles.sectionTitle}>Facturas emitidas</Text>
               <Text style={styles.sectionSubtitle}>
-                Ajusta el concepto o el importe de los recibos mensuales generados.
+                Revisa primero las facturas actuales o pendientes y consulta el histórico por mes.
               </Text>
             </View>
 
@@ -895,13 +978,37 @@ export default function CaseroCobrosScreen() {
               </View>
             ) : (
               <View style={styles.invoiceList}>
-                {facturasEmitidas.map((factura) => (
-                  <FacturaCard
-                    key={factura.id}
-                    factura={factura}
-                    onEditar={abrirEditorFactura}
-                    onVerFactura={abrirFacturaEmitida}
-                  />
+                {facturasPrioritarias.length > 0 && (
+                  <View style={styles.currentInvoiceList}>
+                    {facturasPrioritarias.map((factura) => (
+                      <FacturaCard
+                        key={factura.id}
+                        factura={factura}
+                        onEditar={abrirEditorFactura}
+                        onVerFactura={abrirFacturaEmitida}
+                      />
+                    ))}
+                  </View>
+                )}
+
+                {gruposFacturasPasadas.map((grupo) => (
+                  <AccordionSection
+                    key={grupo.key}
+                    title={grupo.titulo}
+                    subtitle={`${grupo.facturas.length} facturas cerradas`}
+                    meta={formatearImporte(grupo.total)}
+                    expanded={!!gruposFacturasExpandidos[grupo.key]}
+                    onToggle={() => alternarGrupoFacturas(grupo.key)}
+                  >
+                    {grupo.facturas.map((factura) => (
+                      <FacturaCard
+                        key={factura.id}
+                        factura={factura}
+                        onEditar={abrirEditorFactura}
+                        onVerFactura={abrirFacturaEmitida}
+                      />
+                    ))}
+                  </AccordionSection>
                 ))}
               </View>
             )}

--- a/frontend/components/common/AccordionSection.tsx
+++ b/frontend/components/common/AccordionSection.tsx
@@ -1,0 +1,106 @@
+import type { ReactNode } from 'react';
+import { Pressable, StyleProp, StyleSheet, Text, View, ViewStyle } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { Theme } from '@/constants/theme';
+
+type AccordionSectionProps = {
+  title: string;
+  subtitle?: string;
+  meta?: string;
+  expanded: boolean;
+  onToggle: () => void;
+  children: ReactNode;
+  style?: StyleProp<ViewStyle>;
+};
+
+export function AccordionSection({
+  title,
+  subtitle,
+  meta,
+  expanded,
+  onToggle,
+  children,
+  style,
+}: AccordionSectionProps) {
+  return (
+    <View style={[styles.container, style]}>
+      <Pressable
+        style={styles.header}
+        onPress={onToggle}
+        accessibilityRole="button"
+        accessibilityState={{ expanded }}
+        accessibilityLabel={`${expanded ? 'Plegar' : 'Desplegar'} ${title}`}
+      >
+        <View style={styles.iconBox}>
+          <Ionicons name={expanded ? 'chevron-up' : 'chevron-down'} size={20} color={Theme.colors.primary} />
+        </View>
+        <View style={styles.copy}>
+          <Text style={styles.title}>{title}</Text>
+          {subtitle ? <Text style={styles.subtitle}>{subtitle}</Text> : null}
+        </View>
+        {meta ? <Text style={styles.meta}>{meta}</Text> : null}
+      </Pressable>
+
+      {expanded ? <View style={styles.content}>{children}</View> : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: Theme.colors.surface,
+    borderRadius: Theme.radius.lg,
+    borderWidth: 1,
+    borderColor: Theme.colors.border,
+    overflow: 'hidden',
+    ...Theme.shadows.sm,
+  },
+  header: {
+    minHeight: 72,
+    padding: Theme.spacing.base,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Theme.spacing.base,
+  },
+  iconBox: {
+    width: 40,
+    height: 40,
+    borderRadius: Theme.radius.full,
+    backgroundColor: Theme.colors.primaryLight,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+  copy: {
+    flex: 1,
+    minWidth: 0,
+    gap: Theme.spacing.xs,
+  },
+  title: {
+    fontSize: Theme.typography.body,
+    fontWeight: '800',
+    color: Theme.colors.text,
+  },
+  subtitle: {
+    fontSize: Theme.typography.caption,
+    color: Theme.colors.textSecondary,
+    lineHeight: 18,
+  },
+  meta: {
+    fontSize: Theme.typography.caption,
+    fontWeight: '800',
+    color: Theme.colors.primary,
+    backgroundColor: Theme.colors.primaryLight,
+    borderRadius: Theme.radius.full,
+    paddingHorizontal: Theme.spacing.md,
+    paddingVertical: Theme.spacing.sm,
+    overflow: 'hidden',
+    flexShrink: 0,
+  },
+  content: {
+    borderTopWidth: 1,
+    borderTopColor: Theme.colors.border,
+    padding: Theme.spacing.base,
+    gap: Theme.spacing.base,
+  },
+});

--- a/frontend/components/common/__tests__/AccordionSection.test.tsx
+++ b/frontend/components/common/__tests__/AccordionSection.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { Text } from 'react-native';
+import { AccordionSection } from '../AccordionSection';
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+describe('AccordionSection', () => {
+  it('muestra el contenido solo cuando esta expandido', () => {
+    const onToggle = jest.fn();
+
+    const { rerender } = render(
+      <AccordionSection title="marzo 2026" expanded={false} onToggle={onToggle}>
+        <Text>Factura cerrada</Text>
+      </AccordionSection>,
+    );
+
+    expect(screen.queryByText('Factura cerrada')).toBeNull();
+
+    rerender(
+      <AccordionSection title="marzo 2026" expanded onToggle={onToggle}>
+        <Text>Factura cerrada</Text>
+      </AccordionSection>,
+    );
+
+    expect(screen.getByText('Factura cerrada')).toBeTruthy();
+  });
+
+  it('expone estado accesible y ejecuta onToggle', () => {
+    const onToggle = jest.fn();
+
+    render(
+      <AccordionSection title="abril 2026" expanded={false} onToggle={onToggle}>
+        <Text>Factura cerrada</Text>
+      </AccordionSection>,
+    );
+
+    const button = screen.getByLabelText('Desplegar abril 2026');
+
+    expect(button.props.accessibilityRole).toBe('button');
+    expect(button.props.accessibilityState).toEqual({ expanded: false });
+
+    fireEvent.press(button);
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/styles/casero/cobros.styles.ts
+++ b/frontend/styles/casero/cobros.styles.ts
@@ -168,6 +168,9 @@ export const styles = StyleSheet.create({
   invoiceList: {
     gap: Theme.spacing.base,
   },
+  currentInvoiceList: {
+    gap: Theme.spacing.base,
+  },
   invoiceCard: {
     backgroundColor: Theme.colors.surface,
     borderRadius: Theme.radius.lg,


### PR DESCRIPTION
## Objetivo
Añadir un patrón de acordeón para que el dashboard de cobros priorice facturas actuales o pendientes y mantenga accesible el histórico acumulado sin saturar la pantalla.

## Cambios principales
* Añadido componente reutilizable `AccordionSection` para listados plegables.
* Agrupadas las facturas pasadas cerradas por mes y año en la pantalla de cobros del casero.
* Conservadas visibles las facturas del mes actual o con deudas pendientes.
* Añadidos tests de plegado y accesibilidad básica del acordeón.

## UI / UX
* Acordeón alineado con `Theme.ts`, usando radios, espaciado, sombras suaves y tintes existentes.
* Labels táctiles y estado expandido/colapsado expuestos para accesibilidad.

## Changelog
* `docs/changelog/Epica16/epica-16-issue-272-acordeon-facturas-pasadas.md`

## Testing
* `npm test -- --runInBand`
* `npm run lint`