### PR TITLE
Add cargos mensuales por alquiler de habitación

### DIFF
--- a/backend/prisma/migrations/20260417203000_add_cargos_habitacion/migration.sql
+++ b/backend/prisma/migrations/20260417203000_add_cargos_habitacion/migration.sql
@@ -1,0 +1,23 @@
+ALTER TYPE "TipoGasto" ADD VALUE IF NOT EXISTS 'ALQUILER_HABITACION';
+
+ALTER TABLE "Gasto"
+ADD COLUMN "periodo_facturacion" TEXT,
+ADD COLUMN "habitacion_cargo_id" INTEGER,
+ADD COLUMN "inquilino_cargo_id" INTEGER;
+
+ALTER TABLE "Gasto"
+ADD CONSTRAINT "Gasto_habitacion_cargo_id_fkey"
+FOREIGN KEY ("habitacion_cargo_id")
+REFERENCES "Habitacion"("id")
+ON DELETE SET NULL
+ON UPDATE CASCADE;
+
+ALTER TABLE "Gasto"
+ADD CONSTRAINT "Gasto_inquilino_cargo_id_fkey"
+FOREIGN KEY ("inquilino_cargo_id")
+REFERENCES "Usuario"("id")
+ON DELETE SET NULL
+ON UPDATE CASCADE;
+
+CREATE UNIQUE INDEX "Gasto_tipo_periodo_habitacion_inquilino_key"
+ON "Gasto"("tipo", "periodo_facturacion", "habitacion_cargo_id", "inquilino_cargo_id");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -53,6 +53,7 @@ enum TipoGasto {
   FACTURA_PUNTUAL
   FACTURA_MENSUAL
   CARGO_RECURRENTE
+  ALQUILER_HABITACION
 }
 
 enum EstadoItem {
@@ -86,6 +87,7 @@ model Usuario {
   gastos_pagados     Gasto[]
   gastos_modificados Gasto[]                  @relation("ModificadorGasto")
   gastos_recurrentes_pagados GastoRecurrente[]
+  cargos_habitacion Gasto[]                  @relation("InquilinoCargoHabitacion")
   deudas_a_pagar     Deuda[]                  @relation("DeudorDeuda")
   deudas_a_cobrar    Deuda[]                  @relation("AcreedorDeuda")
 }
@@ -125,6 +127,7 @@ model Habitacion {
   codigo_invitacion String?          @unique
   incidencias       Incidencia[]
   items_inventario  ItemInventario[]
+  cargos_alquiler   Gasto[]          @relation("CargoHabitacion")
 }
 
 model Incidencia {
@@ -167,9 +170,16 @@ model Gasto {
   pagador            Usuario   @relation(fields: [pagador_id], references: [id])
   modificado_por_id  Int?
   modificado_por     Usuario?  @relation("ModificadorGasto", fields: [modificado_por_id], references: [id], onDelete: SetNull)
+  periodo_facturacion String?
+  habitacion_cargo_id Int?
+  habitacion_cargo    Habitacion? @relation("CargoHabitacion", fields: [habitacion_cargo_id], references: [id], onDelete: SetNull)
+  inquilino_cargo_id  Int?
+  inquilino_cargo     Usuario? @relation("InquilinoCargoHabitacion", fields: [inquilino_cargo_id], references: [id], onDelete: SetNull)
   vivienda_id        Int
   vivienda           Vivienda  @relation(fields: [vivienda_id], references: [id])
   deudas             Deuda[]
+
+  @@unique([tipo, periodo_facturacion, habitacion_cargo_id, inquilino_cargo_id])
 }
 
 model GastoRecurrente {

--- a/backend/src/cron/mensualidades.cron.ts
+++ b/backend/src/cron/mensualidades.cron.ts
@@ -1,11 +1,19 @@
 import cron from 'node-cron';
 import { prisma } from '../lib/prisma';
-import { crearGastoDividido } from '../services/gasto.service';
+import { crearCargosMensualesHabitacion, crearGastoDividido } from '../services/gasto.service';
 
 let cronMensualidadesIniciado = false;
 
 export const procesarMensualidadesDelDia = async () => {
-  const diaActual = new Date().getDate();
+  const hoy = new Date();
+  const diaActual = hoy.getDate();
+
+  if (diaActual === 1) {
+    const resultadoCargosHabitacion = await crearCargosMensualesHabitacion(hoy);
+    console.log(
+      `[cron] Alquileres ${resultadoCargosHabitacion.periodo}: ${resultadoCargosHabitacion.creados} creado(s), ${resultadoCargosHabitacion.omitidosExistentes} existente(s), ${resultadoCargosHabitacion.omitidosSinPrecio} sin precio.`,
+    );
+  }
 
   const gastosRecurrentes = await prisma.gastoRecurrente.findMany({
     where: {

--- a/backend/src/services/gasto.service.ts
+++ b/backend/src/services/gasto.service.ts
@@ -4,6 +4,7 @@ export const TIPOS_GASTO_CASERO = [
   'FACTURA_PUNTUAL',
   'FACTURA_MENSUAL',
   'CARGO_RECURRENTE',
+  'ALQUILER_HABITACION',
 ] as const;
 
 export const TIPOS_GASTO_COMPANEROS = ['ENTRE_COMPANEROS'] as const;
@@ -25,7 +26,24 @@ type CrearGastoDivididoInput = {
     usuario_id: number;
     importe: number;
   }[];
+  periodoFacturacion?: string | null;
+  habitacionCargoId?: number | null;
+  inquilinoCargoId?: number | null;
 };
+
+type CrearCargosMensualesHabitacionResultado = {
+  periodo: string;
+  creados: number;
+  omitidosExistentes: number;
+  omitidosSinPrecio: number;
+  omitidosSinInquilino: number;
+};
+
+const esErrorDuplicadoPrisma = (error: unknown) =>
+  typeof error === 'object' &&
+  error !== null &&
+  'code' in error &&
+  (error as { code?: string }).code === 'P2002';
 
 export const usuarioPerteneceAVivienda = async (viviendaId: number, usuarioId: number) => {
   return prisma.habitacion.findFirst({
@@ -84,6 +102,9 @@ export const crearGastoDividido = async ({
   facturaUrl,
   fecha,
   repartoManual,
+  periodoFacturacion,
+  habitacionCargoId,
+  inquilinoCargoId,
 }: CrearGastoDivididoInput) => {
   const vivienda = await prisma.vivienda.findUnique({
     where: { id: viviendaId },
@@ -154,6 +175,9 @@ export const crearGastoDividido = async ({
         factura_url: facturaUrl ?? null,
         fecha_creacion: fecha,
         pagador_id: pagadorId,
+        periodo_facturacion: periodoFacturacion ?? null,
+        habitacion_cargo_id: habitacionCargoId ?? null,
+        inquilino_cargo_id: inquilinoCargoId ?? null,
         vivienda_id: viviendaId,
         deudas: {
           create: repartoManual
@@ -190,6 +214,9 @@ export const crearGastoDividido = async ({
       factura_url: facturaUrl ?? null,
       fecha_creacion: fecha,
       pagador_id: pagadorId,
+      periodo_facturacion: periodoFacturacion ?? null,
+      habitacion_cargo_id: habitacionCargoId ?? null,
+      inquilino_cargo_id: inquilinoCargoId ?? null,
       vivienda_id: viviendaId,
       deudas: {
         create: deudoresIds
@@ -203,4 +230,100 @@ export const crearGastoDividido = async ({
     },
     include: { deudas: true },
   });
+};
+
+export const obtenerPeriodoMensual = (fecha = new Date()) => {
+  const mes = `${fecha.getMonth() + 1}`.padStart(2, '0');
+  return `${fecha.getFullYear()}-${mes}`;
+};
+
+export const crearCargosMensualesHabitacion = async (
+  fecha = new Date(),
+): Promise<CrearCargosMensualesHabitacionResultado> => {
+  const periodo = obtenerPeriodoMensual(fecha);
+  const fechaCargo = new Date(fecha.getFullYear(), fecha.getMonth(), 1);
+  const resultado: CrearCargosMensualesHabitacionResultado = {
+    periodo,
+    creados: 0,
+    omitidosExistentes: 0,
+    omitidosSinPrecio: 0,
+    omitidosSinInquilino: 0,
+  };
+
+  const habitaciones = await prisma.habitacion.findMany({
+    where: {
+      es_habitable: true,
+      inquilino_id: { not: null },
+      inquilino: { estado_presencia: 'ACTIVO' },
+    },
+    select: {
+      id: true,
+      nombre: true,
+      precio: true,
+      inquilino_id: true,
+      vivienda_id: true,
+      vivienda: {
+        select: {
+          casero_id: true,
+          alias_nombre: true,
+        },
+      },
+    },
+  });
+
+  for (const habitacion of habitaciones) {
+    if (!habitacion.inquilino_id) {
+      resultado.omitidosSinInquilino += 1;
+      continue;
+    }
+
+    if (habitacion.precio == null || !Number.isFinite(habitacion.precio) || habitacion.precio <= 0) {
+      resultado.omitidosSinPrecio += 1;
+      console.warn(
+        `[cron] Habitacion ${habitacion.id} sin precio valido para el periodo ${periodo}; no se genera alquiler.`,
+      );
+      continue;
+    }
+
+    const existente = await prisma.gasto.findFirst({
+      where: {
+        tipo: 'ALQUILER_HABITACION',
+        periodo_facturacion: periodo,
+        habitacion_cargo_id: habitacion.id,
+        inquilino_cargo_id: habitacion.inquilino_id,
+      },
+      select: { id: true },
+    });
+
+    if (existente) {
+      resultado.omitidosExistentes += 1;
+      continue;
+    }
+
+    try {
+      await crearGastoDividido({
+        concepto: `Alquiler ${periodo} - ${habitacion.nombre}`,
+        importe: habitacion.precio,
+        tipo: 'ALQUILER_HABITACION',
+        viviendaId: habitacion.vivienda_id,
+        pagadorId: habitacion.vivienda.casero_id,
+        implicadosIds: [habitacion.inquilino_id],
+        fecha: fechaCargo,
+        periodoFacturacion: periodo,
+        habitacionCargoId: habitacion.id,
+        inquilinoCargoId: habitacion.inquilino_id,
+      });
+    } catch (error) {
+      if (esErrorDuplicadoPrisma(error)) {
+        resultado.omitidosExistentes += 1;
+        continue;
+      }
+
+      throw error;
+    }
+
+    resultado.creados += 1;
+  }
+
+  return resultado;
 };

--- a/backend/tests/economico.test.ts
+++ b/backend/tests/economico.test.ts
@@ -52,6 +52,7 @@ const prisma = vi.hoisted(() => ({
 vi.mock('../src/lib/prisma', () => ({ prisma }));
 
 const { crearGastoDividido } = await import('../src/services/gasto.service');
+const { crearCargosMensualesHabitacion } = await import('../src/services/gasto.service');
 const {
   actualizarGasto,
   listarGastos,
@@ -64,6 +65,7 @@ let ultimoGastoCreate: {
 } | null = null;
 let deudaUpdateCalls: unknown[] = [];
 let ultimoGastoFindMany: unknown = null;
+let ultimoGastoFindFirst: unknown = null;
 let ultimaDeudaFindMany: unknown = null;
 let transactionCalled = false;
 
@@ -71,6 +73,7 @@ function resetPrisma() {
   ultimoGastoCreate = null;
   deudaUpdateCalls = [];
   ultimoGastoFindMany = null;
+  ultimoGastoFindFirst = null;
   ultimaDeudaFindMany = null;
   transactionCalled = false;
 
@@ -100,7 +103,10 @@ function resetPrisma() {
     ultimoGastoFindMany = args;
     return [];
   };
-  prisma.gasto.findFirst = async () => null;
+  prisma.gasto.findFirst = async (args: unknown) => {
+    ultimoGastoFindFirst = args;
+    return null;
+  };
   prisma.deuda.findMany = async (args: unknown) => {
     ultimaDeudaFindMany = args;
     return [];
@@ -310,7 +316,7 @@ describe('modulo economico', () => {
     assert.equal(res.statusCode, 200);
     assert.deepEqual(
       (ultimoGastoFindMany as { where: { tipo: { in: string[] } } }).where.tipo.in,
-      ['FACTURA_PUNTUAL', 'FACTURA_MENSUAL', 'CARGO_RECURRENTE'],
+      ['FACTURA_PUNTUAL', 'FACTURA_MENSUAL', 'CARGO_RECURRENTE', 'ALQUILER_HABITACION'],
     );
   });
 
@@ -358,8 +364,99 @@ describe('modulo economico', () => {
     assert.equal(res.statusCode, 200);
     assert.deepEqual(
       (ultimaDeudaFindMany as { where: { gasto: { tipo: { in: string[] } } } }).where.gasto.tipo.in,
-      ['FACTURA_PUNTUAL', 'FACTURA_MENSUAL', 'CARGO_RECURRENTE'],
+      ['FACTURA_PUNTUAL', 'FACTURA_MENSUAL', 'CARGO_RECURRENTE', 'ALQUILER_HABITACION'],
     );
+  });
+
+  test('genera alquiler mensual de habitacion como deuda del inquilino con el casero', async () => {
+    prisma.habitacion.findMany = async (args: unknown) => {
+      if ((args as { select?: { precio?: boolean } }).select?.precio) {
+        return [
+          {
+            id: 7,
+            nombre: 'Habitacion azul',
+            precio: 450,
+            inquilino_id: 2,
+            vivienda_id: 1,
+            vivienda: { casero_id: 99, alias_nombre: 'Piso Centro' },
+          },
+        ];
+      }
+
+      return [{ inquilino_id: 2 }];
+    };
+
+    const resultado = await crearCargosMensualesHabitacion(new Date(2026, 3, 1));
+
+    assert.deepEqual(resultado, {
+      periodo: '2026-04',
+      creados: 1,
+      omitidosExistentes: 0,
+      omitidosSinPrecio: 0,
+      omitidosSinInquilino: 0,
+    });
+    assert.deepEqual((ultimoGastoFindFirst as { where: unknown }).where, {
+      tipo: 'ALQUILER_HABITACION',
+      periodo_facturacion: '2026-04',
+      habitacion_cargo_id: 7,
+      inquilino_cargo_id: 2,
+    });
+    assert.equal(ultimoGastoCreate?.data.tipo, 'ALQUILER_HABITACION');
+    assert.equal(ultimoGastoCreate?.data.importe, 450);
+    assert.deepEqual(ultimoGastoCreate?.data.deudas.create, [
+      { deudor_id: 2, acreedor_id: 99, importe: 450 },
+    ]);
+  });
+
+  test('no duplica alquiler mensual si ya existe para el mismo periodo habitacion e inquilino', async () => {
+    prisma.habitacion.findMany = async (args: unknown) => {
+      if ((args as { select?: { precio?: boolean } }).select?.precio) {
+        return [
+          {
+            id: 7,
+            nombre: 'Habitacion azul',
+            precio: 450,
+            inquilino_id: 2,
+            vivienda_id: 1,
+            vivienda: { casero_id: 99, alias_nombre: 'Piso Centro' },
+          },
+        ];
+      }
+
+      return [{ inquilino_id: 2 }];
+    };
+    prisma.gasto.findFirst = async (args: unknown) => {
+      ultimoGastoFindFirst = args;
+      return { id: 20 };
+    };
+
+    const resultado = await crearCargosMensualesHabitacion(new Date(2026, 3, 1));
+
+    assert.equal(resultado.creados, 0);
+    assert.equal(resultado.omitidosExistentes, 1);
+    assert.equal(ultimoGastoCreate, null);
+  });
+
+  test('omite alquiler mensual sin precio y deja traza en consola', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    prisma.habitacion.findMany = async () => [
+      {
+        id: 8,
+        nombre: 'Habitacion sin precio',
+        precio: null,
+        inquilino_id: 2,
+        vivienda_id: 1,
+        vivienda: { casero_id: 99, alias_nombre: 'Piso Centro' },
+      },
+    ];
+
+    const resultado = await crearCargosMensualesHabitacion(new Date(2026, 3, 1));
+
+    assert.equal(resultado.creados, 0);
+    assert.equal(resultado.omitidosSinPrecio, 1);
+    assert.equal(ultimoGastoCreate, null);
+    assert.match(warn.mock.calls[0]?.[0] ?? '', /sin precio valido/i);
+    warn.mockRestore();
   });
 
   test('el deudor puede saldar su propia deuda pendiente', async () => {


### PR DESCRIPTION
## Summary
- Añade generación mensual automática de deudas por precio de habitación.
- Registra el cargo como deuda con el casero mediante `ALQUILER_HABITACION`.
- Evita duplicados por periodo, habitación e inquilino con metadatos e índice único.
- Omite habitaciones sin precio válido y deja trazabilidad en logs.

## Testing
- `npm run build`
- `npm test -- economico.test.ts`
- `npm test`
- `npx prisma validate --schema prisma/schema.prisma`