### PR TITLE
[Épica 17] Reorienta limpieza a habitaciones

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -83,7 +83,6 @@ model Usuario {
   incidencias        Incidencia[]
   anuncios           Anuncio[]
   turnos_limpieza    TurnoLimpieza[]
-  asignaciones_fijas AsignacionLimpiezaFija[]
   gastos_pagados     Gasto[]
   gastos_modificados Gasto[]                  @relation("ModificadorGasto")
   gastos_recurrentes_pagados GastoRecurrente[]
@@ -128,6 +127,9 @@ model Habitacion {
   incidencias       Incidencia[]
   items_inventario  ItemInventario[]
   cargos_alquiler   Gasto[]          @relation("CargoHabitacion")
+  zonas_limpieza_objetivo ZonaLimpieza[] @relation("ZonaLimpiezaObjetivoHabitacion")
+  asignaciones_limpieza_fijas AsignacionLimpiezaFija[] @relation("AsignacionLimpiezaFijaHabitacion")
+  turnos_limpieza_responsable TurnoLimpieza[] @relation("TurnoLimpiezaHabitacionResponsable")
 }
 
 model Incidencia {
@@ -238,6 +240,8 @@ model ZonaLimpieza {
   id                 Int                      @id @default(autoincrement())
   vivienda_id        Int
   vivienda           Vivienda                 @relation(fields: [vivienda_id], references: [id])
+  habitacion_id      Int?
+  habitacion         Habitacion?              @relation("ZonaLimpiezaObjetivoHabitacion", fields: [habitacion_id], references: [id], onDelete: SetNull)
   nombre             String
   peso               Float
   activa             Boolean                  @default(true)
@@ -245,23 +249,28 @@ model ZonaLimpieza {
   asignaciones_fijas AsignacionLimpiezaFija[]
 }
 
-/// Tabla de asignaciones fijas: una zona siempre la limpia el mismo usuario,
-/// sin participar en la rotación global. Su peso SÍ cuenta para el balance.
+/// Tabla de asignaciones fijas: una zona siempre la limpia la misma habitacion
+/// responsable, sin participar en la rotacion global. Su peso si cuenta para el
+/// balance del ocupante actual cuando exista.
 model AsignacionLimpiezaFija {
   id         Int          @id @default(autoincrement())
   zona_id    Int
   zona       ZonaLimpieza @relation(fields: [zona_id], references: [id], onDelete: Cascade)
-  usuario_id Int
-  usuario    Usuario      @relation(fields: [usuario_id], references: [id])
+  habitacion_id Int
+  habitacion Habitacion   @relation("AsignacionLimpiezaFijaHabitacion", fields: [habitacion_id], references: [id], onDelete: Cascade)
 
-  @@unique([zona_id, usuario_id])
+  @@unique([zona_id, habitacion_id])
 }
 
 /// Registro semanal del reparto. Generado por el algoritmo al inicio de cada semana.
+/// La entidad principal es la habitacion responsable; usuario guarda un snapshot
+/// opcional del ocupante en el momento de generar el turno.
 model TurnoLimpieza {
   id           Int          @id @default(autoincrement())
-  usuario_id   Int
-  usuario      Usuario      @relation(fields: [usuario_id], references: [id])
+  usuario_id   Int?
+  usuario      Usuario?     @relation(fields: [usuario_id], references: [id], onDelete: SetNull)
+  habitacion_id Int
+  habitacion   Habitacion   @relation("TurnoLimpiezaHabitacionResponsable", fields: [habitacion_id], references: [id], onDelete: Cascade)
   zona_id      Int
   zona         ZonaLimpieza @relation(fields: [zona_id], references: [id], onDelete: Cascade)
   fecha_inicio DateTime

--- a/backend/src/controllers/limpieza.controller.ts
+++ b/backend/src/controllers/limpieza.controller.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import { TipoHabitacion } from '../generated/prisma/client';
 import { prisma } from '../lib/prisma';
 import { generarTurnosSemanales } from '../services/limpieza.service';
 
@@ -6,8 +7,10 @@ type EstadoTurnoExport = 'PENDIENTE' | 'HECHO' | 'NO_HECHO';
 
 const ESTADOS_EXPORTABLES = new Set<EstadoTurnoExport>(['PENDIENTE', 'HECHO', 'NO_HECHO']);
 const CABECERAS_EXPORTACION = [
-  'Zona a limpiar',
-  'Inquilino',
+  'Espacio',
+  'Tipo de espacio',
+  'Habitacion responsable',
+  'Responsable actual',
   'Fecha',
 ];
 
@@ -45,8 +48,8 @@ const formatearFechaCsv = (fecha: Date | string | null | undefined) => {
   });
 };
 
-const nombreCompleto = (usuario: { nombre: string; apellidos: string | null }) =>
-  `${usuario.nombre}${usuario.apellidos ? ` ${usuario.apellidos}` : ''}`;
+const nombreCompleto = (usuario: { nombre: string; apellidos: string | null } | null | undefined) =>
+  usuario ? `${usuario.nombre}${usuario.apellidos ? ` ${usuario.apellidos}` : ''}` : 'Sin ocupante';
 
 const escaparCsv = (valor: unknown) => {
   const texto = String(valor ?? '');
@@ -65,8 +68,10 @@ const limpiarNombreArchivo = (valor: string) =>
 
 const generarCsvLimpiezas = (
   filas: Array<{
-    zona: string;
-    inquilino: string;
+    espacio: string;
+    tipoEspacio: string;
+    habitacionResponsable: string;
+    responsableActual: string;
     fecha: Date;
   }>,
 ) => {
@@ -74,8 +79,10 @@ const generarCsvLimpiezas = (
     CABECERAS_EXPORTACION.map(escaparCsv).join(';'),
     ...filas.map((fila) =>
       [
-        fila.zona,
-        fila.inquilino,
+        fila.espacio,
+        fila.tipoEspacio,
+        fila.habitacionResponsable,
+        fila.responsableActual,
         formatearFechaCsv(fila.fecha),
       ]
         .map(escaparCsv)
@@ -98,16 +105,207 @@ const verificarPropiedadVivienda = async (viviendaId: number, caseroId: number) 
   return vivienda;
 };
 
+const obtenerContextoAcceso = async (viviendaId: number, usuarioId: number) => {
+  const viviendaCasero = await verificarPropiedadVivienda(viviendaId, usuarioId);
+  if (viviendaCasero) {
+    return { rol: 'CASERO' as const, miHabitacionId: null };
+  }
+
+  const miHabitacion = await prisma.habitacion.findFirst({
+    where: { vivienda_id: viviendaId, inquilino_id: usuarioId },
+    select: { id: true },
+  });
+
+  if (!miHabitacion) return null;
+  return { rol: 'INQUILINO' as const, miHabitacionId: miHabitacion.id };
+};
+
+const obtenerTipoEspacio = (
+  habitacion: { tipo: TipoHabitacion; es_habitable: boolean } | null | undefined,
+) => {
+  if (!habitacion) return 'ESPACIO';
+  if (habitacion.tipo === TipoHabitacion.DORMITORIO && habitacion.es_habitable) return 'HABITACION';
+  return 'ZONA_COMUN';
+};
+
+const etiquetaTipoEspacio = (tipoEspacio: string) => {
+  if (tipoEspacio === 'HABITACION') return 'Habitacion';
+  if (tipoEspacio === 'ZONA_COMUN') return 'Zona comun';
+  return 'Espacio';
+};
+
+const serializarZona = (zona: {
+  id: number;
+  nombre: string;
+  peso: number;
+  activa: boolean;
+  habitacion: {
+    id: number;
+    nombre: string;
+    tipo: TipoHabitacion;
+    es_habitable: boolean;
+    inquilino: { id: number; nombre: string; apellidos: string | null } | null;
+  } | null;
+  asignaciones_fijas: Array<{
+    id: number;
+    habitacion: {
+      id: number;
+      nombre: string;
+      tipo: TipoHabitacion;
+      es_habitable: boolean;
+      inquilino: { id: number; nombre: string; apellidos: string | null } | null;
+    };
+  }>;
+}) => ({
+  id: zona.id,
+  nombre: zona.nombre,
+  peso: zona.peso,
+  activa: zona.activa,
+  tipo_espacio: obtenerTipoEspacio(zona.habitacion),
+  habitacion: zona.habitacion
+    ? {
+        id: zona.habitacion.id,
+        nombre: zona.habitacion.nombre,
+        tipo: zona.habitacion.tipo,
+        es_habitable: zona.habitacion.es_habitable,
+        inquilino: zona.habitacion.inquilino,
+      }
+    : null,
+  asignaciones_fijas: zona.asignaciones_fijas.map((asignacion) => ({
+    id: asignacion.id,
+    habitacion_id: asignacion.habitacion.id,
+    habitacion: {
+      id: asignacion.habitacion.id,
+      nombre: asignacion.habitacion.nombre,
+      tipo: asignacion.habitacion.tipo,
+      es_habitable: asignacion.habitacion.es_habitable,
+      inquilino: asignacion.habitacion.inquilino,
+    },
+    responsable_actual: asignacion.habitacion.inquilino,
+  })),
+});
+
+const buildTurnosWhere = ({
+  viviendaId,
+  inicio,
+  fin,
+  estado,
+  acceso,
+}: {
+  viviendaId: number;
+  inicio?: Date;
+  fin?: Date;
+  estado?: EstadoTurnoExport;
+  acceso: { rol: 'CASERO'; miHabitacionId: null } | { rol: 'INQUILINO'; miHabitacionId: number };
+}) => {
+  const filtroBase = {
+    zona: { vivienda_id: viviendaId },
+    ...(estado ? { estado } : {}),
+    ...(inicio || fin
+      ? {
+          fecha_inicio: {
+            ...(inicio ? { gte: inicio } : {}),
+            ...(fin ? { lte: fin } : {}),
+          },
+        }
+      : {}),
+  };
+
+  if (acceso.rol === 'CASERO') {
+    return filtroBase;
+  }
+
+  return {
+    ...filtroBase,
+    OR: [
+      { habitacion_id: acceso.miHabitacionId },
+      {
+        zona: {
+          OR: [
+            { habitacion_id: null },
+            {
+              habitacion: {
+                NOT: {
+                  tipo: TipoHabitacion.DORMITORIO,
+                  es_habitable: true,
+                },
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+};
+
+const serializarTurno = (turno: {
+  id: number;
+  usuario_id: number | null;
+  habitacion_id: number;
+  zona_id: number;
+  fecha_inicio: Date;
+  fecha_fin: Date;
+  estado: EstadoTurnoExport;
+  zona: {
+    id: number;
+    nombre: string;
+    peso: number;
+    habitacion: {
+      id: number;
+      nombre: string;
+      tipo: TipoHabitacion;
+      es_habitable: boolean;
+      inquilino: { id: number; nombre: string; apellidos: string | null } | null;
+    } | null;
+  };
+  habitacion: {
+    id: number;
+    nombre: string;
+    tipo: TipoHabitacion;
+    es_habitable: boolean;
+    inquilino: { id: number; nombre: string; apellidos: string | null } | null;
+  };
+  usuario: { id: number; nombre: string; apellidos: string | null } | null;
+}) => ({
+  id: turno.id,
+  usuario_id: turno.usuario_id,
+  habitacion_id: turno.habitacion_id,
+  zona_id: turno.zona_id,
+  fecha_inicio: turno.fecha_inicio,
+  fecha_fin: turno.fecha_fin,
+  estado: turno.estado,
+  tipo_espacio: obtenerTipoEspacio(turno.zona.habitacion),
+  zona: {
+    id: turno.zona.id,
+    nombre: turno.zona.nombre,
+    peso: turno.zona.peso,
+    habitacion: turno.zona.habitacion,
+  },
+  habitacion: {
+    id: turno.habitacion.id,
+    nombre: turno.habitacion.nombre,
+    tipo: turno.habitacion.tipo,
+    es_habitable: turno.habitacion.es_habitable,
+    inquilino: turno.habitacion.inquilino,
+  },
+  responsable_actual: turno.habitacion.inquilino,
+  usuario: turno.usuario,
+});
+
 export const crearZona: express.RequestHandler = async (req, res) => {
   const viviendaId = parseInt(req.params['id'] as string, 10);
-  const { nombre, peso } = req.body as { nombre: string; peso: number };
+  const { nombre, peso, habitacion_id } = req.body as {
+    nombre?: string;
+    peso: number;
+    habitacion_id?: number | null;
+  };
 
-  if (!nombre || peso === undefined || peso === null) {
-    res.status(400).json({ error: 'nombre y peso son obligatorios.' });
+  if (peso === undefined || peso === null) {
+    res.status(400).json({ error: 'peso es obligatorio.' });
     return;
   }
   if (typeof peso !== 'number' || peso <= 0) {
-    res.status(400).json({ error: 'peso debe ser un número positivo.' });
+    res.status(400).json({ error: 'peso debe ser un numero positivo.' });
     return;
   }
 
@@ -117,11 +315,55 @@ export const crearZona: express.RequestHandler = async (req, res) => {
     return;
   }
 
+  let habitacionObjetivo: {
+    id: number;
+    nombre: string;
+  } | null = null;
+
+  if (habitacion_id !== undefined && habitacion_id !== null) {
+    habitacionObjetivo = await prisma.habitacion.findFirst({
+      where: { id: habitacion_id, vivienda_id: viviendaId },
+      select: { id: true, nombre: true },
+    });
+
+    if (!habitacionObjetivo) {
+      res.status(404).json({ error: 'La habitacion objetivo no existe en esta vivienda.' });
+      return;
+    }
+  }
+
+  const nombreFinal = nombre?.trim() || habitacionObjetivo?.nombre;
+  if (!nombreFinal) {
+    res.status(400).json({ error: 'nombre es obligatorio cuando no se vincula una habitacion.' });
+    return;
+  }
+
   const zona = await prisma.zonaLimpieza.create({
-    data: { vivienda_id: viviendaId, nombre, peso },
+    data: {
+      vivienda_id: viviendaId,
+      habitacion_id: habitacionObjetivo?.id ?? null,
+      nombre: nombreFinal,
+      peso,
+    },
+    include: {
+      habitacion: {
+        include: {
+          inquilino: { select: { id: true, nombre: true, apellidos: true } },
+        },
+      },
+      asignaciones_fijas: {
+        include: {
+          habitacion: {
+            include: {
+              inquilino: { select: { id: true, nombre: true, apellidos: true } },
+            },
+          },
+        },
+      },
+    },
   });
 
-  res.status(201).json(zona);
+  res.status(201).json(serializarZona(zona));
 };
 
 export const listarZonas: express.RequestHandler = async (req, res) => {
@@ -136,22 +378,36 @@ export const listarZonas: express.RequestHandler = async (req, res) => {
   const zonas = await prisma.zonaLimpieza.findMany({
     where: { vivienda_id: viviendaId },
     include: {
+      habitacion: {
+        include: {
+          inquilino: { select: { id: true, nombre: true, apellidos: true } },
+        },
+      },
       asignaciones_fijas: {
         include: {
-          usuario: { select: { id: true, nombre: true, apellidos: true } },
+          habitacion: {
+            include: {
+              inquilino: { select: { id: true, nombre: true, apellidos: true } },
+            },
+          },
         },
       },
     },
-    orderBy: { id: 'asc' },
+    orderBy: [{ activa: 'desc' }, { id: 'asc' }],
   });
 
-  res.status(200).json(zonas);
+  res.status(200).json(zonas.map(serializarZona));
 };
 
 export const actualizarZona: express.RequestHandler = async (req, res) => {
   const viviendaId = parseInt(req.params['id'] as string, 10);
   const zonaId = parseInt(req.params['zonaId'] as string, 10);
-  const { nombre, peso, activa } = req.body as { nombre?: string; peso?: number; activa?: boolean };
+  const { nombre, peso, activa, habitacion_id } = req.body as {
+    nombre?: string;
+    peso?: number;
+    activa?: boolean;
+    habitacion_id?: number | null;
+  };
 
   const vivienda = await verificarPropiedadVivienda(viviendaId, req.usuario!.id);
   if (!vivienda) {
@@ -166,29 +422,75 @@ export const actualizarZona: express.RequestHandler = async (req, res) => {
   }
 
   if (peso !== undefined && (typeof peso !== 'number' || peso <= 0)) {
-    res.status(400).json({ error: 'peso debe ser un número positivo.' });
+    res.status(400).json({ error: 'peso debe ser un numero positivo.' });
+    return;
+  }
+
+  let habitacionObjetivoId = zona.habitacion_id;
+  let nombreFinal = nombre?.trim() ?? zona.nombre;
+
+  if (habitacion_id !== undefined) {
+    if (habitacion_id === null) {
+      habitacionObjetivoId = null;
+    } else {
+      const habitacionObjetivo = await prisma.habitacion.findFirst({
+        where: { id: habitacion_id, vivienda_id: viviendaId },
+        select: { id: true, nombre: true },
+      });
+
+      if (!habitacionObjetivo) {
+        res.status(404).json({ error: 'La habitacion objetivo no existe en esta vivienda.' });
+        return;
+      }
+
+      habitacionObjetivoId = habitacionObjetivo.id;
+      if (!nombre?.trim()) {
+        nombreFinal = habitacionObjetivo.nombre;
+      }
+    }
+  }
+
+  if (!nombreFinal) {
+    res.status(400).json({ error: 'nombre es obligatorio cuando no se vincula una habitacion.' });
     return;
   }
 
   const zonaActualizada = await prisma.zonaLimpieza.update({
     where: { id: zonaId },
     data: {
-      nombre: nombre ?? zona.nombre,
+      nombre: nombreFinal,
       peso: peso ?? zona.peso,
       activa: activa !== undefined ? activa : zona.activa,
+      habitacion_id: habitacionObjetivoId,
+    },
+    include: {
+      habitacion: {
+        include: {
+          inquilino: { select: { id: true, nombre: true, apellidos: true } },
+        },
+      },
+      asignaciones_fijas: {
+        include: {
+          habitacion: {
+            include: {
+              inquilino: { select: { id: true, nombre: true, apellidos: true } },
+            },
+          },
+        },
+      },
     },
   });
 
-  res.status(200).json(zonaActualizada);
+  res.status(200).json(serializarZona(zonaActualizada));
 };
 
 export const asignarZonaFija: express.RequestHandler = async (req, res) => {
   const viviendaId = parseInt(req.params['id'] as string, 10);
   const zonaId = parseInt(req.params['zonaId'] as string, 10);
-  const { usuario_ids } = req.body as { usuario_ids: number[] };
+  const { habitacion_ids } = req.body as { habitacion_ids: number[] };
 
-  if (!Array.isArray(usuario_ids)) {
-    res.status(400).json({ error: 'usuario_ids debe ser un array de números.' });
+  if (!Array.isArray(habitacion_ids)) {
+    res.status(400).json({ error: 'habitacion_ids debe ser un array de numeros.' });
     return;
   }
 
@@ -204,33 +506,56 @@ export const asignarZonaFija: express.RequestHandler = async (req, res) => {
     return;
   }
 
-  if (usuario_ids.length > 0) {
+  if (habitacion_ids.length > 0) {
     const habitaciones = await prisma.habitacion.findMany({
-      where: { vivienda_id: viviendaId, inquilino_id: { in: usuario_ids } },
-      select: { inquilino_id: true },
+      where: {
+        vivienda_id: viviendaId,
+        id: { in: habitacion_ids },
+        es_habitable: true,
+        tipo: TipoHabitacion.DORMITORIO,
+      },
+      select: { id: true },
     });
-    const validos = new Set(habitaciones.map((h) => h.inquilino_id));
-    const invalidos = usuario_ids.filter((uid) => !validos.has(uid));
+    const validos = new Set(habitaciones.map((habitacion) => habitacion.id));
+    const invalidos = habitacion_ids.filter((habitacionId) => !validos.has(habitacionId));
     if (invalidos.length > 0) {
-      res.status(403).json({ error: 'Uno o más usuarios no son inquilinos de esta vivienda.' });
+      res.status(403).json({ error: 'Una o mas habitaciones no pueden ser responsables fijas.' });
       return;
     }
   }
 
-  // Sincronización atómica: eliminar todas las asignaciones actuales y crear las nuevas.
   const asignaciones = await prisma.$transaction(async (tx) => {
     await tx.asignacionLimpiezaFija.deleteMany({ where: { zona_id: zonaId } });
-    if (usuario_ids.length === 0) return [];
+    if (habitacion_ids.length === 0) return [];
     await tx.asignacionLimpiezaFija.createMany({
-      data: usuario_ids.map((uid) => ({ zona_id: zonaId, usuario_id: uid })),
+      data: habitacion_ids.map((habitacionId) => ({ zona_id: zonaId, habitacion_id: habitacionId })),
     });
     return tx.asignacionLimpiezaFija.findMany({
       where: { zona_id: zonaId },
-      include: { usuario: { select: { id: true, nombre: true, apellidos: true } } },
+      include: {
+        habitacion: {
+          include: {
+            inquilino: { select: { id: true, nombre: true, apellidos: true } },
+          },
+        },
+      },
     });
   });
 
-  res.status(200).json(asignaciones);
+  res.status(200).json(
+    asignaciones.map((asignacion) => ({
+      id: asignacion.id,
+      habitacion_id: asignacion.habitacion.id,
+      habitacion: {
+        id: asignacion.habitacion.id,
+        nombre: asignacion.habitacion.nombre,
+        tipo: asignacion.habitacion.tipo,
+        es_habitable: asignacion.habitacion.es_habitable,
+        inquilino: asignacion.habitacion.inquilino,
+      },
+      responsable_actual: asignacion.habitacion.inquilino,
+    })),
+  );
 };
 
 export const eliminarZona: express.RequestHandler = async (req, res) => {
@@ -249,7 +574,6 @@ export const eliminarZona: express.RequestHandler = async (req, res) => {
     return;
   }
 
-  // Mantiene compatibilidad con bases previas aunque el schema ya define cascada.
   await prisma.$transaction([
     prisma.turnoLimpieza.deleteMany({ where: { zona_id: zonaId } }),
     prisma.asignacionLimpiezaFija.deleteMany({ where: { zona_id: zonaId } }),
@@ -277,7 +601,7 @@ export const quitarAsignacionFija: express.RequestHandler = async (req, res) => 
 
   const asignacion = await prisma.asignacionLimpiezaFija.findFirst({ where: { zona_id: zonaId } });
   if (!asignacion) {
-    res.status(404).json({ error: 'Esta zona no tiene asignación fija.' });
+    res.status(404).json({ error: 'Esta zona no tiene asignacion fija.' });
     return;
   }
 
@@ -287,21 +611,13 @@ export const quitarAsignacionFija: express.RequestHandler = async (req, res) => 
 
 export const obtenerTurnos: express.RequestHandler = async (req, res) => {
   const viviendaId = parseInt(req.params['id'] as string, 10);
-  const usuarioId = req.usuario!.id;
+  const acceso = await obtenerContextoAcceso(viviendaId, req.usuario!.id);
 
-  // Autorización: casero de la vivienda O inquilino con habitación en ella
-  const esCasero = await verificarPropiedadVivienda(viviendaId, usuarioId);
-  if (!esCasero) {
-    const habitacion = await prisma.habitacion.findFirst({
-      where: { vivienda_id: viviendaId, inquilino_id: usuarioId },
-    });
-    if (!habitacion) {
-      res.status(403).json({ error: 'No tienes acceso a esta vivienda.' });
-      return;
-    }
+  if (!acceso) {
+    res.status(403).json({ error: 'No tienes acceso a esta vivienda.' });
+    return;
   }
 
-  // Semana objetivo: usa ?fecha=YYYY-MM-DD si se envía, si no la semana actual.
   const base = req.query['fecha'] ? new Date(req.query['fecha'] as string) : new Date();
   const offset = (base.getDay() + 6) % 7;
   const lunes = new Date(base);
@@ -312,44 +628,63 @@ export const obtenerTurnos: express.RequestHandler = async (req, res) => {
   domingo.setHours(23, 59, 59, 999);
 
   const turnos = await prisma.turnoLimpieza.findMany({
-    where: {
-      zona: { vivienda_id: viviendaId },
-      fecha_inicio: { gte: lunes },
-      fecha_fin: { lte: domingo },
-    },
+    where: buildTurnosWhere({ viviendaId, inicio: lunes, fin: domingo, acceso }),
     include: {
-      zona: { select: { id: true, nombre: true, peso: true } },
+      zona: {
+        select: {
+          id: true,
+          nombre: true,
+          peso: true,
+          habitacion: {
+            select: {
+              id: true,
+              nombre: true,
+              tipo: true,
+              es_habitable: true,
+              inquilino: { select: { id: true, nombre: true, apellidos: true } },
+            },
+          },
+        },
+      },
+      habitacion: {
+        select: {
+          id: true,
+          nombre: true,
+          tipo: true,
+          es_habitable: true,
+          inquilino: { select: { id: true, nombre: true, apellidos: true } },
+        },
+      },
       usuario: { select: { id: true, nombre: true, apellidos: true } },
     },
-    orderBy: [{ usuario_id: 'asc' }, { zona: { peso: 'desc' } }],
+    orderBy: [{ fecha_inicio: 'asc' }, { habitacion_id: 'asc' }, { zona: { peso: 'desc' } }],
   });
 
-  res.json(turnos);
+  res.json(turnos.map(serializarTurno));
 };
 
 export const exportarTurnos: express.RequestHandler = async (req, res) => {
   const viviendaId = parseInt(req.params['id'] as string, 10);
-  const usuarioId = req.usuario!.id;
+  const acceso = await obtenerContextoAcceso(viviendaId, req.usuario!.id);
 
-  const vivienda = await prisma.vivienda.findFirst({
-    where: {
-      id: viviendaId,
-      OR: [
-        { casero_id: usuarioId },
-        { habitaciones: { some: { inquilino_id: usuarioId } } },
-      ],
-    },
+  if (!acceso) {
+    res.status(403).json({ error: 'No tienes acceso a esta vivienda.' });
+    return;
+  }
+
+  const vivienda = await prisma.vivienda.findUnique({
+    where: { id: viviendaId },
     select: { id: true, alias_nombre: true },
   });
 
   if (!vivienda) {
-    res.status(403).json({ error: 'No tienes acceso a esta vivienda.' });
+    res.status(404).json({ error: 'Vivienda no encontrada.' });
     return;
   }
 
   const estado = typeof req.query['estado'] === 'string' ? req.query['estado'].toUpperCase() : undefined;
   if (estado && !ESTADOS_EXPORTABLES.has(estado as EstadoTurnoExport)) {
-    res.status(400).json({ error: 'estado no válido para exportar limpiezas.' });
+    res.status(400).json({ error: 'estado no valido para exportar limpiezas.' });
     return;
   }
 
@@ -376,28 +711,33 @@ export const exportarTurnos: express.RequestHandler = async (req, res) => {
   }
 
   const turnos = await prisma.turnoLimpieza.findMany({
-    where: {
-      zona: { vivienda_id: viviendaId },
-      ...(estado ? { estado: estado as EstadoTurnoExport } : {}),
-      ...(inicio || fin
-        ? {
-            fecha_inicio: {
-              ...(inicio ? { gte: inicio } : {}),
-              ...(fin ? { lte: fin } : {}),
-            },
-          }
-        : {}),
-    },
+    where: buildTurnosWhere({
+      viviendaId,
+      inicio: inicio ?? undefined,
+      fin: fin ?? undefined,
+      estado: estado as EstadoTurnoExport | undefined,
+      acceso,
+    }),
     include: {
-      zona: { select: { nombre: true } },
-      usuario: {
+      zona: {
         select: {
           nombre: true,
-          apellidos: true,
+          habitacion: {
+            select: {
+              tipo: true,
+              es_habitable: true,
+            },
+          },
+        },
+      },
+      habitacion: {
+        select: {
+          nombre: true,
+          inquilino: { select: { nombre: true, apellidos: true } },
         },
       },
     },
-    orderBy: [{ fecha_inicio: 'asc' }, { usuario: { nombre: 'asc' } }, { zona: { nombre: 'asc' } }],
+    orderBy: [{ fecha_inicio: 'asc' }, { habitacion: { nombre: 'asc' } }, { zona: { nombre: 'asc' } }],
   });
 
   if (turnos.length === 0) {
@@ -406,8 +746,10 @@ export const exportarTurnos: express.RequestHandler = async (req, res) => {
   }
 
   const filas = turnos.map((turno) => ({
-    zona: turno.zona.nombre,
-    inquilino: nombreCompleto(turno.usuario),
+    espacio: turno.zona.nombre,
+    tipoEspacio: etiquetaTipoEspacio(obtenerTipoEspacio(turno.zona.habitacion ?? null)),
+    habitacionResponsable: turno.habitacion.nombre,
+    responsableActual: nombreCompleto(turno.habitacion.inquilino),
     fecha: turno.fecha_inicio,
   }));
 
@@ -437,6 +779,13 @@ export const marcarTurnoHecho: express.RequestHandler = async (req, res) => {
 
   const turno = await prisma.turnoLimpieza.findFirst({
     where: { id: turnoId, zona: { vivienda_id: viviendaId } },
+    include: {
+      habitacion: {
+        select: {
+          inquilino_id: true,
+        },
+      },
+    },
   });
 
   if (!turno) {
@@ -444,11 +793,10 @@ export const marcarTurnoHecho: express.RequestHandler = async (req, res) => {
     return;
   }
 
-  // Autorización: el propio asignado o el casero de la vivienda
-  if (turno.usuario_id !== usuarioId) {
+  if (turno.habitacion.inquilino_id !== usuarioId) {
     const esCasero = await verificarPropiedadVivienda(viviendaId, usuarioId);
     if (!esCasero) {
-      res.status(403).json({ error: 'Solo puedes marcar tus propios turnos.' });
+      res.status(403).json({ error: 'Solo puedes marcar turnos de tu habitacion o del casero.' });
       return;
     }
   }
@@ -457,12 +805,36 @@ export const marcarTurnoHecho: express.RequestHandler = async (req, res) => {
     where: { id: turnoId },
     data: { estado: 'HECHO' },
     include: {
-      zona: { select: { id: true, nombre: true, peso: true } },
+      zona: {
+        select: {
+          id: true,
+          nombre: true,
+          peso: true,
+          habitacion: {
+            select: {
+              id: true,
+              nombre: true,
+              tipo: true,
+              es_habitable: true,
+              inquilino: { select: { id: true, nombre: true, apellidos: true } },
+            },
+          },
+        },
+      },
+      habitacion: {
+        select: {
+          id: true,
+          nombre: true,
+          tipo: true,
+          es_habitable: true,
+          inquilino: { select: { id: true, nombre: true, apellidos: true } },
+        },
+      },
       usuario: { select: { id: true, nombre: true, apellidos: true } },
     },
   });
 
-  res.json(turnoActualizado);
+  res.json(serializarTurno(turnoActualizado));
 };
 
 export const generarTurnos: express.RequestHandler = async (req, res) => {

--- a/backend/src/services/limpieza.service.ts
+++ b/backend/src/services/limpieza.service.ts
@@ -1,29 +1,40 @@
 import { prisma } from '../lib/prisma';
-import { EstadoPresencia, EstadoTurno } from '../generated/prisma/client';
+import { EstadoPresencia, EstadoTurno, TipoHabitacion } from '../generated/prisma/client';
 
-/** Devuelve el lunes 00:00 de la semana que contiene `fecha`. */
 function getLunesDeSemana(fecha: Date): Date {
   const lunes = new Date(fecha);
-  const offset = (fecha.getDay() + 6) % 7; // 0=Lun … 6=Dom
+  const offset = (fecha.getDay() + 6) % 7;
   lunes.setDate(fecha.getDate() - offset);
   lunes.setHours(0, 0, 0, 0);
   return lunes;
 }
 
-/**
- * Genera los TurnoLimpieza de la próxima semana para una vivienda.
- *
- * Algoritmo de tres fases:
- *   A) Zonas con asignación fija cuyo usuario está ACTIVO → turno directo.
- *   B) Zonas rotativas → turno al usuario con menor (carga_semanal + balance_limpieza).
- *   C) Actualiza balance_limpieza = balance_anterior + (carga_asignada − cuota_ideal).
- *
- * Todo se persiste en una única transacción de Prisma.
- */
+type HabitacionResponsable = {
+  id: number;
+  nombre: string;
+  tipo: TipoHabitacion;
+  es_habitable: boolean;
+  inquilino_id?: number | null;
+  vivienda_id?: number;
+  codigo_invitacion?: string | null;
+  metros_cuadrados?: number | null;
+  precio?: number | null;
+  inquilino: {
+    id: number;
+    balance_limpieza: number;
+    estado_presencia: EstadoPresencia;
+  } | null;
+};
+
+const esHabitacionOcupadaActiva = (habitacion: HabitacionResponsable) =>
+  habitacion.inquilino?.estado_presencia === EstadoPresencia.ACTIVO;
+
+const cargaEfectivaHabitacion = (
+  habitacion: HabitacionResponsable,
+  cargaSemanal: Map<number, number>,
+) => (cargaSemanal.get(habitacion.id) ?? 0) + (habitacion.inquilino?.balance_limpieza ?? 0);
+
 export async function generarTurnosSemanales(viviendaId: number): Promise<void> {
-  // Determina la semana objetivo de forma incremental:
-  // - Si no hay turnos o el último es de una semana pasada → semana actual.
-  // - Si el último es de esta semana o futura → semana siguiente al último turno.
   const ultimoTurno = await prisma.turnoLimpieza.findFirst({
     where: { zona: { vivienda_id: viviendaId } },
     orderBy: { fecha_inicio: 'desc' },
@@ -35,10 +46,8 @@ export async function generarTurnosSemanales(viviendaId: number): Promise<void> 
 
   let inicio: Date;
   if (!ultimoTurno || ultimoTurno.fecha_inicio < lunesHoy) {
-    // Sin historial o historial antiguo → empezar por la semana actual.
     inicio = lunesHoy;
   } else {
-    // Hay turnos recientes → siguiente semana después del último.
     const lunesUltimo = getLunesDeSemana(new Date(ultimoTurno.fecha_inicio));
     inicio = new Date(lunesUltimo);
     inicio.setDate(lunesUltimo.getDate() + 7);
@@ -49,30 +58,52 @@ export async function generarTurnosSemanales(viviendaId: number): Promise<void> 
   fin.setDate(inicio.getDate() + 6);
   fin.setHours(23, 59, 59, 999);
 
-  // ── 1. Inquilinos ACTIVOS ────────────────────────────────────────────────────
-  const habitaciones = await prisma.habitacion.findMany({
+  const habitacionesResponsables = await prisma.habitacion.findMany({
     where: {
       vivienda_id: viviendaId,
-      inquilino_id: { not: null },
-      inquilino: { estado_presencia: EstadoPresencia.ACTIVO },
+      es_habitable: true,
+      tipo: TipoHabitacion.DORMITORIO,
     },
     include: {
-      inquilino: { select: { id: true, balance_limpieza: true } },
+      inquilino: {
+        select: {
+          id: true,
+          balance_limpieza: true,
+          estado_presencia: true,
+        },
+      },
     },
+    orderBy: { id: 'asc' },
   });
 
-  const usuariosActivos = habitaciones
-    .filter((h) => h.inquilino !== null)
-    .map((h) => h.inquilino!);
-
-  if (usuariosActivos.length === 0) {
-    throw new Error('No hay inquilinos activos en la vivienda.');
+  if (habitacionesResponsables.length === 0) {
+    throw new Error('No hay habitaciones habitables en la vivienda.');
   }
 
-  // ── 2. Zonas activas con asignaciones fijas (ordenadas desc por peso) ────────
+  const habitacionesActivas = habitacionesResponsables.filter(esHabitacionOcupadaActiva);
+  if (habitacionesActivas.length === 0) {
+    throw new Error('No hay habitaciones ocupadas activas para repartir la limpieza.');
+  }
+
   const zonas = await prisma.zonaLimpieza.findMany({
     where: { vivienda_id: viviendaId, activa: true },
-    include: { asignaciones_fijas: true },
+    include: {
+      asignaciones_fijas: {
+        include: {
+          habitacion: {
+            include: {
+              inquilino: {
+                select: {
+                  id: true,
+                  balance_limpieza: true,
+                  estado_presencia: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
     orderBy: { peso: 'desc' },
   });
 
@@ -80,97 +111,92 @@ export async function generarTurnosSemanales(viviendaId: number): Promise<void> 
     throw new Error('No hay zonas activas en la vivienda.');
   }
 
-  const activeUserIds = new Set(usuariosActivos.map((u) => u.id));
-
-  // carga_semanal: cuánto peso se ha asignado a cada usuario esta semana.
-  const cargaSemanal = new Map<number, number>(usuariosActivos.map((u) => [u.id, 0]));
+  const habitacionesActivasIds = new Set(habitacionesActivas.map((habitacion) => habitacion.id));
+  const cargaSemanal = new Map<number, number>(habitacionesResponsables.map((habitacion) => [habitacion.id, 0]));
 
   type TurnoData = {
-    usuario_id: number;
+    usuario_id: number | null;
+    habitacion_id: number;
     zona_id: number;
     fecha_inicio: Date;
     fecha_fin: Date;
     estado: EstadoTurno;
   };
+
   const turnos: TurnoData[] = [];
   const zonasRotativas: typeof zonas = [];
 
-  // ── Fase A: Zonas fijas con sub-rotación ────────────────────────────────────
-  // Una zona puede tener varios asignados. De los ACTIVOS, se elige al de menor
-  // carga efectiva esta semana → sub-rotación justa entre co-responsables.
   for (const zona of zonas) {
-    const asignadosActivos = zona.asignaciones_fijas
-      .filter((a) => activeUserIds.has(a.usuario_id))
-      .map((a) => usuariosActivos.find((u) => u.id === a.usuario_id)!)
-      .filter(Boolean);
+    const asignadasActivas = zona.asignaciones_fijas
+      .map((asignacion) => asignacion.habitacion)
+      .filter((habitacion): habitacion is typeof habitacion & HabitacionResponsable => Boolean(habitacion))
+      .filter((habitacion) => habitacionesActivasIds.has(habitacion.id));
 
-    if (asignadosActivos.length > 0) {
-      let elegido = asignadosActivos[0];
-      let menorCarga = (cargaSemanal.get(elegido.id) ?? 0) + elegido.balance_limpieza;
+    if (asignadasActivas.length > 0) {
+      let elegida = asignadasActivas[0];
+      let menorCarga = cargaEfectivaHabitacion(elegida, cargaSemanal);
 
-      for (const usuario of asignadosActivos) {
-        const carga = (cargaSemanal.get(usuario.id) ?? 0) + usuario.balance_limpieza;
+      for (const habitacion of asignadasActivas) {
+        const carga = cargaEfectivaHabitacion(habitacion, cargaSemanal);
         if (carga < menorCarga) {
           menorCarga = carga;
-          elegido = usuario;
+          elegida = habitacion;
         }
       }
 
       turnos.push({
-        usuario_id: elegido.id,
+        usuario_id: elegida.inquilino?.id ?? null,
+        habitacion_id: elegida.id,
         zona_id: zona.id,
         fecha_inicio: inicio,
         fecha_fin: fin,
         estado: EstadoTurno.PENDIENTE,
       });
-      cargaSemanal.set(elegido.id, (cargaSemanal.get(elegido.id) ?? 0) + zona.peso);
-    } else {
-      // Sin asignados activos → entra en rotación global.
-      zonasRotativas.push(zona);
+      cargaSemanal.set(elegida.id, (cargaSemanal.get(elegida.id) ?? 0) + zona.peso);
+      continue;
     }
+
+    zonasRotativas.push(zona);
   }
 
-  // ── Fase B: Zonas rotativas (bloques grandes primero) ───────────────────────
-  // El orden desc por peso ya viene de la query; lo mantenemos en zonasRotativas.
   for (const zona of zonasRotativas) {
-    // Usuario con menor carga efectiva = carga_semanal + balance_limpieza acumulado.
-    let elegido = usuariosActivos[0];
-    let menorCarga =
-      (cargaSemanal.get(elegido.id) ?? 0) + elegido.balance_limpieza;
+    let elegida = habitacionesActivas[0];
+    let menorCarga = cargaEfectivaHabitacion(elegida, cargaSemanal);
 
-    for (const usuario of usuariosActivos) {
-      const cargaEfectiva =
-        (cargaSemanal.get(usuario.id) ?? 0) + usuario.balance_limpieza;
-      if (cargaEfectiva < menorCarga) {
-        menorCarga = cargaEfectiva;
-        elegido = usuario;
+    for (const habitacion of habitacionesActivas) {
+      const carga = cargaEfectivaHabitacion(habitacion, cargaSemanal);
+      if (carga < menorCarga) {
+        menorCarga = carga;
+        elegida = habitacion;
       }
     }
 
     turnos.push({
-      usuario_id: elegido.id,
+      usuario_id: elegida.inquilino?.id ?? null,
+      habitacion_id: elegida.id,
       zona_id: zona.id,
       fecha_inicio: inicio,
       fecha_fin: fin,
       estado: EstadoTurno.PENDIENTE,
     });
-    cargaSemanal.set(elegido.id, (cargaSemanal.get(elegido.id) ?? 0) + zona.peso);
+    cargaSemanal.set(elegida.id, (cargaSemanal.get(elegida.id) ?? 0) + zona.peso);
   }
 
-  // ── Fase C: Karma — actualiza balance_limpieza en base de datos ──────────────
-  const pesoTotal = zonas.reduce((acc, z) => acc + z.peso, 0);
-  const cuotaIdeal = pesoTotal / usuariosActivos.length;
+  const habitacionesConBalance = habitacionesActivas.filter((habitacion) => habitacion.inquilino !== null);
 
-  const actualizacionesBalance = usuariosActivos.map((u) => {
-    const cargaAsignada = cargaSemanal.get(u.id) ?? 0;
-    const nuevoBalance = u.balance_limpieza + (cargaAsignada - cuotaIdeal);
+  const pesoTotal = zonas.reduce((acc, zona) => acc + zona.peso, 0);
+  const cuotaIdeal = pesoTotal / habitacionesConBalance.length;
+
+  const actualizacionesBalance = habitacionesConBalance.map((habitacion) => {
+    const cargaAsignada = cargaSemanal.get(habitacion.id) ?? 0;
+    const inquilino = habitacion.inquilino!;
+    const nuevoBalance = inquilino.balance_limpieza + (cargaAsignada - cuotaIdeal);
     return prisma.usuario.update({
-      where: { id: u.id },
+      where: { id: inquilino.id },
       data: { balance_limpieza: nuevoBalance },
     });
   });
 
-  // ── Persistencia en transacción atómica ─────────────────────────────────────
   await prisma.$transaction([
     prisma.turnoLimpieza.createMany({ data: turnos }),
     ...actualizacionesBalance,

--- a/backend/tests/limpieza.service.test.ts
+++ b/backend/tests/limpieza.service.test.ts
@@ -36,7 +36,8 @@ const { generarTurnosSemanales } = await import('../src/services/limpieza.servic
 
 type TurnoCreateMany = {
   data: Array<{
-    usuario_id: number;
+    usuario_id: number | null;
+    habitacion_id: number;
     zona_id: number;
     fecha_inicio: Date;
     fecha_fin: Date;
@@ -59,8 +60,20 @@ function resetPrisma() {
     return { operation: 'createMany', args };
   };
   prisma.habitacion.findMany = async () => [
-    { inquilino: { id: 1, balance_limpieza: 0 } },
-    { inquilino: { id: 2, balance_limpieza: 2 } },
+    {
+      id: 101,
+      nombre: 'Habitacion A',
+      tipo: 'DORMITORIO',
+      es_habitable: true,
+      inquilino: { id: 1, balance_limpieza: 0, estado_presencia: 'ACTIVO' },
+    },
+    {
+      id: 102,
+      nombre: 'Habitacion B',
+      tipo: 'DORMITORIO',
+      es_habitable: true,
+      inquilino: { id: 2, balance_limpieza: 2, estado_presencia: 'ACTIVO' },
+    },
   ];
   prisma.zonaLimpieza.findMany = async () => [
     { id: 10, peso: 3, asignaciones_fijas: [] },
@@ -87,18 +100,19 @@ afterEach(() => {
 });
 
 describe('generacion de turnos de limpieza', () => {
-  test('reparte zonas por carga efectiva y actualiza balances semanales', async () => {
+  test('reparte zonas por carga efectiva de la habitacion responsable y actualiza balances', async () => {
     await generarTurnosSemanales(10);
 
     assert.deepEqual(
       createManyArgs?.data.map((turno) => ({
         usuario_id: turno.usuario_id,
+        habitacion_id: turno.habitacion_id,
         zona_id: turno.zona_id,
         estado: turno.estado,
       })),
       [
-        { usuario_id: 1, zona_id: 10, estado: 'PENDIENTE' },
-        { usuario_id: 2, zona_id: 11, estado: 'PENDIENTE' },
+        { usuario_id: 1, habitacion_id: 101, zona_id: 10, estado: 'PENDIENTE' },
+        { usuario_id: 2, habitacion_id: 102, zona_id: 11, estado: 'PENDIENTE' },
       ],
     );
     assert.equal(createManyArgs?.data[0]?.fecha_inicio.toISOString(), '2026-04-05T22:00:00.000Z');
@@ -121,12 +135,20 @@ describe('generacion de turnos de limpieza', () => {
     assert.equal(createManyArgs?.data[0]?.fecha_fin.toISOString(), '2026-04-26T21:59:59.999Z');
   });
 
-  test('lanza error si no hay inquilinos activos', async () => {
-    prisma.habitacion.findMany = async () => [];
+  test('lanza error si no hay habitaciones ocupadas activas', async () => {
+    prisma.habitacion.findMany = async () => [
+      {
+        id: 101,
+        nombre: 'Habitacion vacia',
+        tipo: 'DORMITORIO',
+        es_habitable: true,
+        inquilino: null,
+      },
+    ];
 
     await assert.rejects(
       () => generarTurnosSemanales(10),
-      /no hay inquilinos activos/i,
+      /no hay habitaciones ocupadas activas/i,
     );
     assert.equal(createManyArgs, null);
   });

--- a/backend/tests/operational-modules.test.ts
+++ b/backend/tests/operational-modules.test.ts
@@ -258,7 +258,7 @@ describe('exportacion de limpieza', () => {
 
   test('genera csv con cabeceras, filtros y nombre descargable', async () => {
     let filtros: unknown;
-    prisma.vivienda.findFirst = async () => ({ id: 10, alias_nombre: 'Piso Centro' });
+    prisma.vivienda.findUnique = async () => ({ id: 10, alias_nombre: 'Piso Centro', casero_id: 99 });
     prisma.turnoLimpieza.findMany = async (args: unknown) => {
       filtros = args;
       return [
@@ -267,10 +267,13 @@ describe('exportacion de limpieza', () => {
           fecha_inicio: new Date('2026-04-13T00:00:00.000Z'),
           fecha_fin: new Date('2026-04-19T23:59:59.999Z'),
           estado: 'HECHO',
-          zona: { nombre: 'Cocina' },
-          usuario: {
-            nombre: 'Ada',
-            apellidos: 'Lovelace',
+          zona: {
+            nombre: 'Cocina',
+            habitacion: { tipo: 'COCINA', es_habitable: false },
+          },
+          habitacion: {
+            nombre: 'Habitacion 1',
+            inquilino: { nombre: 'Ada', apellidos: 'Lovelace' },
           },
         },
       ];
@@ -288,21 +291,27 @@ describe('exportacion de limpieza', () => {
     assert.equal(response.statusCode, 200);
     assert.match(response.headers['content-type'], /text\/csv/);
     assert.match(response.headers['content-disposition'], /limpiezas-piso-centro-/);
-    assert.match(response.body as string, /"Zona a limpiar";"Inquilino";"Fecha"/);
-    assert.match(response.body as string, /"Cocina";"Ada Lovelace";"13\/04\/2026"/);
+    assert.match(response.body as string, /"Espacio";"Tipo de espacio";"Habitacion responsable";"Responsable actual";"Fecha"/);
+    assert.match(response.body as string, /"Cocina";"Zona comun";"Habitacion 1";"Ada Lovelace";"13\/04\/2026"/);
     assert.equal((filtros as { where: { estado: string } }).where.estado, 'HECHO');
   });
 
   test('devuelve base64 para preservar acentos en movil', async () => {
-    prisma.vivienda.findFirst = async () => ({ id: 10, alias_nombre: 'Piso Centro' });
+    prisma.vivienda.findUnique = async () => ({ id: 10, alias_nombre: 'Piso Centro', casero_id: 99 });
     prisma.turnoLimpieza.findMany = async () => [
       {
         id: 1,
         fecha_inicio: new Date('2026-04-13T00:00:00.000Z'),
         fecha_fin: new Date('2026-04-19T23:59:59.999Z'),
         estado: 'PENDIENTE',
-        zona: { nombre: 'BaÃ±o 1' },
-        usuario: { nombre: 'Ada', apellidos: 'Lovelace' },
+        zona: {
+          nombre: 'Baño 1',
+          habitacion: { tipo: 'BANO', es_habitable: false },
+        },
+        habitacion: {
+          nombre: 'Habitacion 2',
+          inquilino: { nombre: 'Ada', apellidos: 'Lovelace' },
+        },
       },
     ];
 
@@ -319,11 +328,11 @@ describe('exportacion de limpieza', () => {
     const body = response.body as { contenidoBase64: string; nombreArchivo: string };
     const csv = Buffer.from(body.contenidoBase64, 'base64').subarray(2).toString('utf16le');
     assert.match(body.nombreArchivo, /limpiezas-piso-centro-/);
-    assert.match(csv, /"BaÃ±o 1";"Ada Lovelace";"13\/04\/2026"/);
+    assert.match(csv, /"Baño 1";"Zona comun";"Habitacion 2";"Ada Lovelace";"13\/04\/2026"/);
   });
 
   test('responde claro si no hay turnos para los filtros actuales', async () => {
-    prisma.vivienda.findFirst = async () => ({ id: 10, alias_nombre: 'Piso Centro' });
+    prisma.vivienda.findUnique = async () => ({ id: 10, alias_nombre: 'Piso Centro', casero_id: 99 });
     prisma.turnoLimpieza.findMany = async () => [];
 
     const response = await invoke(

--- a/docs/changelog/Epica17/epica-17-issue-283-limpieza-por-habitaciones.md
+++ b/docs/changelog/Epica17/epica-17-issue-283-limpieza-por-habitaciones.md
@@ -1,0 +1,21 @@
+# Epica 17 - Issue 283 - Limpieza por habitaciones
+
+## Objetivo
+
+Reorientar el módulo de limpieza para que los turnos y asignaciones se apoyen en habitaciones responsables y en espacios objetivo, en lugar de depender directamente de inquilinos como entidad principal.
+
+## Cambios principales
+
+- `backend/prisma/schema.prisma`: `ZonaLimpieza` puede vincularse a una habitación objetivo; `AsignacionLimpiezaFija` y `TurnoLimpieza` pasan a guardar habitación responsable y mantienen `usuario_id` como snapshot opcional del ocupante al generar el turno.
+- `backend/src/services/limpieza.service.ts`: el reparto semanal rota por habitaciones habitables ocupadas, conserva balances por ocupante activo y sigue permitiendo zonas con asignación fija.
+- `backend/src/controllers/limpieza.controller.ts`: las respuestas de zonas y turnos exponen tipo de espacio, habitación responsable y responsable actual derivado; los permisos del inquilino se limitan a su habitación y a zonas comunes/espacios visibles.
+- `frontend/app/casero/vivienda/[id]/(tabs)/limpieza.tsx`: el casero configura espacios de limpieza vinculados a habitación o personalizados y asigna responsables fijas por habitación.
+- `frontend/app/inquilino/(tabs)/limpieza.tsx`: el inquilino ve sus tareas según su habitación responsable y solo el contexto relacionado del resto de la vivienda.
+- `backend/tests/limpieza.service.test.ts` y `backend/tests/operational-modules.test.ts`: se actualizan al nuevo contrato de habitaciones responsables y a la exportación enriquecida.
+
+## Verificacion
+
+- `npx prisma validate --schema prisma/schema.prisma`
+- `npm run build` en `backend/`
+- `npm test -- limpieza.service.test.ts operational-modules.test.ts` en `backend/`
+- `npm run lint` en `frontend/` (mantiene únicamente warnings previos ajenos en `frontend/app/casero/vivienda/[id]/(tabs)/index.tsx`)

--- a/frontend/app/casero/vivienda/[id]/(tabs)/limpieza.tsx
+++ b/frontend/app/casero/vivienda/[id]/(tabs)/limpieza.tsx
@@ -15,7 +15,7 @@ import { Ionicons } from '@expo/vector-icons';
 import * as FileSystem from 'expo-file-system/legacy';
 import Toast from 'react-native-toast-message';
 import type { AppTheme } from '@/constants/theme';
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import api from '@/services/api';
 import { Card } from '@/components/common/Card';
 import { CustomButton } from '@/components/common/CustomButton';
@@ -24,16 +24,17 @@ import { createStyles } from '@/styles/casero/vivienda/limpieza.styles';
 import { useViviendaIdParam } from '@/hooks/useViviendaIdParam';
 import { useAppTheme } from '@/contexts/ThemeContext';
 
-// ── Helpers UI ────────────────────────────────────────────────────────────────
-
 const ZONA_ICONS: Record<string, string> = {
   cocina: 'restaurant-outline',
-  'baño': 'water-outline', 'baño 1': 'water-outline', 'baño 2': 'water-outline',
-  'salón': 'tv-outline', salon: 'tv-outline',
+  baño: 'water-outline',
+  'baño 1': 'water-outline',
+  'baño 2': 'water-outline',
+  salón: 'tv-outline',
+  salon: 'tv-outline',
   pasillo: 'footsteps-outline',
 };
-const zonaIcon = (nombre: string) =>
-  (ZONA_ICONS[nombre.toLowerCase()] ?? 'sparkles-outline') as any;
+
+const zonaIcon = (nombre: string) => (ZONA_ICONS[nombre.toLowerCase()] ?? 'sparkles-outline') as any;
 
 const AvatarInitials = ({
   nombre,
@@ -48,18 +49,21 @@ const AvatarInitials = ({
 }) => {
   const initials = `${nombre[0] ?? ''}${apellidos?.[0] ?? ''}`.toUpperCase();
   return (
-    <View style={{
-      width: size, height: size, borderRadius: size / 2,
-      backgroundColor: theme.colors.primaryLight, alignItems: 'center', justifyContent: 'center',
-    }}>
-      <Text style={{ fontSize: size * 0.33, fontWeight: '700', color: theme.colors.primary }}>
-        {initials}
-      </Text>
+    <View
+      style={{
+        width: size,
+        height: size,
+        borderRadius: size / 2,
+        backgroundColor: theme.colors.primaryLight,
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <Text style={{ fontSize: size * 0.33, fontWeight: '700', color: theme.colors.primary }}>{initials}</Text>
     </View>
   );
 };
 
-// ── T-Shirt Sizing ────────────────────────────────────────────────────────────
 const TALLAS = [
   { label: 'Ligera', peso: 3 },
   { label: 'Normal', peso: 6 },
@@ -67,6 +71,12 @@ const TALLAS = [
 ] as const;
 
 const ETIQUETA_ESFUERZO: Record<number, string> = { 3: 'Ligera', 6: 'Normal', 10: 'Intensa' };
+const QUICK_CHIPS = ['Cocina', 'Baño', 'Salón', 'Pasillo'];
+const ZONAS_BASE = [
+  { nombre: 'Cocina', peso: 10 },
+  { nombre: 'Salón', peso: 6 },
+  { nombre: 'Baño', peso: 6 },
+];
 
 const etiquetaEsfuerzo = (peso: number) =>
   ETIQUETA_ESFUERZO[peso] ? `Esfuerzo: ${ETIQUETA_ESFUERZO[peso]}` : `Peso: ${peso}`;
@@ -78,26 +88,25 @@ const formatearFechaParam = (fecha: Date) => {
   return `${year}-${month}-${day}`;
 };
 
-const QUICK_CHIPS = ['Cocina', 'Baño', 'Salón', 'Pasillo'];
-
-const ZONAS_BASE = [
-  { nombre: 'Cocina', peso: 10 },
-  { nombre: 'Salón', peso: 6 },
-  { nombre: 'Baño', peso: 6 },
-];
-
-// ─────────────────────────────────────────────────────────────────────────────
-
-type Inquilino = {
+type ResponsableActual = {
   id: number;
   nombre: string;
   apellidos: string | null;
+} | null;
+
+type Habitacion = {
+  id: number;
+  nombre: string;
+  tipo: 'DORMITORIO' | 'BANO' | 'COCINA' | 'SALON' | 'OTRO';
+  es_habitable: boolean;
+  inquilino: ResponsableActual;
 };
 
 type AsignacionFija = {
   id: number;
-  usuario_id: number;
-  usuario: Inquilino;
+  habitacion_id: number;
+  habitacion: Habitacion;
+  responsable_actual: ResponsableActual;
 };
 
 type ZonaLimpieza = {
@@ -105,18 +114,23 @@ type ZonaLimpieza = {
   nombre: string;
   peso: number;
   activa: boolean;
+  tipo_espacio: 'HABITACION' | 'ZONA_COMUN' | 'ESPACIO';
+  habitacion: Habitacion | null;
   asignaciones_fijas: AsignacionFija[];
 };
 
 type Turno = {
   id: number;
-  usuario_id: number;
+  usuario_id: number | null;
+  habitacion_id: number;
   zona_id: number;
   fecha_inicio: string;
   fecha_fin: string;
   estado: 'PENDIENTE' | 'HECHO' | 'NO_HECHO';
-  zona: { id: number; nombre: string; peso: number };
-  usuario: { id: number; nombre: string; apellidos: string | null };
+  tipo_espacio: 'HABITACION' | 'ZONA_COMUN' | 'ESPACIO';
+  zona: { id: number; nombre: string; peso: number; habitacion: Habitacion | null };
+  habitacion: Habitacion;
+  responsable_actual: ResponsableActual;
 };
 
 type ExportLimpiezasResponse = {
@@ -133,35 +147,37 @@ const FILTROS_ESTADO: { label: string; value: EstadoFiltro }[] = [
   { label: 'Hechos', value: 'HECHO' },
 ];
 
-// ─────────────────────────────────────────────────────────────────────────────
+const getTipoEspacioLabel = (tipo: ZonaLimpieza['tipo_espacio']) => {
+  if (tipo === 'HABITACION') return 'Habitación';
+  if (tipo === 'ZONA_COMUN') return 'Zona común';
+  return 'Espacio';
+};
+
+const getResponsableLabel = (responsable: ResponsableActual) =>
+  responsable ? `${responsable.nombre}${responsable.apellidos ? ` ${responsable.apellidos}` : ''}` : 'Sin ocupante';
 
 export default function LimpiezaCaseroTab() {
   const id = useViviendaIdParam();
   const { theme } = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
-  // — Vista activa —
   const [vistaActual, setVistaActual] = useState<'CONFIG' | 'CALENDARIO'>('CONFIG');
-
-  // — Config state —
   const [zonas, setZonas] = useState<ZonaLimpieza[]>([]);
-  const [inquilinos, setInquilinos] = useState<Inquilino[]>([]);
+  const [habitaciones, setHabitaciones] = useState<Habitacion[]>([]);
   const [loading, setLoading] = useState(true);
   const [generando, setGenerando] = useState(false);
   const [creandoBase, setCreandoBase] = useState(false);
 
-  // — Modal nueva zona —
   const [modalZonaVisible, setModalZonaVisible] = useState(false);
   const [nombre, setNombre] = useState('');
   const [pesoSeleccionado, setPesoSeleccionado] = useState<number | null>(null);
+  const [habitacionObjetivoId, setHabitacionObjetivoId] = useState<number | null>(null);
   const [guardando, setGuardando] = useState(false);
 
-  // — Modal asignación fija (multi-select) —
   const [zonaSeleccionada, setZonaSeleccionada] = useState<ZonaLimpieza | null>(null);
   const [seleccionados, setSeleccionados] = useState<number[]>([]);
   const [asignando, setAsignando] = useState(false);
 
-  // — Calendario state —
   const [turnos, setTurnos] = useState<Turno[]>([]);
   const [loadingTurnos, setLoadingTurnos] = useState(false);
   const [exportando, setExportando] = useState(false);
@@ -174,44 +190,48 @@ export default function LimpiezaCaseroTab() {
     return hoy;
   });
 
+  const habitacionesResponsables = habitaciones.filter(
+    (habitacion) => habitacion.es_habitable && habitacion.tipo === 'DORMITORIO',
+  );
+
   useEffect(() => {
     const inicializar = async () => {
       setLoading(true);
-      await Promise.all([cargarZonas(), cargarInquilinos()]);
+      await Promise.all([cargarZonas(), cargarHabitaciones()]);
       setLoading(false);
     };
     inicializar();
-  }, [id]);
+  }, [cargarHabitaciones, cargarZonas]);
 
   useEffect(() => {
-    if (vistaActual === 'CALENDARIO') cargarTurnos(fechaObjetivo);
-  }, [vistaActual, fechaObjetivo]);
+    if (vistaActual === 'CALENDARIO') {
+      cargarTurnos(fechaObjetivo);
+    }
+  }, [cargarTurnos, fechaObjetivo, vistaActual]);
 
-  const cargarZonas = async () => {
+  const cargarZonas = useCallback(async () => {
     if (!id) return;
 
     try {
       const { data } = await api.get<ZonaLimpieza[]>(`/viviendas/${id}/limpieza/zonas`);
       setZonas(data);
     } catch {
-      Toast.show({ type: 'error', text1: 'No se pudieron cargar las zonas.' });
+      Toast.show({ type: 'error', text1: 'No se pudieron cargar los espacios de limpieza.' });
     }
-  };
+  }, [id]);
 
-  const cargarInquilinos = async () => {
+  const cargarHabitaciones = useCallback(async () => {
     if (!id) return;
 
     try {
-      const { data } = await api.get<{ habitaciones: { inquilino: Inquilino | null }[] }>(`/viviendas/${id}`);
-      setInquilinos(
-        data.habitaciones.filter((h) => h.inquilino !== null).map((h) => h.inquilino!)
-      );
+      const { data } = await api.get<{ habitaciones: Habitacion[] }>(`/viviendas/${id}`);
+      setHabitaciones(data.habitaciones);
     } catch {
-      // non-critical
+      Toast.show({ type: 'error', text1: 'No se pudieron cargar las habitaciones.' });
     }
-  };
+  }, [id]);
 
-  const cargarTurnos = async (fecha?: Date) => {
+  const cargarTurnos = useCallback(async (fecha?: Date) => {
     if (!id) return;
 
     setLoadingTurnos(true);
@@ -225,7 +245,7 @@ export default function LimpiezaCaseroTab() {
     } finally {
       setLoadingTurnos(false);
     }
-  };
+  }, [fechaObjetivo, id]);
 
   const guardarArchivoCsv = async (contenidoBase64: string, nombreArchivo: string, mimeType: string) => {
     if (Platform.OS === 'web' && typeof document !== 'undefined') {
@@ -319,53 +339,54 @@ export default function LimpiezaCaseroTab() {
     });
   };
 
-  // — Nueva zona —
   const cerrarModalZona = () => {
     setModalZonaVisible(false);
     setNombre('');
     setPesoSeleccionado(null);
+    setHabitacionObjetivoId(null);
   };
 
   const handleGuardar = async () => {
-    if (!id || !nombre.trim() || pesoSeleccionado === null) return;
+    if (!id || pesoSeleccionado === null) return;
+    if (!nombre.trim() && !habitacionObjetivoId) return;
+
     setGuardando(true);
     try {
       const { data } = await api.post<ZonaLimpieza>(`/viviendas/${id}/limpieza/zonas`, {
-        nombre: nombre.trim(),
+        nombre: nombre.trim() || undefined,
         peso: pesoSeleccionado,
+        habitacion_id: habitacionObjetivoId,
       });
-      setZonas((prev) => [...prev, { ...data, asignaciones_fijas: [] }]);
+      setZonas((prev) => [...prev, data]);
       cerrarModalZona();
     } catch (err: any) {
-      Toast.show({ type: 'error', text1: err.response?.data?.error ?? 'No se pudo crear la zona.' });
+      Toast.show({ type: 'error', text1: err.response?.data?.error ?? 'No se pudo crear el espacio.' });
     } finally {
       setGuardando(false);
     }
   };
 
-  const puedeGuardar = nombre.trim().length > 0 && pesoSeleccionado !== null;
+  const puedeGuardar = (nombre.trim().length > 0 || habitacionObjetivoId !== null) && pesoSeleccionado !== null;
 
-  // — Starter Pack —
   const handleGenerarZonasBasicas = async () => {
     if (!id) return;
 
     setCreandoBase(true);
     try {
       const resultados = await Promise.all(
-        ZONAS_BASE.map((z) => api.post<ZonaLimpieza>(`/viviendas/${id}/limpieza/zonas`, z))
+        ZONAS_BASE.map((zonaBase) => api.post<ZonaLimpieza>(`/viviendas/${id}/limpieza/zonas`, zonaBase)),
       );
-      setZonas(resultados.map((r) => ({ ...r.data, asignaciones_fijas: [] })));
+      setZonas((prev) => [...prev, ...resultados.map((resultado) => resultado.data)]);
     } catch (err: any) {
-      Toast.show({ type: 'error', text1: err.response?.data?.error ?? 'No se pudieron crear las zonas base.' });
+      Toast.show({ type: 'error', text1: err.response?.data?.error ?? 'No se pudieron crear los espacios base.' });
     } finally {
       setCreandoBase(false);
     }
   };
 
-  // — Asignación fija multi-select —
   const abrirModalAsignacion = (zona: ZonaLimpieza) => {
     setZonaSeleccionada(zona);
-    setSeleccionados((zona.asignaciones_fijas ?? []).map((a) => a.usuario_id));
+    setSeleccionados((zona.asignaciones_fijas ?? []).map((asignacion) => asignacion.habitacion_id));
   };
 
   const cerrarModalAsignacion = () => {
@@ -373,22 +394,23 @@ export default function LimpiezaCaseroTab() {
     setSeleccionados([]);
   };
 
-  const toggleSeleccion = (usuarioId: number) => {
+  const toggleSeleccion = (habitacionId: number) => {
     setSeleccionados((prev) =>
-      prev.includes(usuarioId) ? prev.filter((x) => x !== usuarioId) : [...prev, usuarioId]
+      prev.includes(habitacionId) ? prev.filter((idHabitacion) => idHabitacion !== habitacionId) : [...prev, habitacionId],
     );
   };
 
   const handleGuardarAsignacion = async () => {
     if (!id || !zonaSeleccionada) return;
+
     setAsignando(true);
     try {
       const { data } = await api.post<AsignacionFija[]>(
         `/viviendas/${id}/limpieza/zonas/${zonaSeleccionada.id}/asignacion`,
-        { usuario_ids: seleccionados }
+        { habitacion_ids: seleccionados },
       );
       setZonas((prev) =>
-        prev.map((z) => (z.id === zonaSeleccionada.id ? { ...z, asignaciones_fijas: data } : z))
+        prev.map((zona) => (zona.id === zonaSeleccionada.id ? { ...zona, asignaciones_fijas: data } : zona)),
       );
       cerrarModalAsignacion();
     } catch (err: any) {
@@ -400,7 +422,7 @@ export default function LimpiezaCaseroTab() {
 
   const handleEliminarZona = (zona: ZonaLimpieza) => {
     Alert.alert(
-      'Eliminar zona',
+      'Eliminar espacio',
       `¿Eliminar "${zona.nombre}"? Se borrarán también sus asignaciones y turnos.`,
       [
         { text: 'Cancelar', style: 'cancel' },
@@ -410,13 +432,13 @@ export default function LimpiezaCaseroTab() {
           onPress: async () => {
             try {
               await api.delete(`/viviendas/${id}/limpieza/zonas/${zona.id}`);
-              setZonas((prev) => prev.filter((z) => z.id !== zona.id));
+              setZonas((prev) => prev.filter((item) => item.id !== zona.id));
             } catch (err: any) {
-              Toast.show({ type: 'error', text1: err.response?.data?.error ?? 'No se pudo eliminar la zona.' });
+              Toast.show({ type: 'error', text1: err.response?.data?.error ?? 'No se pudo eliminar el espacio.' });
             }
           },
         },
-      ]
+      ],
     );
   };
 
@@ -426,19 +448,20 @@ export default function LimpiezaCaseroTab() {
     setGenerando(true);
     try {
       await api.post(`/viviendas/${id}/limpieza/generar`);
-      Toast.show({ type: 'success', text1: 'Turnos generados', text2: 'Ve al Calendario para verlos.' });
+      Toast.show({
+        type: 'success',
+        text1: 'Turnos generados',
+        text2: 'El reparto ya está vinculado a habitaciones responsables.',
+      });
+      if (vistaActual === 'CALENDARIO') {
+        await cargarTurnos(fechaObjetivo);
+      }
     } catch (err: any) {
-      Alert.alert(
-        'No se pudieron generar los turnos',
-        err.response?.data?.error ?? 'Ha ocurrido un error inesperado.'
-      );
+      Alert.alert('No se pudieron generar los turnos', err.response?.data?.error ?? 'Ha ocurrido un error inesperado.');
     } finally {
       setGenerando(false);
     }
   };
-
-  const nombreCorto = (inq: Inquilino) =>
-    `${inq.nombre}${inq.apellidos ? ` ${inq.apellidos[0]}.` : ''}`;
 
   const getSemanaLabel = (base: Date) => {
     const domingo = new Date(base);
@@ -447,13 +470,11 @@ export default function LimpiezaCaseroTab() {
     return `${fmt(base)} — ${fmt(domingo)}`;
   };
 
-  // ── Render: card de zona ──────────────────────────────────────────────────
-
   const renderZona = ({ item }: { item: ZonaLimpieza }) => {
     const asignaciones = item.asignaciones_fijas ?? [];
     const etiquetaFijos =
       asignaciones.length > 0
-        ? `👤 Fijos: ${asignaciones.map((a) => nombreCorto(a.usuario)).join(', ')}`
+        ? `Responsables fijas: ${asignaciones.map((asignacion) => asignacion.habitacion.nombre).join(', ')}`
         : null;
 
     return (
@@ -470,12 +491,16 @@ export default function LimpiezaCaseroTab() {
           </Pressable>
         </View>
         <Text style={styles.zonaPeso}>{etiquetaEsfuerzo(item.peso)}</Text>
+        <Text style={[styles.zonaPeso, { color: theme.colors.textSecondary, marginTop: theme.spacing.xs }]}>
+          {getTipoEspacioLabel(item.tipo_espacio)}
+          {item.habitacion ? ` · ${item.habitacion.nombre}` : ' · Espacio personalizado'}
+        </Text>
         <View style={styles.asignacionRow}>
           <Pressable onPress={() => abrirModalAsignacion(item)} hitSlop={6}>
             {etiquetaFijos ? (
               <Text style={styles.asignacionFija}>{etiquetaFijos}</Text>
             ) : (
-              <Text style={styles.asignarLink}>+ Asignar inquilino(s) fijo(s)</Text>
+              <Text style={styles.asignarLink}>+ Asignar habitación responsable fija</Text>
             )}
           </Pressable>
         </View>
@@ -488,10 +513,12 @@ export default function LimpiezaCaseroTab() {
       <View style={styles.emptyIconBox}>
         <Ionicons name="sparkles-outline" size={40} color={theme.colors.success} />
       </View>
-      <Text style={styles.emptyTitulo}>Sin zonas todavía</Text>
-      <Text style={styles.emptySubtitulo}>Genera las zonas básicas para empezar a repartir las tareas de limpieza.</Text>
+      <Text style={styles.emptyTitulo}>Sin espacios todavía</Text>
+      <Text style={styles.emptySubtitulo}>
+        Crea habitaciones, zonas comunes o espacios personalizados para planificar la limpieza por espacio.
+      </Text>
       <CustomButton
-        label={creandoBase ? 'Creando...' : 'Generar zonas básicas'}
+        label={creandoBase ? 'Creando...' : 'Generar espacios base'}
         variant="outline"
         onPress={handleGenerarZonasBasicas}
         disabled={creandoBase}
@@ -500,27 +527,22 @@ export default function LimpiezaCaseroTab() {
     </View>
   );
 
-  // ── Render: vista Calendario ──────────────────────────────────────────────
-
   const renderCalendario = () => {
     if (loadingTurnos) {
       return <ActivityIndicator style={{ flex: 1, marginTop: 40 }} size="large" color={theme.colors.primary} />;
     }
 
-    const turnosFiltrados = turnos.filter((turno) =>
-      filtroEstado === 'TODOS' ? true : turno.estado === filtroEstado
-    );
-    const turnosFiltradosPorUsuario = turnosFiltrados.reduce<
-      Record<number, { usuario: Turno['usuario']; items: Turno[] }>
-    >((acc, t) => {
-      if (!acc[t.usuario_id]) acc[t.usuario_id] = { usuario: t.usuario, items: [] };
-      acc[t.usuario_id].items.push(t);
+    const turnosFiltrados = turnos.filter((turno) => (filtroEstado === 'TODOS' ? true : turno.estado === filtroEstado));
+    const turnosAgrupados = turnosFiltrados.reduce<Record<number, { habitacion: Habitacion; items: Turno[] }>>((acc, turno) => {
+      if (!acc[turno.habitacion_id]) {
+        acc[turno.habitacion_id] = { habitacion: turno.habitacion, items: [] };
+      }
+      acc[turno.habitacion_id].items.push(turno);
       return acc;
     }, {});
 
     return (
       <ScrollView contentContainerStyle={styles.content}>
-        {/* ── Cabecera ── */}
         <View style={styles.calendarioHeader}>
           <View>
             <Text style={styles.calendarioGestion}>Gestión</Text>
@@ -528,10 +550,7 @@ export default function LimpiezaCaseroTab() {
           </View>
           <View style={styles.calendarioActions}>
             <Pressable
-              style={({ pressed }) => [
-                styles.calendarioBtnExport,
-                (pressed || exportando) && { opacity: 0.7 },
-              ]}
+              style={({ pressed }) => [styles.calendarioBtnExport, (pressed || exportando) && { opacity: 0.7 }]}
               onPress={exportarTurnos}
               disabled={exportando}
             >
@@ -540,9 +559,7 @@ export default function LimpiezaCaseroTab() {
               ) : (
                 <Ionicons name="download-outline" size={16} color={theme.colors.primary} />
               )}
-              <Text style={styles.calendarioBtnExportTexto}>
-                {exportando ? 'Exportando' : 'Exportar todo'}
-              </Text>
+              <Text style={styles.calendarioBtnExportTexto}>{exportando ? 'Exportando' : 'Exportar todo'}</Text>
             </Pressable>
             <Pressable
               style={({ pressed }) => [styles.calendarioBtnConfig, pressed && { opacity: 0.7 }]}
@@ -553,13 +570,20 @@ export default function LimpiezaCaseroTab() {
           </View>
         </View>
 
-        {/* ── Navegación de semana ── */}
         <View style={styles.semanaNav}>
-          <Pressable onPress={() => navegar(-1)} hitSlop={12} style={({ pressed }) => [styles.semanaNavBtn, pressed && { opacity: 0.5 }]}>
+          <Pressable
+            onPress={() => navegar(-1)}
+            hitSlop={12}
+            style={({ pressed }) => [styles.semanaNavBtn, pressed && { opacity: 0.5 }]}
+          >
             <Text style={styles.semanaNavTexto}>‹</Text>
           </Pressable>
           <Text style={styles.semanaLabel}>{getSemanaLabel(fechaObjetivo)}</Text>
-          <Pressable onPress={() => navegar(1)} hitSlop={12} style={({ pressed }) => [styles.semanaNavBtn, pressed && { opacity: 0.5 }]}>
+          <Pressable
+            onPress={() => navegar(1)}
+            hitSlop={12}
+            style={({ pressed }) => [styles.semanaNavBtn, pressed && { opacity: 0.5 }]}
+          >
             <Text style={styles.semanaNavTexto}>›</Text>
           </Pressable>
         </View>
@@ -593,7 +617,9 @@ export default function LimpiezaCaseroTab() {
               <Ionicons name="calendar-outline" size={40} color={theme.colors.success} />
             </View>
             <Text style={styles.emptyTitulo}>Sin turnos esta semana</Text>
-            <Text style={styles.emptySubtitulo}>Genera los turnos para asignar las tareas de limpieza de esta semana.</Text>
+            <Text style={styles.emptySubtitulo}>
+              Genera los turnos para repartir tareas por habitación responsable y mantener el histórico del espacio.
+            </Text>
             <CustomButton
               label={generando ? 'Generando...' : 'Generar turnos'}
               variant="primary"
@@ -611,37 +637,44 @@ export default function LimpiezaCaseroTab() {
             <Text style={styles.emptySubtitulo}>No hay turnos de limpieza con el filtro seleccionado.</Text>
           </View>
         ) : (
-          Object.values(turnosFiltradosPorUsuario).map((grupo) => (
-            <View key={grupo.usuario.id} style={styles.userCard}>
-              {/* Avatar + nombre */}
+          Object.values(turnosAgrupados).map((grupo) => (
+            <View key={grupo.habitacion.id} style={styles.userCard}>
               <View style={styles.userCardHeader}>
-                <AvatarInitials nombre={grupo.usuario.nombre} apellidos={grupo.usuario.apellidos} theme={theme} />
+                <AvatarInitials
+                  nombre={grupo.habitacion.inquilino?.nombre ?? grupo.habitacion.nombre}
+                  apellidos={grupo.habitacion.inquilino?.apellidos ?? null}
+                  theme={theme}
+                />
                 <View style={{ flex: 1 }}>
-                  <Text style={styles.userNombre}>
-                    {grupo.usuario.nombre}{grupo.usuario.apellidos ? ` ${grupo.usuario.apellidos}` : ''}
-                  </Text>
-                  <Text style={styles.userSubtitle}>
-                    {grupo.items.length} {grupo.items.length === 1 ? 'tarea' : 'tareas'}
-                  </Text>
+                  <Text style={styles.userNombre}>{grupo.habitacion.nombre}</Text>
+                  <Text style={styles.userSubtitle}>{getResponsableLabel(grupo.habitacion.inquilino)}</Text>
                 </View>
               </View>
 
-              {/* Turnos */}
-              {grupo.items.map((t) => (
-                <View key={t.id} style={styles.turnoRow}>
+              {grupo.items.map((turno) => (
+                <View key={turno.id} style={styles.turnoRow}>
                   <View style={styles.turnoIconWrapper}>
-                    <Ionicons name={zonaIcon(t.zona.nombre)} size={15} color={theme.colors.primary} />
+                    <Ionicons name={zonaIcon(turno.zona.nombre)} size={15} color={theme.colors.primary} />
                   </View>
-                  <Text style={styles.turnoZona}>{t.zona.nombre}</Text>
-                  <View style={[
-                    styles.turnoEstadoBadge,
-                    t.estado === 'HECHO' ? styles.turnoEstadoBadgeHecho : styles.turnoEstadoBadgePendiente,
-                  ]}>
-                    <Text style={[
-                      styles.turnoEstadoTexto,
-                      t.estado === 'HECHO' ? styles.turnoEstadoTextoHecho : styles.turnoEstadoTextoPendiente,
-                    ]}>
-                      {t.estado === 'HECHO' ? 'Hecho' : 'Pendiente'}
+                  <View style={{ flex: 1 }}>
+                    <Text style={styles.turnoZona}>{turno.zona.nombre}</Text>
+                    <Text style={[styles.userSubtitle, { marginTop: 2 }]}>
+                      {getTipoEspacioLabel(turno.tipo_espacio)}
+                    </Text>
+                  </View>
+                  <View
+                    style={[
+                      styles.turnoEstadoBadge,
+                      turno.estado === 'HECHO' ? styles.turnoEstadoBadgeHecho : styles.turnoEstadoBadgePendiente,
+                    ]}
+                  >
+                    <Text
+                      style={[
+                        styles.turnoEstadoTexto,
+                        turno.estado === 'HECHO' ? styles.turnoEstadoTextoHecho : styles.turnoEstadoTextoPendiente,
+                      ]}
+                    >
+                      {turno.estado === 'HECHO' ? 'Hecho' : 'Pendiente'}
                     </Text>
                   </View>
                 </View>
@@ -653,27 +686,20 @@ export default function LimpiezaCaseroTab() {
     );
   };
 
-  // ── Render principal ──────────────────────────────────────────────────────
-
   return (
     <View style={styles.container}>
-      {/* Segmented Control */}
       <View style={styles.segmentedControl}>
         <Pressable
           style={[styles.segTab, vistaActual === 'CALENDARIO' && styles.segTabActivo]}
           onPress={() => setVistaActual('CALENDARIO')}
         >
-          <Text style={[styles.segTabTexto, vistaActual === 'CALENDARIO' && styles.segTabTextoActivo]}>
-            Calendario
-          </Text>
+          <Text style={[styles.segTabTexto, vistaActual === 'CALENDARIO' && styles.segTabTextoActivo]}>Calendario</Text>
         </Pressable>
         <Pressable
           style={[styles.segTab, vistaActual === 'CONFIG' && styles.segTabActivo]}
           onPress={() => setVistaActual('CONFIG')}
         >
-          <Text style={[styles.segTabTexto, vistaActual === 'CONFIG' && styles.segTabTextoActivo]}>
-            Configuración
-          </Text>
+          <Text style={[styles.segTabTexto, vistaActual === 'CONFIG' && styles.segTabTextoActivo]}>Configuración</Text>
         </Pressable>
       </View>
 
@@ -697,10 +723,7 @@ export default function LimpiezaCaseroTab() {
               ListEmptyComponent={emptyComponent}
             />
           )}
-          <Pressable
-            style={({ pressed }) => [styles.fab, pressed && styles.fabPressed]}
-            onPress={() => setModalZonaVisible(true)}
-          >
+          <Pressable style={({ pressed }) => [styles.fab, pressed && styles.fabPressed]} onPress={() => setModalZonaVisible(true)}>
             <Text style={styles.fabTexto}>+</Text>
           </Pressable>
         </>
@@ -708,16 +731,11 @@ export default function LimpiezaCaseroTab() {
         renderCalendario()
       )}
 
-      {/* Modal nueva zona */}
       <Modal visible={modalZonaVisible} animationType="slide" transparent onRequestClose={cerrarModalZona}>
-        <KeyboardAvoidingView
-          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-          style={styles.modalOverlay}
-        >
+        <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={styles.modalOverlay}>
           <View style={styles.modalContainer}>
-            <Text style={styles.modalTitulo}>Nueva zona</Text>
+            <Text style={styles.modalTitulo}>Nuevo espacio</Text>
 
-            {/* Quick Chips */}
             <View style={styles.chipRow}>
               {QUICK_CHIPS.map((chip) => (
                 <Pressable
@@ -731,14 +749,56 @@ export default function LimpiezaCaseroTab() {
             </View>
 
             <CustomInput
-              label="Nombre de la zona"
-              placeholder="ej. Cocina, Baño 1, Pasillo..."
+              label="Nombre del espacio"
+              placeholder="ej. Cocina, Baño 1 o Despensa"
               value={nombre}
               onChangeText={setNombre}
               maxLength={80}
             />
 
-            {/* T-Shirt Sizing */}
+            <Text style={styles.tshirtLabel}>Vincular a una habitación existente (opcional)</Text>
+            <ScrollView style={{ maxHeight: 160, marginBottom: theme.spacing.md }}>
+              <Pressable
+                style={({ pressed }) => [
+                  styles.inquilinoRow,
+                  habitacionObjetivoId === null && styles.inquilinoRowActual,
+                  pressed && styles.botonPressed,
+                ]}
+                onPress={() => setHabitacionObjetivoId(null)}
+              >
+                <Text style={[styles.inquilinoNombre, habitacionObjetivoId === null && styles.inquilinoNombreActual]}>
+                  Espacio personalizado
+                </Text>
+              </Pressable>
+              {habitaciones.map((habitacion) => {
+                const seleccionado = habitacionObjetivoId === habitacion.id;
+                return (
+                  <Pressable
+                    key={habitacion.id}
+                    style={({ pressed }) => [
+                      styles.inquilinoRow,
+                      seleccionado && styles.inquilinoRowActual,
+                      pressed && styles.botonPressed,
+                    ]}
+                    onPress={() => {
+                      setHabitacionObjetivoId(habitacion.id);
+                      setNombre(habitacion.nombre);
+                    }}
+                  >
+                    <View style={{ flex: 1 }}>
+                      <Text style={[styles.inquilinoNombre, seleccionado && styles.inquilinoNombreActual]}>
+                        {habitacion.nombre}
+                      </Text>
+                      <Text style={{ color: theme.colors.textTertiary, fontSize: theme.typography.caption }}>
+                        {habitacion.es_habitable ? 'Habitación' : 'Zona común'}
+                      </Text>
+                    </View>
+                    {seleccionado && <Text style={styles.checkmark}>✓</Text>}
+                  </Pressable>
+                );
+              })}
+            </ScrollView>
+
             <Text style={styles.tshirtLabel}>Esfuerzo</Text>
             <View style={styles.tshirtRow}>
               {TALLAS.map((talla) => (
@@ -748,10 +808,7 @@ export default function LimpiezaCaseroTab() {
                   onPress={() => setPesoSeleccionado(talla.peso)}
                 >
                   <Text
-                    style={[
-                      styles.tshirtBtnTexto,
-                      pesoSeleccionado === talla.peso && styles.tshirtBtnTextoActivo,
-                    ]}
+                    style={[styles.tshirtBtnTexto, pesoSeleccionado === talla.peso && styles.tshirtBtnTextoActivo]}
                   >
                     {talla.label}
                   </Text>
@@ -760,10 +817,7 @@ export default function LimpiezaCaseroTab() {
             </View>
 
             <View style={styles.modalAcciones}>
-              <Pressable
-                style={({ pressed }) => [styles.botonCancelar, pressed && styles.botonPressed]}
-                onPress={cerrarModalZona}
-              >
+              <Pressable style={({ pressed }) => [styles.botonCancelar, pressed && styles.botonPressed]} onPress={cerrarModalZona}>
                 <Text style={styles.botonCancelarTexto}>Cancelar</Text>
               </Pressable>
               <Pressable
@@ -775,51 +829,51 @@ export default function LimpiezaCaseroTab() {
                 onPress={handleGuardar}
                 disabled={!puedeGuardar || guardando}
               >
-                {guardando ? (
-                  <ActivityIndicator color={theme.colors.surface} />
-                ) : (
-                  <Text style={styles.botonGuardarTexto}>Guardar</Text>
-                )}
+                {guardando ? <ActivityIndicator color={theme.colors.surface} /> : <Text style={styles.botonGuardarTexto}>Guardar</Text>}
               </Pressable>
             </View>
           </View>
         </KeyboardAvoidingView>
       </Modal>
 
-      {/* Modal asignación fija — multi-select */}
-      <Modal
-        visible={zonaSeleccionada !== null}
-        animationType="slide"
-        transparent
-        onRequestClose={cerrarModalAsignacion}
-      >
+      <Modal visible={zonaSeleccionada !== null} animationType="slide" transparent onRequestClose={cerrarModalAsignacion}>
         <View style={styles.modalOverlay}>
           <View style={styles.modalContainer}>
-            <Text style={styles.modalTitulo}>Asignar fijos</Text>
-            {zonaSeleccionada && (
-              <Text style={styles.modalSubtitulo}>{zonaSeleccionada.nombre}</Text>
-            )}
-            {inquilinos.length === 0 ? (
-              <Text style={{ textAlign: 'center', color: theme.colors.textTertiary, fontSize: theme.typography.body, paddingVertical: theme.spacing.md }}>
-                No hay inquilinos en esta vivienda.
+            <Text style={styles.modalTitulo}>Asignar responsables fijas</Text>
+            {zonaSeleccionada && <Text style={styles.modalSubtitulo}>{zonaSeleccionada.nombre}</Text>}
+            {habitacionesResponsables.length === 0 ? (
+              <Text
+                style={{
+                  textAlign: 'center',
+                  color: theme.colors.textTertiary,
+                  fontSize: theme.typography.body,
+                  paddingVertical: theme.spacing.md,
+                }}
+              >
+                No hay habitaciones habitables disponibles.
               </Text>
             ) : (
-              inquilinos.map((inq) => {
-                const seleccionado = seleccionados.includes(inq.id);
+              habitacionesResponsables.map((habitacion) => {
+                const seleccionado = seleccionados.includes(habitacion.id);
                 return (
                   <Pressable
-                    key={inq.id}
+                    key={habitacion.id}
                     style={({ pressed }) => [
                       styles.inquilinoRow,
                       seleccionado && styles.inquilinoRowActual,
                       pressed && styles.botonPressed,
                     ]}
-                    onPress={() => toggleSeleccion(inq.id)}
+                    onPress={() => toggleSeleccion(habitacion.id)}
                     disabled={asignando}
                   >
-                    <Text style={[styles.inquilinoNombre, seleccionado && styles.inquilinoNombreActual]}>
-                      {inq.nombre} {inq.apellidos ?? ''}
-                    </Text>
+                    <View style={{ flex: 1 }}>
+                      <Text style={[styles.inquilinoNombre, seleccionado && styles.inquilinoNombreActual]}>
+                        {habitacion.nombre}
+                      </Text>
+                      <Text style={{ color: theme.colors.textTertiary, fontSize: theme.typography.caption }}>
+                        {getResponsableLabel(habitacion.inquilino)}
+                      </Text>
+                    </View>
                     {seleccionado && <Text style={styles.checkmark}>✓</Text>}
                   </Pressable>
                 );
@@ -838,11 +892,7 @@ export default function LimpiezaCaseroTab() {
                 onPress={handleGuardarAsignacion}
                 disabled={asignando}
               >
-                {asignando ? (
-                  <ActivityIndicator color={theme.colors.surface} />
-                ) : (
-                  <Text style={styles.botonGuardarTexto}>Guardar</Text>
-                )}
+                {asignando ? <ActivityIndicator color={theme.colors.surface} /> : <Text style={styles.botonGuardarTexto}>Guardar</Text>}
               </Pressable>
             </View>
           </View>

--- a/frontend/app/inquilino/(tabs)/limpieza.tsx
+++ b/frontend/app/inquilino/(tabs)/limpieza.tsx
@@ -1,10 +1,4 @@
-import {
-  View,
-  Text,
-  ScrollView,
-  Pressable,
-  ActivityIndicator,
-} from 'react-native';
+import { View, Text, ScrollView, Pressable, ActivityIndicator } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import Toast from 'react-native-toast-message';
 import type { AppTheme } from '@/constants/theme';
@@ -14,20 +8,20 @@ import { useFocusEffect } from 'expo-router';
 import api from '@/services/api';
 import { createStyles } from '@/styles/inquilino/limpieza.styles';
 
-// ── Helpers UI ────────────────────────────────────────────────────────────────
-
 const ETIQUETA_ESFUERZO: Record<number, string> = { 3: 'Ligera', 6: 'Normal', 10: 'Intensa' };
-const etiquetaEsfuerzo = (peso: number) =>
-  ETIQUETA_ESFUERZO[peso] ?? `Peso ${peso}`;
+const etiquetaEsfuerzo = (peso: number) => ETIQUETA_ESFUERZO[peso] ?? `Peso ${peso}`;
 
 const ZONA_ICONS: Record<string, string> = {
   cocina: 'restaurant-outline',
-  'baño': 'water-outline', 'baño 1': 'water-outline', 'baño 2': 'water-outline',
-  'salón': 'tv-outline', salon: 'tv-outline',
+  baño: 'water-outline',
+  'baño 1': 'water-outline',
+  'baño 2': 'water-outline',
+  salón: 'tv-outline',
+  salon: 'tv-outline',
   pasillo: 'footsteps-outline',
 };
-const zonaIcon = (nombre: string) =>
-  (ZONA_ICONS[nombre.toLowerCase()] ?? 'sparkles-outline') as any;
+
+const zonaIcon = (nombre: string) => (ZONA_ICONS[nombre.toLowerCase()] ?? 'sparkles-outline') as any;
 
 const AvatarInitials = ({
   nombre,
@@ -42,38 +36,55 @@ const AvatarInitials = ({
 }) => {
   const initials = `${nombre[0] ?? ''}${apellidos?.[0] ?? ''}`.toUpperCase();
   return (
-    <View style={{
-      width: size, height: size, borderRadius: size / 2,
-      backgroundColor: theme.colors.primaryLight,
-      alignItems: 'center', justifyContent: 'center', flexShrink: 0,
-    }}>
-      <Text style={{ fontSize: size * 0.33, fontWeight: '700', color: theme.colors.primary }}>
-        {initials}
-      </Text>
+    <View
+      style={{
+        width: size,
+        height: size,
+        borderRadius: size / 2,
+        backgroundColor: theme.colors.primaryLight,
+        alignItems: 'center',
+        justifyContent: 'center',
+        flexShrink: 0,
+      }}
+    >
+      <Text style={{ fontSize: size * 0.33, fontWeight: '700', color: theme.colors.primary }}>{initials}</Text>
     </View>
   );
 };
 
-// ─────────────────────────────────────────────────────────────────────────────
+type Habitacion = {
+  id: number;
+  nombre: string;
+  tipo: 'DORMITORIO' | 'BANO' | 'COCINA' | 'SALON' | 'OTRO';
+  es_habitable: boolean;
+  inquilino: { id: number; nombre: string; apellidos: string | null } | null;
+};
 
 type Turno = {
   id: number;
-  usuario_id: number;
+  usuario_id: number | null;
+  habitacion_id: number;
   zona_id: number;
   fecha_inicio: string;
   fecha_fin: string;
   estado: 'PENDIENTE' | 'HECHO' | 'NO_HECHO';
-  zona: { id: number; nombre: string; peso: number };
-  usuario: { id: number; nombre: string; apellidos: string | null };
+  tipo_espacio: 'HABITACION' | 'ZONA_COMUN' | 'ESPACIO';
+  zona: { id: number; nombre: string; peso: number; habitacion: Habitacion | null };
+  habitacion: Habitacion;
+  responsable_actual: { id: number; nombre: string; apellidos: string | null } | null;
 };
 
-// ─────────────────────────────────────────────────────────────────────────────
+const getTipoEspacioLabel = (tipo: Turno['tipo_espacio']) => {
+  if (tipo === 'HABITACION') return 'Habitación';
+  if (tipo === 'ZONA_COMUN') return 'Zona común';
+  return 'Espacio';
+};
 
 export default function LimpiezaInquilinoTab() {
   const { theme } = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const [viviendaId, setViviendaId] = useState<number | null>(null);
-  const [miUsuarioId, setMiUsuarioId] = useState<number | null>(null);
+  const [miHabitacionId, setMiHabitacionId] = useState<number | null>(null);
   const [turnos, setTurnos] = useState<Turno[]>([]);
   const [loading, setLoading] = useState(true);
   const [marcando, setMarcando] = useState<number | null>(null);
@@ -87,17 +98,13 @@ export default function LimpiezaInquilinoTab() {
         setLoading(true);
         setModuloDesactivado(false);
         try {
-          const { data: viviendaData } = await api.get<{ miHabitacionId: number; vivienda: any }>(
-            '/inquilino/vivienda'
-          );
-          const miHab = viviendaData.vivienda.habitaciones.find(
-            (h: any) => h.id === viviendaData.miHabitacionId
+          const { data: viviendaData } = await api.get<{ miHabitacionId: number; vivienda: { id: number } }>(
+            '/inquilino/vivienda',
           );
           const vId = viviendaData.vivienda.id;
-          const uId = miHab?.inquilino?.id ?? 0;
           if (!activo) return;
           setViviendaId(vId);
-          setMiUsuarioId(uId);
+          setMiHabitacionId(viviendaData.miHabitacionId);
 
           const { data: turnosData } = await api.get<Turno[]>(`/viviendas/${vId}/limpieza/turnos`);
           if (activo) {
@@ -111,7 +118,7 @@ export default function LimpiezaInquilinoTab() {
             setModuloDesactivado(true);
           } else if (activo) {
             setViviendaId(null);
-            setMiUsuarioId(null);
+            setMiHabitacionId(null);
             setTurnos([]);
             setModuloDesactivado(false);
           }
@@ -121,18 +128,18 @@ export default function LimpiezaInquilinoTab() {
       };
 
       cargarDatos();
-      return () => { activo = false; };
-    }, [])
+      return () => {
+        activo = false;
+      };
+    }, []),
   );
 
   const handleMarcarHecho = async (turnoId: number) => {
     if (!viviendaId) return;
     setMarcando(turnoId);
     try {
-      const { data } = await api.patch<Turno>(
-        `/viviendas/${viviendaId}/limpieza/turnos/${turnoId}/hecho`
-      );
-      setTurnos((prev) => prev.map((t) => (t.id === turnoId ? data : t)));
+      const { data } = await api.patch<Turno>(`/viviendas/${viviendaId}/limpieza/turnos/${turnoId}/hecho`);
+      setTurnos((prev) => prev.map((turno) => (turno.id === turnoId ? data : turno)));
     } catch (err: any) {
       Toast.show({
         type: 'error',
@@ -154,8 +161,6 @@ export default function LimpiezaInquilinoTab() {
     return `${fmt(lunes)} — ${fmt(domingo)}`;
   };
 
-  // ── Loading / sin vivienda ────────────────────────────────────────────────
-
   if (loading) {
     return <ActivityIndicator style={styles.loading} size="large" color={theme.colors.primary} />;
   }
@@ -169,15 +174,14 @@ export default function LimpiezaInquilinoTab() {
           </View>
           <Text style={styles.emptyTitle}>Limpieza desactivada</Text>
           <Text style={styles.emptyText}>
-            El casero ha desactivado este modulo para la vivienda. Cuando vuelva a estar activo,
-            veras aqui tus turnos.
+            El casero ha desactivado este módulo para la vivienda. Cuando vuelva a estar activo, verás aquí tus tareas.
           </Text>
         </View>
       </View>
     );
   }
 
-  if (!viviendaId) {
+  if (!viviendaId || !miHabitacionId) {
     return (
       <View style={styles.container}>
         <View style={styles.emptyContainer}>
@@ -187,58 +191,52 @@ export default function LimpiezaInquilinoTab() {
     );
   }
 
-  const misTurnos = turnos.filter((t) => t.usuario_id === miUsuarioId);
-  const turnosResto = turnos.filter((t) => t.usuario_id !== miUsuarioId);
-
-  // ── Render ────────────────────────────────────────────────────────────────
+  const misTurnos = turnos.filter((turno) => turno.habitacion_id === miHabitacionId);
+  const turnosRelacionados = turnos.filter((turno) => turno.habitacion_id !== miHabitacionId);
 
   return (
     <View style={styles.container}>
       <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
-
-        {/* ── Cabecera ── */}
         <View style={styles.header}>
           <Text style={styles.headerSemana}>{getSemanaLabel()}</Text>
           <Text style={styles.headerTitulo}>Mis Tareas</Text>
-          <Text style={styles.headerSubtitulo}>Mantén el orden para una mejor convivencia.</Text>
+          <Text style={styles.headerSubtitulo}>Las tareas se organizan por habitación y zonas comunes de la vivienda.</Text>
         </View>
 
-        {/* ── Mis turnos ── */}
         {misTurnos.length === 0 ? (
           <View style={styles.miTareaVacia}>
-            <Text style={styles.miTareaVaciaTexto}>No tienes tareas asignadas esta semana.</Text>
+            <Text style={styles.miTareaVaciaTexto}>Tu habitación no tiene tareas asignadas esta semana.</Text>
           </View>
         ) : (
-          misTurnos.map((t) => {
-            const esPendiente = t.estado === 'PENDIENTE';
-            const esHecho = t.estado === 'HECHO';
+          misTurnos.map((turno) => {
+            const esPendiente = turno.estado === 'PENDIENTE';
+            const esHecho = turno.estado === 'HECHO';
             return (
-              <View key={t.id} style={[styles.miTareaCard, esHecho && styles.miTareaCardHecha]}>
-                {/* Zona + icono */}
+              <View key={turno.id} style={[styles.miTareaCard, esHecho && styles.miTareaCardHecha]}>
                 <View style={styles.miTareaTop}>
                   <View style={styles.miTareaTexto}>
-                    <Text style={styles.miTareaZona}>{t.zona.nombre}</Text>
-                    <Text style={styles.miTareaEsfuerzo}>
-                      ESFUERZO: {etiquetaEsfuerzo(t.zona.peso).toUpperCase()}
+                    <Text style={styles.miTareaZona}>{turno.zona.nombre}</Text>
+                    <Text style={styles.miTareaEsfuerzo}>ESFUERZO: {etiquetaEsfuerzo(turno.zona.peso).toUpperCase()}</Text>
+                    <Text style={[styles.companeroAsignado, { marginTop: theme.spacing.xs }]}>
+                      {getTipoEspacioLabel(turno.tipo_espacio).toUpperCase()}
                     </Text>
                   </View>
                   <View style={[styles.miTareaIconBox, esHecho && styles.miTareaIconBoxHecha]}>
                     <Ionicons
-                      name={zonaIcon(t.zona.nombre)}
+                      name={zonaIcon(turno.zona.nombre)}
                       size={22}
                       color={esHecho ? theme.colors.successText : theme.colors.primary}
                     />
                   </View>
                 </View>
 
-                {/* Botón o badge hecho */}
                 {esPendiente ? (
                   <Pressable
                     style={({ pressed }) => [styles.botonHecho, pressed && styles.botonHechoPressed]}
-                    onPress={() => handleMarcarHecho(t.id)}
-                    disabled={marcando === t.id}
+                    onPress={() => handleMarcarHecho(turno.id)}
+                    disabled={marcando === turno.id}
                   >
-                    {marcando === t.id ? (
+                    {marcando === turno.id ? (
                       <ActivityIndicator color={theme.colors.surface} size="small" />
                     ) : (
                       <>
@@ -258,34 +256,38 @@ export default function LimpiezaInquilinoTab() {
           })
         )}
 
-        {/* ── Turnos de la casa ── */}
-        {turnosResto.length > 0 && (
+        {turnosRelacionados.length > 0 && (
           <>
-            <Text style={styles.seccionTitulo}>Turnos de la casa</Text>
-            {turnosResto.map((t) => {
-              const esPendiente = t.estado === 'PENDIENTE';
+            <Text style={styles.seccionTitulo}>Tareas relacionadas</Text>
+            {turnosRelacionados.map((turno) => {
+              const esPendiente = turno.estado === 'PENDIENTE';
+              const nombreResponsable =
+                turno.responsable_actual?.nombre ?? turno.habitacion.nombre;
+              const apellidosResponsable = turno.responsable_actual?.apellidos ?? null;
               return (
-                <View key={t.id} style={styles.companeroRow}>
-                  <AvatarInitials nombre={t.usuario.nombre} apellidos={t.usuario.apellidos} theme={theme} />
+                <View key={turno.id} style={styles.companeroRow}>
+                  <AvatarInitials nombre={nombreResponsable} apellidos={apellidosResponsable} theme={theme} />
                   <View style={styles.companeroInfo}>
                     <View style={styles.companeroTurnoTop}>
-                      <Text style={styles.companeroZonaNombre}>{t.zona.nombre}</Text>
+                      <Text style={styles.companeroZonaNombre}>{turno.zona.nombre}</Text>
                       <Text style={esPendiente ? styles.companeroEstadoPendiente : styles.companeroEstadoHecho}>
                         {esPendiente ? 'PENDIENTE' : 'HECHO'}
                       </Text>
                     </View>
                     <Text style={styles.companeroAsignado}>
-                      ASIGNADO A {t.usuario.nombre.toUpperCase()}
+                      RESPONSABLE: {nombreResponsable.toUpperCase()}
+                    </Text>
+                    <Text style={[styles.companeroAsignado, { marginTop: 2 }]}>
+                      {getTipoEspacioLabel(turno.tipo_espacio).toUpperCase()}
                     </Text>
                   </View>
-                  <Ionicons name={zonaIcon(t.zona.nombre)} size={18} color={theme.colors.textTertiary} />
+                  <Ionicons name={zonaIcon(turno.zona.nombre)} size={18} color={theme.colors.textTertiary} />
                 </View>
               );
             })}
           </>
         )}
 
-        {/* Sin ningún turno */}
         {turnos.length === 0 && (
           <View style={styles.emptyContainer}>
             <View style={styles.emptyIconBoxLarge}>
@@ -297,7 +299,6 @@ export default function LimpiezaInquilinoTab() {
             </Text>
           </View>
         )}
-
       </ScrollView>
     </View>
   );


### PR DESCRIPTION
## Objetivo
Refactoriza el módulo de limpieza para que la planificación viva sobre habitaciones y espacios de la vivienda, manteniendo el histórico y derivando el responsable actual desde la habitación ocupada cuando aplique.

## Cambios principales
* El backend pasa a modelar zonas, asignaciones y turnos de limpieza con habitaciones responsables.
* El algoritmo de generación reparte turnos por habitaciones habitables activas y conserva el balance por ocupante.
* Los endpoints de limpieza devuelven espacio objetivo, habitación responsable y responsable actual derivado.
* Las pantallas de casero e inquilino se actualizan para trabajar por habitaciones, zonas comunes y espacios personalizados.
* Se ajustan tests de servicio, exportación y contrato operativo al nuevo modelo.

## UI / UX (Solo si aplica)
* Se mantienen los patrones visuales existentes, pero los textos pasan a hablar de habitaciones, zonas comunes y espacios para aclarar el contexto de cada limpieza.

## Changelog
* `docs/changelog/Epica17/epica-17-issue-283-limpieza-por-habitaciones.md`