### PR TITLE
[Épica 17] Añadir términos de uso y política de privacidad

### DIFF
--- a/docs/changelog/Epica17/issue-276-terminos-privacidad.md
+++ b/docs/changelog/Epica17/issue-276-terminos-privacidad.md
@@ -1,0 +1,16 @@
+# Issue 276 - terminos de uso y politica de privacidad
+
+## Cambios principales
+
+- Se anaden documentos legales versionados en `frontend/constants/legal.ts` para terminos de uso y politica de privacidad.
+- Se crean pantallas de lectura dedicadas en `frontend/app/legal/terminos.tsx` y `frontend/app/legal/privacidad.tsx`, con una vista compartida preparada para futuras revisiones.
+- Se incorpora `LegalNotice` como bloque reutilizable para mostrar enlaces legales y, cuando aplica, aceptacion explicita mediante checkbox accesible.
+- El flujo de registro manual exige aceptar la documentacion legal antes de completar el alta.
+- El flujo de alta de usuarios nuevos que vienen de Google exige la misma aceptacion en `frontend/app/rol.tsx`.
+- Login y perfil muestran accesos claros para consultar ambos documentos desde la app.
+
+## Verificacion prevista
+
+- Mantener enlaces visibles en login, registro, alta inicial y perfil.
+- Mantener version y fecha visibles en los documentos.
+- Dejar el texto preparado para revisiones legales posteriores sin acoplarlo al backend actual.

--- a/frontend/app/index.tsx
+++ b/frontend/app/index.tsx
@@ -1,4 +1,4 @@
-import { View, Text, Pressable } from 'react-native';
+import { View, Text, Pressable, ScrollView } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { useMemo, useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'expo-router';
@@ -11,6 +11,7 @@ import { guardarToken } from '@/services/auth.service';
 import api from '@/services/api';
 import { CustomButton } from '@/components/common/CustomButton';
 import { CustomInput } from '@/components/common/CustomInput';
+import { LegalNotice } from '@/components/common/LegalNotice';
 import { useAppTheme } from '@/contexts/ThemeContext';
 import { syncPushToken } from '@/utils/notifications';
 import { getDashboardRoute } from '@/utils/authRoutes';
@@ -93,7 +94,11 @@ export default function LoginScreen() {
   };
 
   return (
-    <View style={styles.container}>
+    <ScrollView
+      style={styles.scrollContainer}
+      contentContainerStyle={styles.container}
+      keyboardShouldPersistTaps="handled"
+    >
       <Text style={styles.logo}>Roomies</Text>
       <Text style={styles.subtitulo}>Gestión de pisos compartidos</Text>
 
@@ -142,6 +147,11 @@ export default function LoginScreen() {
         <Text style={styles.botonGoogleTexto}>Continuar con Google</Text>
       </Pressable>
 
+      <LegalNotice
+        variant="inline"
+        body="Antes de registrarte o continuar usando Roomies puedes revisar la informacion legal de la app."
+      />
+
       <Pressable
         style={({ pressed }) => [styles.enlaceRegistro, pressed && styles.pressed]}
         onPress={() => router.push('/registro')}
@@ -150,6 +160,6 @@ export default function LoginScreen() {
       >
         <Text style={styles.enlaceRegistroTexto}>¿No tienes cuenta? Regístrate</Text>
       </Pressable>
-    </View>
+    </ScrollView>
   );
 }

--- a/frontend/app/legal/privacidad.tsx
+++ b/frontend/app/legal/privacidad.tsx
@@ -1,0 +1,5 @@
+import { LegalDocumentScreen } from '@/components/common/LegalDocumentScreen';
+
+export default function PrivacidadScreen() {
+  return <LegalDocumentScreen documentKey="privacidad" />;
+}

--- a/frontend/app/legal/terminos.tsx
+++ b/frontend/app/legal/terminos.tsx
@@ -1,0 +1,5 @@
+import { LegalDocumentScreen } from '@/components/common/LegalDocumentScreen';
+
+export default function TerminosScreen() {
+  return <LegalDocumentScreen documentKey="terminos" />;
+}

--- a/frontend/app/perfil.tsx
+++ b/frontend/app/perfil.tsx
@@ -2,6 +2,7 @@ import { View, Text, ScrollView, Pressable } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import Toast from 'react-native-toast-message';
 import { LoadingScreen } from '@/components/common/LoadingScreen';
+import { LegalNotice } from '@/components/common/LegalNotice';
 import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'expo-router';
 import api from '@/services/api';
@@ -152,6 +153,11 @@ export default function PerfilScreen() {
             <Text style={styles.helpButtonText}>Ver guia</Text>
           </Pressable>
         </View>
+
+        <LegalNotice
+          title="Documentacion legal"
+          body="Puedes volver a consultar en cualquier momento los terminos de uso y la politica de privacidad publicados para esta version de Roomies."
+        />
 
         <Pressable
           style={({ pressed }) => [styles.botonLogout, pressed && styles.pressed]}

--- a/frontend/app/registro.tsx
+++ b/frontend/app/registro.tsx
@@ -10,6 +10,7 @@ import { guardarToken } from '@/services/auth.service';
 import api from '@/services/api';
 import { CustomButton } from '@/components/common/CustomButton';
 import { CustomInput } from '@/components/common/CustomInput';
+import { LegalNotice } from '@/components/common/LegalNotice';
 import { useAppTheme } from '@/contexts/ThemeContext';
 import { dniNieSchema, pasaporteSchema, passwordSchema } from '@/utils/schemas';
 import { syncPushToken } from '@/utils/notifications';
@@ -35,6 +36,7 @@ export default function RegistroScreen() {
   const [loading, setLoading] = useState(false);
   const [errorDoc, setErrorDoc] = useState('');
   const [errorPassword, setErrorPassword] = useState('');
+  const [acceptedLegal, setAcceptedLegal] = useState(false);
 
   const [, googleResponse, googlePromptAsync] = Google.useAuthRequest({
     clientId: process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID,
@@ -86,6 +88,14 @@ export default function RegistroScreen() {
     }
     if (!rol) {
       Toast.show({ type: 'error', text1: 'Selecciona un rol', text2: 'Elige si eres Casero o Inquilino.' });
+      return;
+    }
+    if (!acceptedLegal) {
+      Toast.show({
+        type: 'error',
+        text1: 'Acepta las condiciones legales',
+        text2: 'Necesitas aceptar los terminos y la politica de privacidad para crear la cuenta.',
+      });
       return;
     }
 
@@ -240,6 +250,14 @@ export default function RegistroScreen() {
         onPress={handleRegistrar}
         loading={loading}
         style={{ marginTop: 8 }}
+      />
+
+      <LegalNotice
+        title="Condiciones legales"
+        body="Para completar el alta debes revisar la documentacion legal basica de Roomies."
+        accepted={acceptedLegal}
+        onToggleAccepted={() => setAcceptedLegal((current) => !current)}
+        acceptanceLabel="He leido y acepto los Terminos de uso y la Politica de privacidad vigentes."
       />
 
       <View style={styles.separador}>

--- a/frontend/app/rol.tsx
+++ b/frontend/app/rol.tsx
@@ -1,8 +1,9 @@
-import { View, Text, Pressable, ActivityIndicator } from 'react-native';
+import { View, Text, Pressable, ActivityIndicator, ScrollView } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { useMemo, useState } from 'react';
 import { useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
+import { LegalNotice } from '@/components/common/LegalNotice';
 import { createStyles } from '@/styles/rol.styles';
 import { guardarToken } from '@/services/auth.service';
 import api from '@/services/api';
@@ -18,9 +19,18 @@ export default function SeleccionRolScreen() {
   const styles = useMemo(() => createStyles(theme), [theme]);
   const [rolSeleccionado, setRolSeleccionado] = useState<Rol | null>(null);
   const [loading, setLoading] = useState(false);
+  const [acceptedLegal, setAcceptedLegal] = useState(false);
 
   const confirmar = async () => {
     if (!rolSeleccionado) return;
+    if (!acceptedLegal) {
+      Toast.show({
+        type: 'error',
+        text1: 'Acepta las condiciones legales',
+        text2: 'Necesitas aceptar los terminos y la politica de privacidad antes de continuar.',
+      });
+      return;
+    }
     setLoading(true);
     try {
       const { data } = await api.patch<{ token: string; usuario: { rol: string } }>('/auth/rol', {
@@ -37,7 +47,11 @@ export default function SeleccionRolScreen() {
   };
 
   return (
-    <View style={styles.container}>
+    <ScrollView
+      style={styles.scrollContainer}
+      contentContainerStyle={styles.container}
+      keyboardShouldPersistTaps="handled"
+    >
       <Text style={styles.titulo}>¿Cómo usarás Roomies?</Text>
       <Text style={styles.subtitulo}>
         Elige tu rol para personalizar la experiencia. Podrás cambiarlo más adelante desde tu perfil.
@@ -89,6 +103,14 @@ export default function SeleccionRolScreen() {
           <Text style={styles.botonConfirmarTexto}>Confirmar</Text>
         )}
       </Pressable>
-    </View>
+
+      <LegalNotice
+        title="Aceptacion legal"
+        body="Como parte del alta inicial en Roomies, confirma que conoces la documentacion legal publicada en la app."
+        accepted={acceptedLegal}
+        onToggleAccepted={() => setAcceptedLegal((current) => !current)}
+        acceptanceLabel="He leido y acepto los Terminos de uso y la Politica de privacidad vigentes."
+      />
+    </ScrollView>
   );
 }

--- a/frontend/components/common/LegalDocumentScreen.tsx
+++ b/frontend/components/common/LegalDocumentScreen.tsx
@@ -1,0 +1,62 @@
+import { useMemo } from 'react';
+import { ScrollView, Text, View } from 'react-native';
+import { Stack } from 'expo-router';
+import { getLegalDocument, LegalDocumentKey } from '@/constants/legal';
+import { useAppTheme } from '@/contexts/ThemeContext';
+import { createStyles } from '@/styles/legal/legal-document.styles';
+
+type LegalDocumentScreenProps = {
+  documentKey: LegalDocumentKey;
+};
+
+export function LegalDocumentScreen({ documentKey }: LegalDocumentScreenProps) {
+  const { theme } = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const document = getLegalDocument(documentKey);
+
+  return (
+    <>
+      <Stack.Screen
+        options={{
+          headerShown: true,
+          title: document.title,
+          headerStyle: { backgroundColor: theme.colors.surface },
+          headerTitleStyle: { color: theme.colors.text, fontWeight: '600' },
+          headerTintColor: theme.colors.primary,
+          headerShadowVisible: false,
+        }}
+      />
+      <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+        <View style={styles.heroCard}>
+          <Text style={styles.eyebrow}>Documentacion legal</Text>
+          <Text style={styles.title}>{document.title}</Text>
+          <Text style={styles.summary}>{document.summary}</Text>
+          <View style={styles.metaRow}>
+            <View style={styles.metaPill}>
+              <Text style={styles.metaPillText}>Version {document.version}</Text>
+            </View>
+            <View style={styles.metaPill}>
+              <Text style={styles.metaPillText}>Vigente desde {document.effectiveDate}</Text>
+            </View>
+          </View>
+        </View>
+
+        <View style={styles.noteCard}>
+          <Text style={styles.noteTitle}>Importante</Text>
+          <Text style={styles.noteText}>{document.reviewNote}</Text>
+        </View>
+
+        {document.sections.map((section) => (
+          <View key={section.title} style={styles.sectionCard}>
+            <Text style={styles.sectionTitle}>{section.title}</Text>
+            {section.paragraphs.map((paragraph) => (
+              <Text key={paragraph} style={styles.paragraph}>
+                {paragraph}
+              </Text>
+            ))}
+          </View>
+        ))}
+      </ScrollView>
+    </>
+  );
+}

--- a/frontend/components/common/LegalNotice.styles.ts
+++ b/frontend/components/common/LegalNotice.styles.ts
@@ -1,0 +1,80 @@
+import { StyleSheet } from 'react-native';
+import { AppTheme, DefaultAppTheme } from '@/constants/theme';
+
+export const createStyles = (theme: AppTheme = DefaultAppTheme) => StyleSheet.create({
+  card: {
+    width: '100%',
+    backgroundColor: theme.colors.surface,
+    borderRadius: theme.radius.lg,
+    padding: theme.spacing.base,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    gap: theme.spacing.sm,
+    shadowColor: theme.colors.shadow,
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: theme.isDark ? 0.18 : 0.06,
+    shadowRadius: 8,
+    elevation: 2,
+  },
+  inline: {
+    width: '100%',
+    marginTop: theme.spacing.base,
+    gap: theme.spacing.sm,
+  },
+  title: {
+    color: theme.colors.text,
+    fontSize: theme.typography.body,
+    fontWeight: '700',
+  },
+  body: {
+    color: theme.colors.textSecondary,
+    fontSize: theme.typography.label,
+    lineHeight: 20,
+  },
+  rowWrap: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+  },
+  linkText: {
+    color: theme.colors.primary,
+    fontSize: theme.typography.label,
+    fontWeight: '700',
+  },
+  meta: {
+    color: theme.colors.textTertiary,
+    fontSize: theme.typography.caption,
+    lineHeight: 18,
+  },
+  checkboxRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: theme.spacing.sm,
+  },
+  checkbox: {
+    width: 24,
+    height: 24,
+    borderRadius: theme.radius.md,
+    borderWidth: 2,
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.surface2,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 2,
+  },
+  checkboxChecked: {
+    borderColor: theme.colors.primary,
+    backgroundColor: theme.colors.primary,
+  },
+  checkboxCopy: {
+    flex: 1,
+    color: theme.colors.text,
+    fontSize: theme.typography.label,
+    lineHeight: 20,
+  },
+  pressed: {
+    opacity: 0.75,
+  },
+});
+
+export const styles = createStyles();

--- a/frontend/components/common/LegalNotice.tsx
+++ b/frontend/components/common/LegalNotice.tsx
@@ -1,0 +1,88 @@
+import { Ionicons } from '@expo/vector-icons';
+import { useMemo } from 'react';
+import { Pressable, Text, View } from 'react-native';
+import { Href, useRouter } from 'expo-router';
+import { legalDocuments } from '@/constants/legal';
+import { useAppTheme } from '@/contexts/ThemeContext';
+import { createStyles } from './LegalNotice.styles';
+
+type LegalNoticeProps = {
+  title?: string;
+  body: string;
+  accepted?: boolean;
+  onToggleAccepted?: () => void;
+  acceptanceLabel?: string;
+  variant?: 'card' | 'inline';
+};
+
+function LegalLinks() {
+  const router = useRouter();
+  const { theme } = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const version = legalDocuments.terminos.version;
+  const effectiveDate = legalDocuments.terminos.effectiveDate;
+  const terminosRoute = '/legal/terminos' as Href;
+  const privacidadRoute = '/legal/privacidad' as Href;
+
+  return (
+    <>
+      <View style={styles.rowWrap}>
+        <Text style={styles.body}>Consulta </Text>
+        <Pressable
+          onPress={() => router.push(terminosRoute)}
+          accessibilityRole="link"
+          accessibilityLabel="Abrir terminos de uso"
+          style={({ pressed }) => [pressed && styles.pressed]}
+        >
+          <Text style={styles.linkText}>Terminos de uso</Text>
+        </Pressable>
+        <Text style={styles.body}> y </Text>
+        <Pressable
+          onPress={() => router.push(privacidadRoute)}
+          accessibilityRole="link"
+          accessibilityLabel="Abrir politica de privacidad"
+          style={({ pressed }) => [pressed && styles.pressed]}
+        >
+          <Text style={styles.linkText}>Politica de privacidad</Text>
+        </Pressable>
+        <Text style={styles.body}>.</Text>
+      </View>
+      <Text style={styles.meta}>Version {version} · vigente desde {effectiveDate}</Text>
+    </>
+  );
+}
+
+export function LegalNotice({
+  title,
+  body,
+  accepted,
+  onToggleAccepted,
+  acceptanceLabel,
+  variant = 'card',
+}: LegalNoticeProps) {
+  const { theme } = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const containerStyle = variant === 'inline' ? styles.inline : styles.card;
+
+  return (
+    <View style={containerStyle}>
+      {title ? <Text style={styles.title}>{title}</Text> : null}
+      <Text style={styles.body}>{body}</Text>
+      <LegalLinks />
+      {typeof accepted === 'boolean' && onToggleAccepted && acceptanceLabel ? (
+        <Pressable
+          onPress={onToggleAccepted}
+          accessibilityRole="checkbox"
+          accessibilityState={{ checked: accepted }}
+          accessibilityLabel={acceptanceLabel}
+          style={({ pressed }) => [styles.checkboxRow, pressed && styles.pressed]}
+        >
+          <View style={[styles.checkbox, accepted && styles.checkboxChecked]}>
+            {accepted ? <Ionicons name="checkmark" size={16} color={theme.colors.surface} /> : null}
+          </View>
+          <Text style={styles.checkboxCopy}>{acceptanceLabel}</Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+}

--- a/frontend/constants/legal.ts
+++ b/frontend/constants/legal.ts
@@ -1,0 +1,137 @@
+export type LegalDocumentKey = 'terminos' | 'privacidad';
+
+type LegalSection = {
+  title: string;
+  paragraphs: string[];
+};
+
+type LegalDocument = {
+  key: LegalDocumentKey;
+  title: string;
+  shortTitle: string;
+  summary: string;
+  version: string;
+  effectiveDate: string;
+  reviewNote: string;
+  sections: LegalSection[];
+};
+
+const LEGAL_VERSION = '2026.04';
+const LEGAL_EFFECTIVE_DATE = '22 de abril de 2026';
+const LEGAL_REVIEW_NOTE =
+  'Texto base informativo pendiente de revision legal profesional antes de publicacion definitiva.';
+
+export const legalDocuments: Record<LegalDocumentKey, LegalDocument> = {
+  terminos: {
+    key: 'terminos',
+    title: 'Terminos de uso',
+    shortTitle: 'Terminos',
+    summary:
+      'Condiciones generales para crear cuenta, usar la app y mantener una convivencia respetuosa dentro de Roomies.',
+    version: LEGAL_VERSION,
+    effectiveDate: LEGAL_EFFECTIVE_DATE,
+    reviewNote: LEGAL_REVIEW_NOTE,
+    sections: [
+      {
+        title: '1. Uso del servicio',
+        paragraphs: [
+          'Roomies es una aplicacion para gestionar viviendas compartidas, habitaciones, incidencias, tablon, gastos y otras funciones relacionadas con la convivencia.',
+          'El uso de la app debe hacerse de buena fe, respetando a otros usuarios y sin emplearla para actividades ilicitas, fraudulentas o que puedan perjudicar a terceros.',
+        ],
+      },
+      {
+        title: '2. Cuenta y acceso',
+        paragraphs: [
+          'Cada usuario debe aportar datos veraces, mantener sus credenciales protegidas y notificar incidencias de seguridad si detecta un acceso no autorizado.',
+          'Roomies puede limitar o suspender cuentas que incumplan estas condiciones, afecten al funcionamiento del servicio o vulneren derechos de otros usuarios.',
+        ],
+      },
+      {
+        title: '3. Contenido y convivencia',
+        paragraphs: [
+          'Los anuncios, incidencias, nombres de vivienda, documentos y demas contenidos que suba cada usuario son responsabilidad de quien los publica.',
+          'No se permite compartir informacion ofensiva, enganosa, discriminatoria o que revele datos de terceros sin base legitima para ello.',
+        ],
+      },
+      {
+        title: '4. Funcionalidades economicas',
+        paragraphs: [
+          'Los importes, facturas, deudas, justificantes y repartos mostrados en la app dependen de la informacion introducida por los usuarios responsables de cada vivienda.',
+          'Roomies facilita la gestion y trazabilidad de esos datos, pero no sustituye el asesoramiento legal, fiscal o contable que pueda ser necesario en casos concretos.',
+        ],
+      },
+      {
+        title: '5. Disponibilidad y cambios',
+        paragraphs: [
+          'Intentamos mantener la app disponible y segura, aunque pueden producirse interrupciones temporales por mantenimiento, incidencias tecnicas o mejoras del servicio.',
+          'Estas condiciones pueden actualizarse en el futuro. La app queda preparada para versionar estos documentos y mostrar su fecha de entrada en vigor.',
+        ],
+      },
+      {
+        title: '6. Contacto y vigencia',
+        paragraphs: [
+          'Si tienes dudas sobre el uso de la app o sobre estas condiciones, debes contactar con el equipo responsable antes de apoyarte en este texto como documento legal definitivo.',
+          'La version visible en la app identifica la revision actualmente publicada para que futuras actualizaciones puedan compararse con claridad.',
+        ],
+      },
+    ],
+  },
+  privacidad: {
+    key: 'privacidad',
+    title: 'Politica de privacidad',
+    shortTitle: 'Privacidad',
+    summary:
+      'Explica que datos usamos en Roomies, con que finalidad y que opciones tiene cada usuario sobre su informacion.',
+    version: LEGAL_VERSION,
+    effectiveDate: LEGAL_EFFECTIVE_DATE,
+    reviewNote: LEGAL_REVIEW_NOTE,
+    sections: [
+      {
+        title: '1. Datos que tratamos',
+        paragraphs: [
+          'Roomies puede tratar datos de identificacion y contacto como nombre, apellidos, email, telefono, documento de identidad, rol dentro de la app y credenciales necesarias para autenticacion.',
+          'Segun las funciones utilizadas, tambien puede almacenar datos de viviendas, habitaciones, incidencias, anuncios, gastos, justificantes, inventario, imagenes y tokens de notificaciones push.',
+        ],
+      },
+      {
+        title: '2. Finalidades del tratamiento',
+        paragraphs: [
+          'Utilizamos los datos para crear y mantener cuentas, permitir la participacion en viviendas, gestionar incidencias, pagos, mensajeria interna y mejorar la seguridad operativa del servicio.',
+          'Tambien podemos usar cierta informacion para soporte tecnico, prevencion de abuso, diagnostico de errores y comunicaciones funcionales relacionadas con la actividad del usuario.',
+        ],
+      },
+      {
+        title: '3. Base de legitimacion',
+        paragraphs: [
+          'El tratamiento principal se apoya en la ejecucion del servicio solicitado por el usuario y en el cumplimiento de obligaciones asociadas a la gestion de la cuenta y la convivencia digital.',
+          'Cuando una funcion requiera consentimiento adicional, como ciertas comunicaciones o futuras actualizaciones legales, la app podra solicitarlo de forma expresa y versionada.',
+        ],
+      },
+      {
+        title: '4. Cesiones y acceso a terceros',
+        paragraphs: [
+          'Los datos solo deben compartirse con otros usuarios cuando la funcion lo requiera, por ejemplo para identificar companeros de vivienda, gestionar incidencias o repartir gastos.',
+          'Tambien pueden intervenir proveedores tecnologicos necesarios para autenticacion, almacenamiento, infraestructura, correo o notificaciones, siempre dentro del marco operativo del servicio.',
+        ],
+      },
+      {
+        title: '5. Conservacion y seguridad',
+        paragraphs: [
+          'Conservamos los datos durante el tiempo necesario para prestar el servicio, atender obligaciones legales y resolver incidencias o reclamaciones justificadas.',
+          'Aplicamos medidas tecnicas y organizativas razonables para proteger la informacion, aunque ningun sistema conectado a internet puede garantizar seguridad absoluta.',
+        ],
+      },
+      {
+        title: '6. Derechos del usuario',
+        paragraphs: [
+          'Cada usuario puede solicitar acceso, rectificacion, supresion o limitacion del tratamiento de sus datos, asi como plantear dudas sobre el uso de su informacion en la plataforma.',
+          'Antes de publicar la app de forma definitiva, este texto debe revisarse y completarse con la informacion juridica y de contacto exigible en la jurisdiccion aplicable.',
+        ],
+      },
+    ],
+  },
+};
+
+export function getLegalDocument(key: LegalDocumentKey) {
+  return legalDocuments[key];
+}

--- a/frontend/styles/index.styles.ts
+++ b/frontend/styles/index.styles.ts
@@ -2,11 +2,16 @@ import { StyleSheet } from 'react-native';
 import { AppTheme, DefaultAppTheme } from '@/constants/theme';
 
 export const createStyles = (theme: AppTheme = DefaultAppTheme) => StyleSheet.create({
-  container: {
+  scrollContainer: {
     flex: 1,
+    backgroundColor: theme.colors.background,
+  },
+  container: {
+    flexGrow: 1,
     justifyContent: 'center',
     backgroundColor: theme.colors.background,
     paddingHorizontal: theme.spacing.xl,
+    paddingVertical: theme.spacing.xxl,
   },
   logo: {
     fontSize: theme.typography.hero,
@@ -24,6 +29,7 @@ export const createStyles = (theme: AppTheme = DefaultAppTheme) => StyleSheet.cr
   enlaceRegistro: {
     marginTop: theme.spacing.lg,
     alignItems: 'center',
+    marginBottom: theme.spacing.base,
   },
   enlaceRegistroTexto: {
     fontSize: theme.typography.label,

--- a/frontend/styles/legal/legal-document.styles.ts
+++ b/frontend/styles/legal/legal-document.styles.ts
@@ -1,0 +1,97 @@
+import { StyleSheet } from 'react-native';
+import { AppTheme, DefaultAppTheme } from '@/constants/theme';
+
+export const createStyles = (theme: AppTheme = DefaultAppTheme) => StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.background,
+  },
+  content: {
+    padding: theme.spacing.lg,
+    paddingBottom: theme.spacing.xxl,
+    gap: theme.spacing.base,
+  },
+  heroCard: {
+    backgroundColor: theme.colors.surface,
+    borderRadius: theme.radius.xl,
+    padding: theme.spacing.lg,
+    gap: theme.spacing.sm,
+    shadowColor: theme.colors.shadow,
+    shadowOffset: { width: 0, height: 3 },
+    shadowOpacity: theme.isDark ? 0.2 : 0.08,
+    shadowRadius: 10,
+    elevation: 3,
+  },
+  eyebrow: {
+    color: theme.colors.primary,
+    fontSize: theme.typography.label,
+    fontWeight: '700',
+  },
+  title: {
+    color: theme.colors.text,
+    fontSize: theme.typography.heading,
+    fontWeight: '800',
+  },
+  summary: {
+    color: theme.colors.textSecondary,
+    fontSize: theme.typography.body,
+    lineHeight: 24,
+  },
+  metaRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: theme.spacing.sm,
+  },
+  metaPill: {
+    borderRadius: theme.radius.full,
+    paddingHorizontal: theme.spacing.base,
+    paddingVertical: theme.spacing.sm,
+    backgroundColor: theme.colors.primaryLight,
+  },
+  metaPillText: {
+    color: theme.colors.primary,
+    fontSize: theme.typography.caption,
+    fontWeight: '700',
+  },
+  noteCard: {
+    backgroundColor: theme.colors.warningLight,
+    borderRadius: theme.radius.lg,
+    padding: theme.spacing.base,
+    borderWidth: 1,
+    borderColor: theme.colors.warning,
+    gap: theme.spacing.xs,
+  },
+  noteTitle: {
+    color: theme.colors.warningText,
+    fontSize: theme.typography.label,
+    fontWeight: '700',
+  },
+  noteText: {
+    color: theme.colors.warningText,
+    fontSize: theme.typography.label,
+    lineHeight: 20,
+  },
+  sectionCard: {
+    backgroundColor: theme.colors.surface,
+    borderRadius: theme.radius.lg,
+    padding: theme.spacing.base,
+    gap: theme.spacing.sm,
+    shadowColor: theme.colors.shadow,
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: theme.isDark ? 0.18 : 0.05,
+    shadowRadius: 6,
+    elevation: 2,
+  },
+  sectionTitle: {
+    color: theme.colors.text,
+    fontSize: theme.typography.subtitle,
+    fontWeight: '700',
+  },
+  paragraph: {
+    color: theme.colors.textSecondary,
+    fontSize: theme.typography.label,
+    lineHeight: 22,
+  },
+});
+
+export const styles = createStyles();

--- a/frontend/styles/rol.styles.ts
+++ b/frontend/styles/rol.styles.ts
@@ -2,12 +2,17 @@ import { StyleSheet } from 'react-native';
 import { AppTheme, DefaultAppTheme } from '@/constants/theme';
 
 export const createStyles = (theme: AppTheme = DefaultAppTheme) => StyleSheet.create({
-  container: {
+  scrollContainer: {
     flex: 1,
+    backgroundColor: theme.colors.background,
+  },
+  container: {
+    flexGrow: 1,
     backgroundColor: theme.colors.background,
     justifyContent: 'center',
     alignItems: 'center',
     paddingHorizontal: theme.spacing.lg,
+    paddingVertical: theme.spacing.xxl,
     gap: theme.spacing.base,
   },
   titulo: {


### PR DESCRIPTION
## Objetivo
Añade acceso a los documentos legales básicos de Roomies desde la app y obliga a aceptar sus condiciones en los flujos de alta donde corresponde.

## Cambios principales
* Se crean vistas legales dedicadas para términos de uso y política de privacidad.
* Se incorpora un bloque reutilizable para mostrar enlaces legales y checkbox de aceptación.
* Se enlaza la documentación legal desde login, registro, selección de rol y perfil.
* El registro manual y el alta de usuarios nuevos por Google exigen aceptación explícita antes de continuar.
* Se versiona el contenido legal y se deja preparado para futuras actualizaciones.

## UI / UX (Solo si aplica)
* Se ajustan las pantallas de auth a `ScrollView` para manejar documentos largos sin romper el layout.
* Se reutilizan tokens de `Theme.ts` para bordes, espaciado y superficies suaves.

## Changelog
* `docs/changelog/Epica17/issue-276-terminos-privacidad.md`

## Testing
* `npm run lint` en frontend.
* Validación manual del flujo de login, registro, rol y perfil para comprobar enlaces y aceptación legal.