### PR TITLE
[Épica 17] Refuerza la validación y visibilidad del inventario

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -89,6 +89,7 @@ model Usuario {
   cargos_habitacion Gasto[]                  @relation("InquilinoCargoHabitacion")
   deudas_a_pagar     Deuda[]                  @relation("DeudorDeuda")
   deudas_a_cobrar    Deuda[]                  @relation("AcreedorDeuda")
+  items_inventario_validados ItemInventario[] @relation("ValidadorInventario")
 }
 
 model Vivienda {
@@ -213,17 +214,20 @@ model Deuda {
 }
 
 model ItemInventario {
-  id             Int         @id @default(autoincrement())
-  nombre         String
-  descripcion    String?
-  estado         EstadoItem  @default(BUENO)
-  revisado_por_inquilino Boolean @default(false)
-  habitacion_id  Int?
-  habitacion     Habitacion? @relation(fields: [habitacion_id], references: [id])
-  vivienda_id    Int?
-  vivienda       Vivienda?   @relation(fields: [vivienda_id], references: [id])
-  fecha_registro DateTime    @default(now())
-  fotos          FotoAsset[]
+  id                          Int         @id @default(autoincrement())
+  nombre                      String
+  descripcion                 String?
+  estado                      EstadoItem  @default(BUENO)
+  revisado_por_inquilino      Boolean     @default(false)
+  revisado_por_inquilino_id   Int?
+  revisado_por_inquilino_en   DateTime?
+  revisado_por_inquilino_user Usuario?    @relation("ValidadorInventario", fields: [revisado_por_inquilino_id], references: [id], onDelete: SetNull)
+  habitacion_id               Int?
+  habitacion                  Habitacion? @relation(fields: [habitacion_id], references: [id])
+  vivienda_id                 Int?
+  vivienda                    Vivienda?   @relation(fields: [vivienda_id], references: [id])
+  fecha_registro              DateTime    @default(now())
+  fotos                       FotoAsset[]
 }
 
 model FotoAsset {

--- a/backend/src/controllers/inventario.controller.ts
+++ b/backend/src/controllers/inventario.controller.ts
@@ -32,6 +32,18 @@ const usuarioTieneAccesoAVivienda = async (
   return habitacion !== null;
 };
 
+const obtenerHabitacionDelInquilinoEnVivienda = async (usuarioId: number, viviendaId: number) =>
+  prisma.habitacion.findFirst({
+    where: {
+      vivienda_id: viviendaId,
+      inquilino_id: usuarioId,
+    },
+    select: {
+      id: true,
+      vivienda_id: true,
+    },
+  });
+
 const obtenerViviendaDelCasero = async (usuarioId: number, viviendaId: number) =>
   prisma.vivienda.findFirst({
     where: {
@@ -73,7 +85,7 @@ export const crearItemInventario: express.RequestHandler = async (req, res) => {
   };
 
   if (!Number.isInteger(viviendaId) || viviendaId <= 0) {
-    res.status(400).json({ error: 'viviendaId inválido.' });
+    res.status(400).json({ error: 'viviendaId invÃ¡lido.' });
     return;
   }
 
@@ -100,10 +112,10 @@ export const crearItemInventario: express.RequestHandler = async (req, res) => {
   }
 
   const estadoNormalizado =
-    typeof estado === 'string' ? estado.trim().toUpperCase() as EstadoItem : EstadoItem.BUENO;
+    typeof estado === 'string' ? (estado.trim().toUpperCase() as EstadoItem) : EstadoItem.BUENO;
 
   if (!ESTADOS_ITEM_VALIDOS.has(estadoNormalizado)) {
-    res.status(400).json({ error: 'El estado del item no es válido.' });
+    res.status(400).json({ error: 'El estado del item no es vÃ¡lido.' });
     return;
   }
 
@@ -134,12 +146,12 @@ export const crearItemInventario: express.RequestHandler = async (req, res) => {
   }
 
   if (tieneHabitacion && (!Number.isInteger(habitacionId) || habitacionId <= 0)) {
-    res.status(400).json({ error: 'habitacion_id inválido.' });
+    res.status(400).json({ error: 'habitacion_id invÃ¡lido.' });
     return;
   }
 
   if (tieneVivienda && (!Number.isInteger(viviendaIdBody) || viviendaIdBody <= 0)) {
-    res.status(400).json({ error: 'vivienda_id inválido.' });
+    res.status(400).json({ error: 'vivienda_id invÃ¡lido.' });
     return;
   }
 
@@ -149,7 +161,7 @@ export const crearItemInventario: express.RequestHandler = async (req, res) => {
     );
 
     if (!habitacionPerteneceAVivienda) {
-      res.status(400).json({ error: 'La habitación no pertenece a esta vivienda.' });
+      res.status(400).json({ error: 'La habitaciÃ³n no pertenece a esta vivienda.' });
       return;
     }
   }
@@ -168,6 +180,7 @@ export const crearItemInventario: express.RequestHandler = async (req, res) => {
           id: true,
           nombre: true,
           tipo: true,
+          inquilino_id: true,
         },
       },
       fotos: {
@@ -187,7 +200,7 @@ export const listarInventarioVivienda: express.RequestHandler = async (req, res)
   const rol = req.usuario!.rol;
 
   if (!Number.isInteger(viviendaId) || viviendaId <= 0) {
-    res.status(400).json({ error: 'viviendaId inválido.' });
+    res.status(400).json({ error: 'viviendaId invÃ¡lido.' });
     return;
   }
 
@@ -198,25 +211,61 @@ export const listarInventarioVivienda: express.RequestHandler = async (req, res)
   }
 
   const items = await prisma.itemInventario.findMany({
-    where: {
-      OR: [
-        { vivienda_id: viviendaId },
-        { habitacion: { vivienda_id: viviendaId } },
-      ],
-    },
-    include: {
+    where:
+      rol === RolUsuario.CASERO
+        ? {
+            OR: [
+              { vivienda_id: viviendaId },
+              { habitacion: { vivienda_id: viviendaId } },
+            ],
+          }
+        : {
+            OR: [
+              { vivienda_id: viviendaId },
+              { habitacion: { vivienda_id: viviendaId, es_habitable: false } },
+              { habitacion: { vivienda_id: viviendaId, inquilino_id: usuarioId } },
+            ],
+          },
+    select: {
+      id: true,
+      nombre: true,
+      descripcion: true,
+      estado: true,
+      revisado_por_inquilino: true,
+      revisado_por_inquilino_id: true,
+      revisado_por_inquilino_en: true,
+      habitacion_id: true,
+      vivienda_id: true,
+      fecha_registro: true,
       habitacion: {
         select: {
           id: true,
           nombre: true,
           tipo: true,
+          inquilino_id: true,
         },
       },
       fotos: {
+        select: {
+          id: true,
+          url: true,
+          fecha_subida: true,
+        },
         orderBy: {
           fecha_subida: 'desc',
         },
       },
+      ...(rol === RolUsuario.CASERO
+        ? {
+            revisado_por_inquilino_user: {
+              select: {
+                id: true,
+                nombre: true,
+                apellidos: true,
+              },
+            },
+          }
+        : {}),
     },
     orderBy: [
       { habitacion_id: 'asc' },
@@ -234,7 +283,7 @@ export const marcarConformidadInventario: express.RequestHandler = async (req, r
   const rol = req.usuario!.rol;
 
   if (!Number.isInteger(itemId) || itemId <= 0) {
-    res.status(400).json({ error: 'itemId inválido.' });
+    res.status(400).json({ error: 'itemId invÃ¡lido.' });
     return;
   }
 
@@ -245,10 +294,35 @@ export const marcarConformidadInventario: express.RequestHandler = async (req, r
 
   const item = await prisma.itemInventario.findUnique({
     where: { id: itemId },
-    include: {
+    select: {
+      id: true,
+      nombre: true,
+      descripcion: true,
+      estado: true,
+      revisado_por_inquilino: true,
+      revisado_por_inquilino_id: true,
+      revisado_por_inquilino_en: true,
+      habitacion_id: true,
+      vivienda_id: true,
+      fecha_registro: true,
       habitacion: {
         select: {
+          id: true,
+          nombre: true,
+          tipo: true,
           vivienda_id: true,
+          es_habitable: true,
+          inquilino_id: true,
+        },
+      },
+      fotos: {
+        select: {
+          id: true,
+          url: true,
+          fecha_subida: true,
+        },
+        orderBy: {
+          fecha_subida: 'desc',
         },
       },
     },
@@ -262,13 +336,38 @@ export const marcarConformidadInventario: express.RequestHandler = async (req, r
   const viviendaId = item.vivienda_id ?? item.habitacion?.vivienda_id;
 
   if (!viviendaId) {
-    res.status(400).json({ error: 'El item de inventario no está vinculado a una vivienda válida.' });
+    res.status(400).json({ error: 'El item de inventario no estÃ¡ vinculado a una vivienda vÃ¡lida.' });
     return;
   }
 
-  const tieneAcceso = await usuarioTieneAccesoAVivienda(usuarioId, rol, viviendaId);
-  if (!tieneAcceso) {
+  const miHabitacion = await obtenerHabitacionDelInquilinoEnVivienda(usuarioId, viviendaId);
+  if (!miHabitacion) {
     res.status(403).json({ error: 'No tienes acceso a este item de inventario.' });
+    return;
+  }
+
+  const esItemDeZonaComun =
+    item.vivienda_id === viviendaId ||
+    (item.habitacion?.vivienda_id === viviendaId && item.habitacion.es_habitable === false);
+  const esItemDeMiHabitacion =
+    item.habitacion?.vivienda_id === viviendaId && item.habitacion.inquilino_id === usuarioId;
+
+  if (!esItemDeZonaComun && !esItemDeMiHabitacion) {
+    res.status(403).json({ error: 'No puedes validar items de otra habitaciÃ³n.' });
+    return;
+  }
+
+  if (
+    item.revisado_por_inquilino &&
+    item.revisado_por_inquilino_id !== null &&
+    item.revisado_por_inquilino_id !== usuarioId
+  ) {
+    res.status(409).json({ error: 'Este item ya fue validado por otro inquilino.' });
+    return;
+  }
+
+  if (item.revisado_por_inquilino && item.revisado_por_inquilino_id === usuarioId) {
+    res.status(200).json(item);
     return;
   }
 
@@ -276,6 +375,8 @@ export const marcarConformidadInventario: express.RequestHandler = async (req, r
     where: { id: itemId },
     data: {
       revisado_por_inquilino: true,
+      revisado_por_inquilino_id: usuarioId,
+      revisado_por_inquilino_en: new Date(),
     },
     include: {
       habitacion: {
@@ -283,6 +384,7 @@ export const marcarConformidadInventario: express.RequestHandler = async (req, r
           id: true,
           nombre: true,
           tipo: true,
+          inquilino_id: true,
         },
       },
       fotos: {
@@ -302,12 +404,12 @@ export const subirFotoInventario: express.RequestHandler = async (req, res) => {
   const rol = req.usuario!.rol;
 
   if (!cloudinaryEstaConfigurado) {
-    res.status(500).json({ error: 'Cloudinary no está configurado en el servidor.' });
+    res.status(500).json({ error: 'Cloudinary no estÃ¡ configurado en el servidor.' });
     return;
   }
 
   if (!Number.isInteger(itemId) || itemId <= 0) {
-    res.status(400).json({ error: 'itemId inválido.' });
+    res.status(400).json({ error: 'itemId invÃ¡lido.' });
     return;
   }
 
@@ -340,7 +442,7 @@ export const subirFotoInventario: express.RequestHandler = async (req, res) => {
   const viviendaId = item.vivienda_id ?? item.habitacion?.vivienda_id;
 
   if (!viviendaId) {
-    res.status(400).json({ error: 'El item de inventario no está vinculado a una vivienda válida.' });
+    res.status(400).json({ error: 'El item de inventario no estÃ¡ vinculado a una vivienda vÃ¡lida.' });
     return;
   }
 

--- a/backend/tests/inventario-issue-277.test.ts
+++ b/backend/tests/inventario-issue-277.test.ts
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict';
+import type express from 'express';
+import { beforeEach, describe, test, vi } from 'vitest';
+
+type UsuarioTest = { id: number; rol: 'CASERO' | 'INQUILINO' };
+
+const prisma = vi.hoisted(() => ({
+  vivienda: {
+    findFirst: async (_args: unknown): Promise<unknown> => null,
+  },
+  habitacion: {
+    findFirst: async (_args: unknown): Promise<unknown> => null,
+  },
+  itemInventario: {
+    findMany: async (_args: unknown): Promise<unknown> => [],
+    findUnique: async (_args: unknown): Promise<unknown> => null,
+    update: async (_args: unknown): Promise<unknown> => ({}),
+  },
+}));
+
+vi.mock('../src/lib/prisma', () => ({ prisma }));
+
+const {
+  listarInventarioVivienda,
+  marcarConformidadInventario,
+} = await import('../src/controllers/inventario.controller');
+
+function resetPrisma() {
+  prisma.vivienda.findFirst = async () => null;
+  prisma.habitacion.findFirst = async () => null;
+  prisma.itemInventario.findMany = async () => [];
+  prisma.itemInventario.findUnique = async () => null;
+  prisma.itemInventario.update = async (args: unknown) => ({
+    id: 1,
+    ...(args as { data: Record<string, unknown> }).data,
+  });
+}
+
+beforeEach(() => {
+  resetPrisma();
+});
+
+function req({
+  usuario,
+  params = {},
+}: {
+  usuario: UsuarioTest;
+  params?: Record<string, string>;
+}) {
+  return {
+    usuario,
+    params,
+  } as unknown as express.Request;
+}
+
+function res() {
+  const response = {
+    statusCode: 200,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  };
+
+  return response as unknown as express.Response & typeof response;
+}
+
+async function invoke(handler: express.RequestHandler, requestData: express.Request) {
+  const response = res();
+  await handler(requestData, response, () => undefined);
+  return response;
+}
+
+describe('issue 277 - inventario multi-tenant', () => {
+  test('filtra el listado del inquilino a su habitacion y zonas comunes', async () => {
+    let filtros: unknown;
+    prisma.habitacion.findFirst = async () => ({ id: 20, vivienda_id: 10 });
+    prisma.itemInventario.findMany = async (args: unknown) => {
+      filtros = args;
+      return [];
+    };
+
+    const response = await invoke(
+      listarInventarioVivienda,
+      req({ usuario: { id: 20, rol: 'INQUILINO' }, params: { viviendaId: '10' } }),
+    );
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(
+      (filtros as { where: unknown }).where,
+      {
+        OR: [
+          { vivienda_id: 10 },
+          { habitacion: { vivienda_id: 10, es_habitable: false } },
+          { habitacion: { vivienda_id: 10, inquilino_id: 20 } },
+        ],
+      },
+    );
+  });
+
+  test('bloquea la conformidad sobre items de otra habitacion aunque sea la misma vivienda', async () => {
+    let updateCalled = false;
+    prisma.habitacion.findFirst = async () => ({ id: 20, vivienda_id: 10 });
+    prisma.itemInventario.findUnique = async () => ({
+      id: 1,
+      nombre: 'Mesilla',
+      descripcion: null,
+      estado: 'BUENO',
+      revisado_por_inquilino: false,
+      revisado_por_inquilino_id: null,
+      revisado_por_inquilino_en: null,
+      habitacion_id: 12,
+      vivienda_id: null,
+      fecha_registro: new Date('2026-04-12T10:00:00.000Z'),
+      fotos: [],
+      habitacion: {
+        id: 12,
+        nombre: 'Habitacion 2',
+        tipo: 'DORMITORIO',
+        vivienda_id: 10,
+        es_habitable: true,
+        inquilino_id: 21,
+      },
+    });
+    prisma.itemInventario.update = async () => {
+      updateCalled = true;
+      return {};
+    };
+
+    const response = await invoke(
+      marcarConformidadInventario,
+      req({ usuario: { id: 20, rol: 'INQUILINO' }, params: { itemId: '1' } }),
+    );
+
+    assert.equal(response.statusCode, 403);
+    assert.match((response.body as { error: string }).error, /otra habitaci/i);
+    assert.equal(updateCalled, false);
+  });
+});

--- a/docs/changelog/Epica17/issue-277-validacion-inventario-inquilino.md
+++ b/docs/changelog/Epica17/issue-277-validacion-inventario-inquilino.md
@@ -1,0 +1,18 @@
+# Epica 17 - Issue 277 - validacion de inventario por inquilino
+
+## Objetivo
+
+Hacer visible para el casero la conformidad del inquilino sobre cada item de inventario y cerrar el hueco de permisos que permitia listar o validar elementos de otras habitaciones dentro de la misma vivienda.
+
+## Cambios principales
+
+- `backend/prisma/schema.prisma`: se amplia `ItemInventario` con `revisado_por_inquilino_id` y `revisado_por_inquilino_en`, enlazando la validacion con el usuario que la hizo y el instante en que se registro.
+- `backend/src/controllers/inventario.controller.ts`: el listado para inquilino ahora solo devuelve items de su habitacion y de zonas comunes, y la conformidad rechaza intentos sobre habitaciones ajenas aunque pertenezcan a la misma vivienda.
+- `backend/src/controllers/inventario.controller.ts`: la conformidad pasa a ser idempotente para el mismo inquilino y bloquea sobrescrituras cuando un item comun ya fue validado por otra persona.
+- `frontend/app/casero/(tabs)/inventario.tsx`: la vista del casero muestra estados `Validado`, `Pendiente` y `No aplica`, junto con el nombre del inquilino validador y la fecha cuando existe.
+- `frontend/styles/casero/inventario.styles.ts`: se incorporan badges semanticos para el estado de revision y nuevos indicadores resumen en la hero card.
+- `backend/tests/inventario-issue-277.test.ts`: se anaden pruebas dirigidas para filtrar el inventario del inquilino y bloquear la conformidad forzada sobre otra habitacion.
+
+## Verificacion
+
+- `backend`: ejecutar `npm test -- inventario-issue-277.test.ts` para cubrir el filtrado por habitacion y el veto a la conformidad cruzada.

--- a/frontend/app/casero/(tabs)/inventario.tsx
+++ b/frontend/app/casero/(tabs)/inventario.tsx
@@ -24,6 +24,7 @@ import api from '@/services/api';
 import { onModulosViviendaActualizados } from '@/utils/viviendaModules';
 import {
   createEstadoItemStyles,
+  createRevisionInventarioStyles,
   createStyles,
 } from '@/styles/casero/inventario.styles';
 
@@ -33,6 +34,13 @@ type Habitacion = {
   id: number;
   nombre: string;
   tipo: string;
+  inquilino_id?: number | null;
+};
+
+type UsuarioValidacion = {
+  id: number;
+  nombre: string;
+  apellidos: string | null;
 };
 
 type Vivienda = {
@@ -57,6 +65,10 @@ type ItemInventario = {
   habitacion_id: number | null;
   vivienda_id: number | null;
   fecha_registro: string;
+  revisado_por_inquilino: boolean;
+  revisado_por_inquilino_id: number | null;
+  revisado_por_inquilino_en: string | null;
+  revisado_por_inquilino_user?: UsuarioValidacion | null;
   habitacion: Habitacion | null;
   fotos: FotoAsset[];
 };
@@ -87,6 +99,7 @@ export default function CaseroInventarioScreen() {
   const { theme } = useAppTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const estadoItemStyles = useMemo(() => createEstadoItemStyles(theme), [theme]);
+  const revisionInventarioStyles = useMemo(() => createRevisionInventarioStyles(theme), [theme]);
   const [viviendas, setViviendas] = useState<Vivienda[]>([]);
   const [hayViviendas, setHayViviendas] = useState(false);
   const [viviendaSeleccionadaId, setViviendaSeleccionadaId] = useState<number | null>(null);
@@ -105,6 +118,18 @@ export default function CaseroInventarioScreen() {
     viviendas.find((vivienda) => vivienda.id === viviendaSeleccionadaId) ?? null;
 
   const grupos = construirGruposInventario(items);
+  const resumenRevision = useMemo(
+    () =>
+      items.reduce(
+        (acc, item) => {
+          const estadoRevision = obtenerEstadoRevisionCasero(item);
+          acc[estadoRevision] += 1;
+          return acc;
+        },
+        { VALIDADO: 0, PENDIENTE: 0, NO_APLICA: 0 } as Record<EstadoRevisionCasero, number>,
+      ),
+    [items],
+  );
 
   const cargarInventario = useCallback(async (viviendaId: number) => {
     setLoadingItems(true);
@@ -363,6 +388,22 @@ export default function CaseroInventarioScreen() {
                   {viviendaSeleccionada.habitaciones.length} ubicaciones
                 </Text>
               </View>
+              <View style={[styles.heroStat, styles.heroStatSuccess]}>
+                <Ionicons
+                  name="checkmark-circle-outline"
+                  size={14}
+                  color={theme.colors.success}
+                />
+                <Text style={[styles.heroStatText, styles.heroStatTextSuccess]}>
+                  {resumenRevision.VALIDADO} validados
+                </Text>
+              </View>
+              <View style={[styles.heroStat, styles.heroStatWarning]}>
+                <Ionicons name="time-outline" size={14} color={theme.colors.warning} />
+                <Text style={[styles.heroStatText, styles.heroStatTextWarning]}>
+                  {resumenRevision.PENDIENTE} pendientes
+                </Text>
+              </View>
             </View>
           </Card>
         )}
@@ -393,6 +434,7 @@ export default function CaseroInventarioScreen() {
               <View style={styles.itemList}>
                 {grupo.items.map((item) => {
                   const fotoPrincipal = item.fotos[0]?.url;
+                  const estadoRevision = obtenerEstadoRevisionCasero(item);
                   return (
                     <Card key={item.id} style={styles.itemCard}>
                       <View style={styles.itemCardRow}>
@@ -449,7 +491,35 @@ export default function CaseroInventarioScreen() {
                                 {item.fotos.length} foto{item.fotos.length === 1 ? '' : 's'}
                               </Text>
                             </View>
+                            <View
+                              style={[
+                                styles.reviewBadge,
+                                {
+                                  backgroundColor:
+                                    revisionInventarioStyles[estadoRevision].background,
+                                  borderColor:
+                                    revisionInventarioStyles[estadoRevision].border,
+                                },
+                              ]}
+                            >
+                              <Ionicons
+                                name={obtenerIconoRevisionCasero(estadoRevision)}
+                                size={13}
+                                color={revisionInventarioStyles[estadoRevision].text}
+                              />
+                              <Text
+                                style={[
+                                  styles.reviewBadgeText,
+                                  { color: revisionInventarioStyles[estadoRevision].text },
+                                ]}
+                              >
+                                {obtenerEtiquetaRevisionCasero(estadoRevision)}
+                              </Text>
+                            </View>
                           </View>
+                          <Text style={styles.reviewDetail}>
+                            {obtenerDetalleRevisionCasero(item)}
+                          </Text>
                         </View>
                       </View>
                     </Card>
@@ -670,4 +740,79 @@ function construirGruposInventario(items: ItemInventario[]): GrupoInventario[] {
   });
 
   return Array.from(grupos.values());
+}
+
+type EstadoRevisionCasero = 'VALIDADO' | 'PENDIENTE' | 'NO_APLICA';
+
+function obtenerEstadoRevisionCasero(item: ItemInventario): EstadoRevisionCasero {
+  const dormitorioSinInquilino =
+    item.habitacion?.tipo === 'DORMITORIO' && !item.habitacion?.inquilino_id;
+
+  if (dormitorioSinInquilino) {
+    return 'NO_APLICA';
+  }
+
+  if (item.revisado_por_inquilino) {
+    return 'VALIDADO';
+  }
+
+  return 'PENDIENTE';
+}
+
+function obtenerEtiquetaRevisionCasero(estado: EstadoRevisionCasero) {
+  if (estado === 'VALIDADO') {
+    return 'Validado';
+  }
+
+  if (estado === 'NO_APLICA') {
+    return 'No aplica';
+  }
+
+  return 'Pendiente';
+}
+
+function obtenerIconoRevisionCasero(estado: EstadoRevisionCasero) {
+  if (estado === 'VALIDADO') {
+    return 'checkmark-circle-outline' as const;
+  }
+
+  if (estado === 'NO_APLICA') {
+    return 'remove-circle-outline' as const;
+  }
+
+  return 'time-outline' as const;
+}
+
+function obtenerDetalleRevisionCasero(item: ItemInventario) {
+  const estado = obtenerEstadoRevisionCasero(item);
+
+  if (estado === 'NO_APLICA') {
+    return 'No se solicita conformidad hasta que esta habitación tenga un inquilino asignado.';
+  }
+
+  if (estado === 'VALIDADO') {
+    const nombreValidador = item.revisado_por_inquilino_user
+      ? [item.revisado_por_inquilino_user.nombre, item.revisado_por_inquilino_user.apellidos]
+          .filter(Boolean)
+          .join(' ')
+      : 'Un inquilino';
+    const fechaRevision = item.revisado_por_inquilino_en
+      ? ` el ${formatearFechaRevision(item.revisado_por_inquilino_en)}`
+      : '';
+
+    return `${nombreValidador} validó este item${fechaRevision}.`;
+  }
+
+  if (item.habitacion?.tipo === 'DORMITORIO') {
+    return 'Pendiente de revisión por parte del inquilino asignado a esta habitación.';
+  }
+
+  return 'Pendiente de revisión para el inventario visible de zonas comunes.';
+}
+
+function formatearFechaRevision(valor: string) {
+  return new Intl.DateTimeFormat('es-ES', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(valor));
 }

--- a/frontend/styles/casero/inventario.styles.ts
+++ b/frontend/styles/casero/inventario.styles.ts
@@ -24,6 +24,24 @@ export const createEstadoItemStyles = (theme: AppTheme = DefaultAppTheme) => ({
   },
 } as const);
 
+export const createRevisionInventarioStyles = (theme: AppTheme = DefaultAppTheme) => ({
+  VALIDADO: {
+    background: theme.colors.successLight,
+    text: theme.colors.success,
+    border: `${theme.colors.success}30`,
+  },
+  PENDIENTE: {
+    background: theme.colors.warningLight,
+    text: theme.colors.warning,
+    border: `${theme.colors.warning}35`,
+  },
+  NO_APLICA: {
+    background: theme.colors.surface2,
+    text: theme.colors.textMedium,
+    border: theme.colors.border,
+  },
+} as const);
+
 export const createStyles = (theme: AppTheme = DefaultAppTheme) => StyleSheet.create({
   container: {
     flex: 1,
@@ -121,6 +139,12 @@ export const createStyles = (theme: AppTheme = DefaultAppTheme) => StyleSheet.cr
   heroStatNeutral: {
     backgroundColor: theme.colors.surface2,
   },
+  heroStatSuccess: {
+    backgroundColor: theme.colors.successLight,
+  },
+  heroStatWarning: {
+    backgroundColor: theme.colors.warningLight,
+  },
   heroStatText: {
     fontSize: theme.typography.caption,
     fontWeight: '700',
@@ -130,6 +154,12 @@ export const createStyles = (theme: AppTheme = DefaultAppTheme) => StyleSheet.cr
   },
   heroStatTextNeutral: {
     color: theme.colors.textMedium,
+  },
+  heroStatTextSuccess: {
+    color: theme.colors.success,
+  },
+  heroStatTextWarning: {
+    color: theme.colors.warning,
   },
   sectionTitle: {
     fontSize: theme.typography.subtitle,
@@ -233,6 +263,24 @@ export const createStyles = (theme: AppTheme = DefaultAppTheme) => StyleSheet.cr
     fontSize: theme.typography.caption,
     color: theme.colors.textMedium,
     fontWeight: '700',
+  },
+  reviewBadge: {
+    borderRadius: theme.radius.full,
+    paddingHorizontal: theme.spacing.md,
+    paddingVertical: theme.spacing.sm,
+    borderWidth: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: theme.spacing.xs,
+  },
+  reviewBadgeText: {
+    fontSize: theme.typography.caption,
+    fontWeight: '700',
+  },
+  reviewDetail: {
+    fontSize: theme.typography.label,
+    color: theme.colors.textSecondary,
+    lineHeight: 20,
   },
   emptyContainer: {
     alignItems: 'center',


### PR DESCRIPTION
## Objetivo
Refuerza el flujo de inventario para que el casero vea claramente qué items han sido validados por el inquilino y para evitar accesos cruzados entre habitaciones dentro de la misma vivienda.

## Cambios principales
* Amplío `ItemInventario` para guardar quién validó el item y cuándo lo hizo.
* Endurezco el backend para que el inquilino solo liste y valide items de su habitación y de las zonas comunes permitidas.
* Bloqueo la conformidad forzada sobre items de otra habitación aunque pertenezcan a la misma vivienda.
* Actualizo la vista del casero para distinguir items validados, pendientes y no aplicables, mostrando además el validador y la fecha cuando existe.
* Añado pruebas dirigidas para cubrir el filtrado por habitación y el veto a la validación cruzada.

## UI / UX (Solo si aplica)
* Se incorporan badges semánticos y un resumen visual en la pantalla de inventario del casero con los tokens de Theme.
* Se mantienen los soft tints para estados de revisión y se refuerza la lectura rápida del estado de cada item.

## Changelog
* `docs/changelog/Epica17/issue-277-validacion-inventario-inquilino.md`

## Testing
* `backend`: prueba dirigida de inventario para filtrar por habitación y bloquear conformidad cruzada.
* `backend`: build del proyecto completado con generación de Prisma.
* `frontend`: lint de la pantalla y estilos de inventario del casero completado.
* `frontend`: `tsc --noEmit` sigue mostrando errores previos ajenos a este cambio en otra pantalla de limpieza.