### PR TITLE
[Épica 16] Permite borrar facturas puntuales seguras

### DIFF
--- a/backend/src/controllers/gasto.controller.ts
+++ b/backend/src/controllers/gasto.controller.ts
@@ -428,6 +428,66 @@ export const actualizarGasto: express.RequestHandler = async (req, res) => {
   res.status(200).json(gastoActualizado);
 };
 
+export const eliminarGasto: express.RequestHandler = async (req, res) => {
+  const viviendaId = obtenerParamNumerico(req.params.viviendaId);
+  const gastoId = obtenerParamNumerico(req.params.gastoId);
+  const usuarioId = req.usuario!.id;
+
+  if (!Number.isInteger(viviendaId) || viviendaId <= 0) {
+    res.status(400).json({ error: 'viviendaId inválido.' });
+    return;
+  }
+
+  if (!Number.isInteger(gastoId) || gastoId <= 0) {
+    res.status(400).json({ error: 'gastoId inválido.' });
+    return;
+  }
+
+  const esCasero = await usuarioEsCaseroDeVivienda(viviendaId, usuarioId);
+
+  if (!esCasero) {
+    res.status(403).json({ error: 'Solo el casero puede borrar facturas de esta vivienda.' });
+    return;
+  }
+
+  const gasto = await prisma.gasto.findFirst({
+    where: { id: gastoId, vivienda_id: viviendaId, tipo: { in: [...TIPOS_GASTO_CASERO] } },
+    include: { deudas: true },
+  });
+
+  if (!gasto) {
+    res.status(404).json({ error: 'Factura no encontrada para esta vivienda.' });
+    return;
+  }
+
+  if (gasto.tipo !== 'FACTURA_PUNTUAL') {
+    res.status(400).json({
+      error: 'Solo se pueden borrar facturas puntuales creadas manualmente.',
+    });
+    return;
+  }
+
+  const tieneActividadDePago = gasto.deudas.some(
+    (deuda) => deuda.estado === 'PAGADA' || Boolean(deuda.justificante_url),
+  );
+
+  if (tieneActividadDePago) {
+    res.status(400).json({
+      error: 'Esta factura no puede borrarse porque ya tiene actividad de pago asociada.',
+    });
+    return;
+  }
+
+  await prisma.gasto.delete({
+    where: { id: gasto.id },
+  });
+
+  res.status(200).json({
+    ok: true,
+    gasto_id: gasto.id,
+  });
+};
+
 export const subirFacturaGasto: express.RequestHandler = async (req, res) => {
   const viviendaId = obtenerParamNumerico(req.params.viviendaId);
   const gastoId = obtenerParamNumerico(req.params.gastoId);

--- a/backend/src/routes/gasto.routes.ts
+++ b/backend/src/routes/gasto.routes.ts
@@ -7,6 +7,7 @@ import {
   listarGastos,
   crearGasto,
   actualizarGasto,
+  eliminarGasto,
   subirFacturaGasto,
   listarDeudas,
   saldarDeuda,
@@ -18,6 +19,7 @@ const gastosActivos = protegerModuloVivienda('gastos');
 router.get('/:viviendaId/gastos', verificarToken, gastosActivos, listarGastos);
 router.post('/:viviendaId/gastos', verificarToken, gastosActivos, uploadFacturaGasto.single('factura'), crearGasto);
 router.patch('/:viviendaId/gastos/:gastoId', verificarToken, gastosActivos, actualizarGasto);
+router.delete('/:viviendaId/gastos/:gastoId', verificarToken, gastosActivos, eliminarGasto);
 router.post(
   '/:viviendaId/gastos/:gastoId/factura',
   verificarToken,

--- a/backend/tests/economico.test.ts
+++ b/backend/tests/economico.test.ts
@@ -26,6 +26,9 @@ const prisma = vi.hoisted(() => ({
     create: async (_args: unknown): Promise<unknown> => {
       throw new Error('Unexpected prisma call: gasto.create');
     },
+    delete: async (_args: unknown): Promise<unknown> => {
+      throw new Error('Unexpected prisma call: gasto.delete');
+    },
     findMany: async (_args: unknown): Promise<unknown> => {
       throw new Error('Unexpected prisma call: gasto.findMany');
     },
@@ -55,6 +58,7 @@ const { crearGastoDividido } = await import('../src/services/gasto.service');
 const { crearCargosMensualesHabitacion } = await import('../src/services/gasto.service');
 const {
   actualizarGasto,
+  eliminarGasto,
   listarGastos,
   saldarDeuda,
 } = await import('../src/controllers/gasto.controller');
@@ -66,6 +70,7 @@ let ultimoGastoCreate: {
 let deudaUpdateCalls: unknown[] = [];
 let ultimoGastoFindMany: unknown = null;
 let ultimoGastoFindFirst: unknown = null;
+let ultimoGastoDelete: unknown = null;
 let ultimaDeudaFindMany: unknown = null;
 let transactionCalled = false;
 
@@ -74,6 +79,7 @@ function resetPrisma() {
   deudaUpdateCalls = [];
   ultimoGastoFindMany = null;
   ultimoGastoFindFirst = null;
+  ultimoGastoDelete = null;
   ultimaDeudaFindMany = null;
   transactionCalled = false;
 
@@ -106,6 +112,10 @@ function resetPrisma() {
   prisma.gasto.findFirst = async (args: unknown) => {
     ultimoGastoFindFirst = args;
     return null;
+  };
+  prisma.gasto.delete = async (args: unknown) => {
+    ultimoGastoDelete = args;
+    return { id: 1 };
   };
   prisma.deuda.findMany = async (args: unknown) => {
     ultimaDeudaFindMany = args;
@@ -552,5 +562,72 @@ describe('modulo economico', () => {
     ]);
     assert.equal((res.body as { modificado_por_id: number }).modificado_por_id, 99);
     assert.ok((res.body as { fecha_modificacion: Date }).fecha_modificacion instanceof Date);
+  });
+
+  test('permite borrar una factura puntual sin actividad de pago', async () => {
+    prisma.vivienda.findFirst = async () => ({ id: 1, casero_id: 99 });
+    prisma.gasto.findFirst = async () => ({
+      id: 12,
+      tipo: 'FACTURA_PUNTUAL',
+      deudas: [{ id: 20, deudor_id: 2, estado: 'PENDIENTE', justificante_url: null }],
+    });
+
+    const res = await invoke(
+      eliminarGasto,
+      request({
+        usuario: { id: 99, rol: 'CASERO' },
+        params: { viviendaId: '1', gastoId: '12' },
+      }),
+    );
+
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(ultimoGastoDelete, { where: { id: 12 } });
+    assert.deepEqual(res.body, { ok: true, gasto_id: 12 });
+  });
+
+  test('bloquea borrar una factura puntual con justificante asociado', async () => {
+    prisma.vivienda.findFirst = async () => ({ id: 1, casero_id: 99 });
+    prisma.gasto.findFirst = async () => ({
+      id: 12,
+      tipo: 'FACTURA_PUNTUAL',
+      deudas: [{ id: 20, deudor_id: 2, estado: 'PENDIENTE', justificante_url: 'https://ejemplo.test/justificante.jpg' }],
+    });
+
+    const res = await invoke(
+      eliminarGasto,
+      request({
+        usuario: { id: 99, rol: 'CASERO' },
+        params: { viviendaId: '1', gastoId: '12' },
+      }),
+    );
+
+    assert.equal(res.statusCode, 400);
+    assert.deepEqual(res.body, {
+      error: 'Esta factura no puede borrarse porque ya tiene actividad de pago asociada.',
+    });
+    assert.equal(ultimoGastoDelete, null);
+  });
+
+  test('bloquea borrar facturas no puntuales', async () => {
+    prisma.vivienda.findFirst = async () => ({ id: 1, casero_id: 99 });
+    prisma.gasto.findFirst = async () => ({
+      id: 12,
+      tipo: 'FACTURA_MENSUAL',
+      deudas: [],
+    });
+
+    const res = await invoke(
+      eliminarGasto,
+      request({
+        usuario: { id: 99, rol: 'CASERO' },
+        params: { viviendaId: '1', gastoId: '12' },
+      }),
+    );
+
+    assert.equal(res.statusCode, 400);
+    assert.deepEqual(res.body, {
+      error: 'Solo se pueden borrar facturas puntuales creadas manualmente.',
+    });
+    assert.equal(ultimoGastoDelete, null);
   });
 });

--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -1177,6 +1177,29 @@ Edita una factura mensual, factura puntual o cargo recurrente ya generado por el
 
 ---
 
+### DELETE `/viviendas/:viviendaId/gastos/:gastoId`
+
+Borra una factura puntual creada manualmente por el casero cuando todavia no existe actividad de pago asociada.
+
+**Auth requerida:** Si - `Authorization: Bearer <token>`
+
+**Reglas de acceso:**
+- Solo el `CASERO` propietario de la vivienda puede borrar facturas de la vivienda.
+- Solo admite gastos `FACTURA_PUNTUAL`.
+- El borrado se bloquea si alguna `Deuda` hija esta `PAGADA` o si existe `justificante_url` en alguna deuda.
+- Al borrar el `Gasto`, sus `Deuda[]` hijas se eliminan en cascada.
+
+**Respuestas:**
+
+| Codigo | Descripcion |
+|---|---|
+| `200` | Factura puntual eliminada correctamente. |
+| `400` | IDs invalidos, intento de borrar un tipo no permitido o factura con actividad de pago. |
+| `403` | No eres el casero propietario de la vivienda. |
+| `404` | Gasto no encontrado en esa vivienda. |
+
+---
+
 ### POST `/viviendas/:viviendaId/gastos/:gastoId/factura`
 
 Sube o reemplaza la imagen de factura adjunta a una factura o cargo del casero. No permite adjuntar facturas a gastos `ENTRE_COMPANEROS`.

--- a/docs/changelog/Epica16/epica-16-issue-279-borrar-facturas-puntuales.md
+++ b/docs/changelog/Epica16/epica-16-issue-279-borrar-facturas-puntuales.md
@@ -1,0 +1,18 @@
+# Epica 16 - Issue 279 - Borrar facturas puntuales sin pagos asociados
+
+## Objetivo
+
+Permitir al casero eliminar facturas puntuales creadas por error antes de que entren en flujo de pago, sin tocar facturas mensuales ni recibos que ya tengan actividad asociada.
+
+## Cambios
+
+- `backend/src/controllers/gasto.controller.ts`: añade el borrado seguro de facturas puntuales y bloquea la acción si existe cualquier pago registrado o justificante asociado.
+- `backend/src/routes/gasto.routes.ts`: registra `DELETE /api/viviendas/:viviendaId/gastos/:gastoId` protegido por token y modulo de gastos.
+- `backend/tests/economico.test.ts`: cubre borrado permitido, bloqueo por justificante y bloqueo para tipos de factura no incluidos en el alcance.
+- `frontend/app/casero/(tabs)/cobros.tsx`: incorpora confirmacion nativa, accion de eliminar dentro del modal de edicion y actualizacion inmediata del dashboard tras el borrado.
+- `frontend/styles/casero/cobros.styles.ts`: anade una nota destructiva suave para explicar cuando una factura puntual abierta puede borrarse.
+- `docs/backend/api.md`: documenta el endpoint y sus reglas de acceso.
+
+## Validacion
+
+- `npm test` en `backend`.

--- a/frontend/app/casero/(tabs)/cobros.tsx
+++ b/frontend/app/casero/(tabs)/cobros.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
+  Alert,
   KeyboardAvoidingView,
   Linking,
   Modal,
@@ -108,6 +109,7 @@ type FacturaEmitida = {
   id: number;
   concepto: string;
   importe: number;
+  tipo?: 'FACTURA_PUNTUAL' | 'FACTURA_MENSUAL' | 'CARGO_RECURRENTE';
   factura_url: string | null;
   fecha_creacion: string;
   fecha_modificacion: string | null;
@@ -136,6 +138,11 @@ type GastoActualizadoResponse = {
     importe: number;
     estado: 'PENDIENTE' | 'PAGADA';
   }[];
+};
+
+type EliminarGastoResponse = {
+  ok: boolean;
+  gasto_id: number;
 };
 
 type RepartoFacturaPuntualLinea = {
@@ -271,6 +278,7 @@ export default function CaseroCobrosScreen() {
   const [importeEditado, setImporteEditado] = useState('');
   const [fechaEditada, setFechaEditada] = useState('');
   const [guardandoFactura, setGuardandoFactura] = useState(false);
+  const [eliminandoFactura, setEliminandoFactura] = useState(false);
   const [subiendoFactura, setSubiendoFactura] = useState(false);
   const [inquilinosActivos, setInquilinosActivos] = useState<InquilinoActivo[]>([]);
   const [modalFacturaPuntualVisible, setModalFacturaPuntualVisible] = useState(false);
@@ -428,6 +436,7 @@ export default function CaseroCobrosScreen() {
         id: deuda.gasto.id,
         concepto: deuda.gasto.concepto,
         importe: deuda.gasto.importe,
+        tipo: deuda.gasto.tipo,
         factura_url: deuda.gasto.factura_url,
         fecha_creacion: deuda.gasto.fecha_creacion,
         fecha_modificacion: deuda.gasto.fecha_modificacion,
@@ -462,6 +471,11 @@ export default function CaseroCobrosScreen() {
   );
 
   const facturaTienePagos = facturaEditando?.deudas.some((deuda) => deuda.estado === 'PAGADA') ?? false;
+  const facturaTieneActividadPago =
+    facturaEditando?.deudas.some((deuda) => deuda.estado === 'PAGADA' || !!deuda.justificante_url) ??
+    false;
+  const facturaEsBorrable =
+    facturaEditando?.tipo === 'FACTURA_PUNTUAL' && !facturaTieneActividadPago;
 
   const cargarInquilinosActivos = useCallback(async (viviendaId: number) => {
     try {
@@ -718,7 +732,7 @@ export default function CaseroCobrosScreen() {
   };
 
   const cerrarEditorFactura = () => {
-    if (guardandoFactura) {
+    if (guardandoFactura || eliminandoFactura) {
       return;
     }
 
@@ -820,6 +834,68 @@ export default function CaseroCobrosScreen() {
         deudas: deudasActualizadas,
       };
     });
+  };
+
+  const quitarGastoDeCobros = (gastoId: number) => {
+    setResumen((resumenActual) => {
+      if (!resumenActual) {
+        return resumenActual;
+      }
+
+      const deudasActualizadas = resumenActual.deudas.filter((deuda) => deuda.gasto.id !== gastoId);
+
+      return {
+        ...resumenActual,
+        resumen: recalcularResumenCobros(deudasActualizadas),
+        deudas: deudasActualizadas,
+      };
+    });
+  };
+
+  const eliminarFactura = async () => {
+    if (!facturaEditando || !viviendaSeleccionadaId || !facturaEsBorrable) {
+      return;
+    }
+
+    setEliminandoFactura(true);
+    try {
+      const { data } = await api.delete<EliminarGastoResponse>(
+        `/viviendas/${viviendaSeleccionadaId}/gastos/${facturaEditando.id}`,
+      );
+
+      quitarGastoDeCobros(data.gasto_id);
+      setFacturaEditando(null);
+      setConceptoEditado('');
+      setImporteEditado('');
+      setFechaEditada('');
+      Toast.show({
+        type: 'success',
+        text1: 'Factura eliminada',
+        text2: 'La factura puntual ya no genera deuda pendiente.',
+      });
+    } catch (error: any) {
+      Toast.show({
+        type: 'error',
+        text1: error.response?.data?.error ?? 'No se pudo borrar la factura.',
+      });
+    } finally {
+      setEliminandoFactura(false);
+    }
+  };
+
+  const confirmarEliminarFactura = () => {
+    if (!facturaEditando || !facturaEsBorrable) {
+      return;
+    }
+
+    Alert.alert(
+      'Eliminar factura puntual',
+      `¿Quieres eliminar "${facturaEditando.concepto}"? Esta acción borrará la factura y sus cobros pendientes.`,
+      [
+        { text: 'Cancelar', style: 'cancel' },
+        { text: 'Eliminar', style: 'destructive', onPress: () => void eliminarFactura() },
+      ],
+    );
   };
 
   const subirFotoFactura = async () => {
@@ -1385,6 +1461,15 @@ export default function CaseroCobrosScreen() {
               </View>
             )}
 
+            {facturaEditando?.tipo === 'FACTURA_PUNTUAL' && !facturaTieneActividadPago && (
+              <View style={styles.dangerHint}>
+                <Ionicons name="trash-outline" size={18} color={theme.colors.danger} />
+                <Text style={styles.dangerHintText}>
+                  Esta factura puntual todavia puede borrarse porque no tiene pagos ni justificantes asociados.
+                </Text>
+              </View>
+            )}
+
             <View style={styles.editForm}>
               <CustomInput
                 label="Concepto"
@@ -1453,17 +1538,26 @@ export default function CaseroCobrosScreen() {
             </View>
 
             <View style={styles.modalActions}>
+              {facturaEsBorrable && (
+                <CustomButton
+                  label={eliminandoFactura ? 'Eliminando...' : 'Eliminar'}
+                  variant="danger"
+                  onPress={confirmarEliminarFactura}
+                  disabled={guardandoFactura || eliminandoFactura || subiendoFactura}
+                  style={styles.modalAction}
+                />
+              )}
               <CustomButton
                 label="Cancelar"
                 variant="secondary"
                 onPress={cerrarEditorFactura}
-                disabled={guardandoFactura}
+                disabled={guardandoFactura || eliminandoFactura}
                 style={styles.modalAction}
               />
               <CustomButton
                 label={guardandoFactura ? 'Guardando...' : 'Guardar'}
                 onPress={guardarFactura}
-                disabled={guardandoFactura}
+                disabled={guardandoFactura || eliminandoFactura}
                 style={styles.modalAction}
               />
             </View>
@@ -1527,6 +1621,10 @@ function FacturaCard({
 }) {
   const pagosRegistrados = factura.deudas.some((deuda) => deuda.estado === 'PAGADA');
   const pendientes = factura.deudas.filter((deuda) => deuda.estado === 'PENDIENTE').length;
+  const tieneActividadPago = factura.deudas.some(
+    (deuda) => deuda.estado === 'PAGADA' || !!deuda.justificante_url,
+  );
+  const puedeBorrarse = factura.tipo === 'FACTURA_PUNTUAL' && !tieneActividadPago;
 
   return (
     <View style={styles.invoiceCard}>
@@ -1574,6 +1672,10 @@ function FacturaCard({
           {pagosRegistrados ? 'Con pagos registrados' : `${pendientes} pendientes`}
         </Text>
       </View>
+
+      {puedeBorrarse && (
+        <Text style={styles.invoiceDeleteHint}>Factura puntual abierta: se puede eliminar desde editar.</Text>
+      )}
 
       {factura.factura_url && (
         <Pressable style={styles.receiptLink} onPress={() => onVerFactura(factura)}>

--- a/frontend/styles/casero/cobros.styles.ts
+++ b/frontend/styles/casero/cobros.styles.ts
@@ -254,6 +254,11 @@ export const createStyles = (theme: AppTheme = DefaultAppTheme) => StyleSheet.cr
     color: theme.colors.textTertiary,
     lineHeight: 18,
   },
+  invoiceDeleteHint: {
+    fontSize: theme.typography.caption,
+    fontWeight: '700',
+    color: theme.colors.danger,
+  },
   debtCard: {
     backgroundColor: theme.colors.surface,
     borderRadius: theme.radius.lg,
@@ -688,6 +693,24 @@ export const createStyles = (theme: AppTheme = DefaultAppTheme) => StyleSheet.cr
     marginBottom: theme.spacing.lg,
   },
   warningBannerText: {
+    flex: 1,
+    fontSize: theme.typography.label,
+    color: theme.colors.textMedium,
+    lineHeight: 20,
+    fontWeight: '600',
+  },
+  dangerHint: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: theme.spacing.sm,
+    backgroundColor: `${theme.colors.danger}14`,
+    borderRadius: theme.radius.lg,
+    borderWidth: 1,
+    borderColor: `${theme.colors.danger}30`,
+    padding: theme.spacing.base,
+    marginBottom: theme.spacing.lg,
+  },
+  dangerHintText: {
     flex: 1,
     fontSize: theme.typography.label,
     color: theme.colors.textMedium,


### PR DESCRIPTION
## Objetivo
Permitir al casero eliminar facturas puntuales creadas por error cuando todavía no existe actividad de pago asociada, sin afectar a facturas mensuales ni a recibos con pagos o justificantes.

## Cambios principales
* Añadido `DELETE /api/viviendas/:viviendaId/gastos/:gastoId` con validación de propietario, tipo `FACTURA_PUNTUAL` y bloqueo si hay pagos o justificantes asociados.
* Actualizados los tests del módulo económico para cubrir borrado permitido y casos bloqueados.
* Incorporada la acción de eliminar en el modal de edición del dashboard de cobros, con confirmación nativa y refresco inmediato del resumen.
* Documentado el endpoint y el nuevo comportamiento en la API y en el changelog del issue.

## UI / UX (Solo si aplica)
* Se ha añadido una advertencia destructiva suave y una acción de borrado con tokens de `Theme.ts`, manteniendo el estilo de cards y modales existente.

## Changelog
* `docs/changelog/Epica16/epica-16-issue-279-borrar-facturas-puntuales.md`

## Testing
* Tests unitarios del módulo económico para el backend.
* Validación local del frontend con lint.
* Build del backend para verificar el nuevo endpoint y tipado.