### PR TITLE
[Épica 17] Corrige limpieza por habitaciones

### DIFF
--- a/backend/src/controllers/limpieza.controller.ts
+++ b/backend/src/controllers/limpieza.controller.ts
@@ -506,18 +506,20 @@ export const asignarZonaFija: express.RequestHandler = async (req, res) => {
     return;
   }
 
-  if (habitacion_ids.length > 0) {
+  const habitacionIdsUnicos = [...new Set(habitacion_ids)];
+
+  if (habitacionIdsUnicos.length > 0) {
     const habitaciones = await prisma.habitacion.findMany({
       where: {
         vivienda_id: viviendaId,
-        id: { in: habitacion_ids },
+        id: { in: habitacionIdsUnicos },
         es_habitable: true,
         tipo: TipoHabitacion.DORMITORIO,
       },
       select: { id: true },
     });
     const validos = new Set(habitaciones.map((habitacion) => habitacion.id));
-    const invalidos = habitacion_ids.filter((habitacionId) => !validos.has(habitacionId));
+    const invalidos = habitacionIdsUnicos.filter((habitacionId) => !validos.has(habitacionId));
     if (invalidos.length > 0) {
       res.status(403).json({ error: 'Una o mas habitaciones no pueden ser responsables fijas.' });
       return;
@@ -526,9 +528,9 @@ export const asignarZonaFija: express.RequestHandler = async (req, res) => {
 
   const asignaciones = await prisma.$transaction(async (tx) => {
     await tx.asignacionLimpiezaFija.deleteMany({ where: { zona_id: zonaId } });
-    if (habitacion_ids.length === 0) return [];
+    if (habitacionIdsUnicos.length === 0) return [];
     await tx.asignacionLimpiezaFija.createMany({
-      data: habitacion_ids.map((habitacionId) => ({ zona_id: zonaId, habitacion_id: habitacionId })),
+      data: habitacionIdsUnicos.map((habitacionId) => ({ zona_id: zonaId, habitacion_id: habitacionId })),
     });
     return tx.asignacionLimpiezaFija.findMany({
       where: { zona_id: zonaId },
@@ -599,13 +601,12 @@ export const quitarAsignacionFija: express.RequestHandler = async (req, res) => 
     return;
   }
 
-  const asignacion = await prisma.asignacionLimpiezaFija.findFirst({ where: { zona_id: zonaId } });
-  if (!asignacion) {
+  const resultado = await prisma.asignacionLimpiezaFija.deleteMany({ where: { zona_id: zonaId } });
+  if (resultado.count === 0) {
     res.status(404).json({ error: 'Esta zona no tiene asignacion fija.' });
     return;
   }
 
-  await prisma.asignacionLimpiezaFija.delete({ where: { id: asignacion.id } });
   res.status(204).send();
 };
 

--- a/backend/src/services/limpieza.service.ts
+++ b/backend/src/services/limpieza.service.ts
@@ -80,11 +80,6 @@ export async function generarTurnosSemanales(viviendaId: number): Promise<void> 
     throw new Error('No hay habitaciones habitables en la vivienda.');
   }
 
-  const habitacionesActivas = habitacionesResponsables.filter(esHabitacionOcupadaActiva);
-  if (habitacionesActivas.length === 0) {
-    throw new Error('No hay habitaciones ocupadas activas para repartir la limpieza.');
-  }
-
   const zonas = await prisma.zonaLimpieza.findMany({
     where: { vivienda_id: viviendaId, activa: true },
     include: {
@@ -111,7 +106,8 @@ export async function generarTurnosSemanales(viviendaId: number): Promise<void> 
     throw new Error('No hay zonas activas en la vivienda.');
   }
 
-  const habitacionesActivasIds = new Set(habitacionesActivas.map((habitacion) => habitacion.id));
+  const habitacionesActivas = habitacionesResponsables.filter(esHabitacionOcupadaActiva);
+  const habitacionesResponsablesIds = new Set(habitacionesResponsables.map((habitacion) => habitacion.id));
   const cargaSemanal = new Map<number, number>(habitacionesResponsables.map((habitacion) => [habitacion.id, 0]));
 
   type TurnoData = {
@@ -130,7 +126,7 @@ export async function generarTurnosSemanales(viviendaId: number): Promise<void> 
     const asignadasActivas = zona.asignaciones_fijas
       .map((asignacion) => asignacion.habitacion)
       .filter((habitacion): habitacion is typeof habitacion & HabitacionResponsable => Boolean(habitacion))
-      .filter((habitacion) => habitacionesActivasIds.has(habitacion.id));
+      .filter((habitacion) => habitacionesResponsablesIds.has(habitacion.id));
 
     if (asignadasActivas.length > 0) {
       let elegida = asignadasActivas[0];
@@ -159,6 +155,10 @@ export async function generarTurnosSemanales(viviendaId: number): Promise<void> 
     zonasRotativas.push(zona);
   }
 
+  if (zonasRotativas.length > 0 && habitacionesActivas.length === 0) {
+    throw new Error('No hay habitaciones ocupadas activas para repartir la limpieza rotativa.');
+  }
+
   for (const zona of zonasRotativas) {
     let elegida = habitacionesActivas[0];
     let menorCarga = cargaEfectivaHabitacion(elegida, cargaSemanal);
@@ -184,8 +184,12 @@ export async function generarTurnosSemanales(viviendaId: number): Promise<void> 
 
   const habitacionesConBalance = habitacionesActivas.filter((habitacion) => habitacion.inquilino !== null);
 
-  const pesoTotal = zonas.reduce((acc, zona) => acc + zona.peso, 0);
-  const cuotaIdeal = pesoTotal / habitacionesConBalance.length;
+  const pesoConResponsableActual = turnos.reduce((acc, turno) => {
+    const habitacion = habitacionesConBalance.find((item) => item.id === turno.habitacion_id);
+    const zona = zonas.find((item) => item.id === turno.zona_id);
+    return habitacion && zona ? acc + zona.peso : acc;
+  }, 0);
+  const cuotaIdeal = habitacionesConBalance.length > 0 ? pesoConResponsableActual / habitacionesConBalance.length : 0;
 
   const actualizacionesBalance = habitacionesConBalance.map((habitacion) => {
     const cargaAsignada = cargaSemanal.get(habitacion.id) ?? 0;

--- a/backend/tests/limpieza.service.test.ts
+++ b/backend/tests/limpieza.service.test.ts
@@ -152,4 +152,100 @@ describe('generacion de turnos de limpieza', () => {
     );
     assert.equal(createManyArgs, null);
   });
+
+  test('mantiene asignaciones fijas a habitaciones vacias sin moverlas a otro inquilino', async () => {
+    prisma.habitacion.findMany = async () => [
+      {
+        id: 101,
+        nombre: 'Habitacion ocupada',
+        tipo: 'DORMITORIO',
+        es_habitable: true,
+        inquilino: { id: 1, balance_limpieza: 0, estado_presencia: 'ACTIVO' },
+      },
+      {
+        id: 102,
+        nombre: 'Habitacion vacia',
+        tipo: 'DORMITORIO',
+        es_habitable: true,
+        inquilino: null,
+      },
+    ];
+    prisma.zonaLimpieza.findMany = async () => [
+      {
+        id: 10,
+        peso: 6,
+        asignaciones_fijas: [
+          {
+            habitacion: {
+              id: 102,
+              nombre: 'Habitacion vacia',
+              tipo: 'DORMITORIO',
+              es_habitable: true,
+              inquilino: null,
+            },
+          },
+        ],
+      },
+      { id: 11, peso: 3, asignaciones_fijas: [] },
+    ];
+
+    await generarTurnosSemanales(10);
+
+    assert.deepEqual(
+      createManyArgs?.data.map((turno) => ({
+        usuario_id: turno.usuario_id,
+        habitacion_id: turno.habitacion_id,
+        zona_id: turno.zona_id,
+      })),
+      [
+        { usuario_id: null, habitacion_id: 102, zona_id: 10 },
+        { usuario_id: 1, habitacion_id: 101, zona_id: 11 },
+      ],
+    );
+    assert.deepEqual(usuarioUpdateCalls, [
+      { where: { id: 1 }, data: { balance_limpieza: 0 } },
+    ]);
+  });
+
+  test('permite generar solo tareas fijas de habitaciones vacias sin balances', async () => {
+    prisma.habitacion.findMany = async () => [
+      {
+        id: 101,
+        nombre: 'Habitacion vacia',
+        tipo: 'DORMITORIO',
+        es_habitable: true,
+        inquilino: null,
+      },
+    ];
+    prisma.zonaLimpieza.findMany = async () => [
+      {
+        id: 10,
+        peso: 6,
+        asignaciones_fijas: [
+          {
+            habitacion: {
+              id: 101,
+              nombre: 'Habitacion vacia',
+              tipo: 'DORMITORIO',
+              es_habitable: true,
+              inquilino: null,
+            },
+          },
+        ],
+      },
+    ];
+
+    await generarTurnosSemanales(10);
+
+    assert.deepEqual(
+      createManyArgs?.data.map((turno) => ({
+        usuario_id: turno.usuario_id,
+        habitacion_id: turno.habitacion_id,
+        zona_id: turno.zona_id,
+      })),
+      [{ usuario_id: null, habitacion_id: 101, zona_id: 10 }],
+    );
+    assert.deepEqual(usuarioUpdateCalls, []);
+    assert.equal(transactionArgs?.length, 1);
+  });
 });

--- a/docs/changelog/Epica17/epica-17-issue-283-bugfix-limpieza-habitaciones.md
+++ b/docs/changelog/Epica17/epica-17-issue-283-bugfix-limpieza-habitaciones.md
@@ -1,0 +1,19 @@
+# Epica 17 - Issue 283 - Bugfix limpieza por habitaciones
+
+## Objetivo
+
+Corregir regresiones del modulo de limpieza tras orientarlo a habitaciones responsables en lugar de inquilinos.
+
+## Cambios principales
+
+- `backend/src/services/limpieza.service.ts`: las asignaciones fijas a habitaciones habitables generan turno aunque la habitacion este vacia, conservando `usuario_id` como snapshot nulo.
+- `backend/src/services/limpieza.service.ts`: los balances solo consideran el peso de turnos con responsable actual, evitando que una habitacion vacia altere la cuota de inquilinos activos.
+- `backend/src/controllers/limpieza.controller.ts`: el endpoint de asignaciones fijas deduplica habitaciones y el borrado legacy elimina todas las asignaciones de la zona.
+- `frontend/app/casero/vivienda/[id]/(tabs)/limpieza.tsx` y `frontend/app/inquilino/(tabs)/limpieza.tsx`: las pantallas toleran turnos o asignaciones con relacion `habitacion` parcial y usan `habitacion_id` como fallback para evitar crashes al leer `inquilino`.
+- `backend/tests/limpieza.service.test.ts`: se cubren habitaciones vacias con asignacion fija y semanas sin ocupantes cuando solo hay tareas fijas.
+
+## Verificacion
+
+- `npm test -- limpieza.service.test.ts operational-modules.test.ts` en `backend/`
+- `npm run build` en `backend/`
+- `npm run lint` en `frontend/`

--- a/frontend/app/casero/vivienda/[id]/(tabs)/limpieza.tsx
+++ b/frontend/app/casero/vivienda/[id]/(tabs)/limpieza.tsx
@@ -105,7 +105,7 @@ type Habitacion = {
 type AsignacionFija = {
   id: number;
   habitacion_id: number;
-  habitacion: Habitacion;
+  habitacion?: Habitacion | null;
   responsable_actual: ResponsableActual;
 };
 
@@ -129,7 +129,7 @@ type Turno = {
   estado: 'PENDIENTE' | 'HECHO' | 'NO_HECHO';
   tipo_espacio: 'HABITACION' | 'ZONA_COMUN' | 'ESPACIO';
   zona: { id: number; nombre: string; peso: number; habitacion: Habitacion | null };
-  habitacion: Habitacion;
+  habitacion?: Habitacion | null;
   responsable_actual: ResponsableActual;
 };
 
@@ -155,6 +155,9 @@ const getTipoEspacioLabel = (tipo: ZonaLimpieza['tipo_espacio']) => {
 
 const getResponsableLabel = (responsable: ResponsableActual) =>
   responsable ? `${responsable.nombre}${responsable.apellidos ? ` ${responsable.apellidos}` : ''}` : 'Sin ocupante';
+
+const getNombreHabitacion = (habitacion: Habitacion | null | undefined, fallback = 'Habitacion') =>
+  habitacion?.nombre ?? fallback;
 
 export default function LimpiezaCaseroTab() {
   const id = useViviendaIdParam();
@@ -474,7 +477,9 @@ export default function LimpiezaCaseroTab() {
     const asignaciones = item.asignaciones_fijas ?? [];
     const etiquetaFijos =
       asignaciones.length > 0
-        ? `Responsables fijas: ${asignaciones.map((asignacion) => asignacion.habitacion.nombre).join(', ')}`
+        ? `Responsables fijas: ${asignaciones
+            .map((asignacion) => getNombreHabitacion(asignacion.habitacion, `Habitacion ${asignacion.habitacion_id}`))
+            .join(', ')}`
         : null;
 
     return (
@@ -532,10 +537,20 @@ export default function LimpiezaCaseroTab() {
       return <ActivityIndicator style={{ flex: 1, marginTop: 40 }} size="large" color={theme.colors.primary} />;
     }
 
+    const getHabitacionTurno = (turno: Turno) =>
+      turno.habitacion ??
+      habitaciones.find((habitacion) => habitacion.id === turno.habitacion_id) ?? {
+        id: turno.habitacion_id,
+        nombre: `Habitacion ${turno.habitacion_id}`,
+        tipo: 'DORMITORIO',
+        es_habitable: true,
+        inquilino: null,
+      };
     const turnosFiltrados = turnos.filter((turno) => (filtroEstado === 'TODOS' ? true : turno.estado === filtroEstado));
     const turnosAgrupados = turnosFiltrados.reduce<Record<number, { habitacion: Habitacion; items: Turno[] }>>((acc, turno) => {
+      const habitacionTurno = getHabitacionTurno(turno);
       if (!acc[turno.habitacion_id]) {
-        acc[turno.habitacion_id] = { habitacion: turno.habitacion, items: [] };
+        acc[turno.habitacion_id] = { habitacion: habitacionTurno, items: [] };
       }
       acc[turno.habitacion_id].items.push(turno);
       return acc;

--- a/frontend/app/inquilino/(tabs)/limpieza.tsx
+++ b/frontend/app/inquilino/(tabs)/limpieza.tsx
@@ -70,7 +70,7 @@ type Turno = {
   estado: 'PENDIENTE' | 'HECHO' | 'NO_HECHO';
   tipo_espacio: 'HABITACION' | 'ZONA_COMUN' | 'ESPACIO';
   zona: { id: number; nombre: string; peso: number; habitacion: Habitacion | null };
-  habitacion: Habitacion;
+  habitacion?: Habitacion | null;
   responsable_actual: { id: number; nombre: string; apellidos: string | null } | null;
 };
 
@@ -79,6 +79,8 @@ const getTipoEspacioLabel = (tipo: Turno['tipo_espacio']) => {
   if (tipo === 'ZONA_COMUN') return 'Zona común';
   return 'Espacio';
 };
+
+const getHabitacionNombre = (turno: Turno) => turno.habitacion?.nombre ?? `Habitacion ${turno.habitacion_id}`;
 
 export default function LimpiezaInquilinoTab() {
   const { theme } = useAppTheme();
@@ -262,7 +264,7 @@ export default function LimpiezaInquilinoTab() {
             {turnosRelacionados.map((turno) => {
               const esPendiente = turno.estado === 'PENDIENTE';
               const nombreResponsable =
-                turno.responsable_actual?.nombre ?? turno.habitacion.nombre;
+                turno.responsable_actual?.nombre ?? getHabitacionNombre(turno);
               const apellidosResponsable = turno.responsable_actual?.apellidos ?? null;
               return (
                 <View key={turno.id} style={styles.companeroRow}>


### PR DESCRIPTION
## Objetivo
Corrige la regresión del módulo de limpieza tras reorientarlo a habitaciones responsables, evitando crashes cuando alguna respuesta llegue sin la relación `habitacion` cargada y manteniendo el histórico aunque una habitación quede vacía.

## Cambios principales
* `backend/src/services/limpieza.service.ts`: permite generar turnos fijos para habitaciones vacías y limita los balances a tareas con ocupante actual.
* `backend/src/controllers/limpieza.controller.ts`: deduplica `habitacion_ids` al asignar responsables fijos y elimina todas las asignaciones de una zona en el borrado legacy.
* `backend/tests/limpieza.service.test.ts`: añade cobertura para habitaciones vacías con asignación fija y semanas con tareas exclusivamente fijas.
* `frontend/app/casero/vivienda/[id]/(tabs)/limpieza.tsx` y `frontend/app/inquilino/(tabs)/limpieza.tsx`: añaden fallback por `habitacion_id` para evitar el `TypeError: Cannot read property 'inquilino' of undefined`.

## UI / UX (Solo si aplica)
* La pantalla de limpieza tolera respuestas parciales sin romper el calendario ni las etiquetas de responsables.

## Changelog
* `docs/changelog/Epica17/epica-17-issue-283-bugfix-limpieza-habitaciones.md`