### PR TITLE
[Épica 17] Ajusta la posición del cuadro del tutorial

### DIFF
--- a/frontend/app/__tests__/_layout.test.tsx
+++ b/frontend/app/__tests__/_layout.test.tsx
@@ -12,6 +12,7 @@ jest.mock('expo-router', () => {
     Stack: function MockStack() {
       return null;
     },
+    usePathname: () => '/',
     useRouter: () => ({ replace: mockReplace }),
   };
 });

--- a/frontend/contexts/TutorialContext.tsx
+++ b/frontend/contexts/TutorialContext.tsx
@@ -22,10 +22,18 @@ import {
 const TUTORIAL_STATE_KEY = `roomies.tutorial.${TUTORIAL_VERSION}`;
 const HIGHLIGHT_PADDING = 12;
 const CARD_MAX_WIDTH = 380;
+const CARD_ESTIMATED_HEIGHT = 280;
 
 type TargetRect = {
   x: number;
   y: number;
+  width: number;
+  height: number;
+};
+
+type HighlightRect = {
+  top: number;
+  left: number;
   width: number;
   height: number;
 };
@@ -328,6 +336,7 @@ function TutorialOverlay({
   theme: AppTheme;
 }) {
   const { width, height } = useWindowDimensions();
+  const [cardHeight, setCardHeight] = useState(0);
 
   if (!auth || !preferencesLoaded || !session) {
     return null;
@@ -345,6 +354,14 @@ function TutorialOverlay({
         height: Math.min(currentTarget.height + HIGHLIGHT_PADDING * 2, height),
       }
     : null;
+  const measuredCardHeight = cardHeight || CARD_ESTIMATED_HEIGHT;
+  const cardTop = getCardTop({
+    highlight,
+    screenHeight: height,
+    cardHeight: measuredCardHeight,
+    edgeMargin: theme.spacing.xl,
+    gap: theme.spacing.base,
+  });
 
   const nextStep = () => {
     if (isLastStep) {
@@ -438,8 +455,11 @@ function TutorialOverlay({
           <View style={[overlayStyles.dim, StyleSheet.absoluteFillObject]} />
         )}
 
-        <View style={overlayStyles.cardContainer} pointerEvents="box-none">
-          <View style={overlayStyles.card}>
+        <View style={[overlayStyles.cardContainer, { top: cardTop }]} pointerEvents="box-none">
+          <View
+            style={overlayStyles.card}
+            onLayout={({ nativeEvent }) => setCardHeight(nativeEvent.layout.height)}
+          >
             <View style={overlayStyles.cardHeader}>
               <Text style={overlayStyles.stepCounter}>
                 Paso {session.index + 1} de {session.steps.length}
@@ -495,11 +515,40 @@ function TutorialOverlay({
   );
 }
 
+function getCardTop({
+  highlight,
+  screenHeight,
+  cardHeight,
+  edgeMargin,
+  gap,
+}: {
+  highlight: HighlightRect | null;
+  screenHeight: number;
+  cardHeight: number;
+  edgeMargin: number;
+  gap: number;
+}) {
+  const minTop = edgeMargin;
+  const maxTop = Math.max(edgeMargin, screenHeight - cardHeight - edgeMargin);
+
+  if (!highlight) {
+    return maxTop;
+  }
+
+  const spaceAbove = highlight.top;
+  const spaceBelow = screenHeight - (highlight.top + highlight.height);
+  const placeAbove = spaceBelow < cardHeight + gap && spaceAbove > spaceBelow;
+  const desiredTop = placeAbove
+    ? highlight.top - cardHeight - gap
+    : highlight.top + highlight.height + gap;
+
+  return Math.min(Math.max(desiredTop, minTop), maxTop);
+}
+
 const createOverlayStyles = (theme: AppTheme = DefaultAppTheme) =>
   StyleSheet.create({
     root: {
       flex: 1,
-      justifyContent: 'flex-end',
     },
     dim: {
       position: 'absolute',
@@ -513,10 +562,12 @@ const createOverlayStyles = (theme: AppTheme = DefaultAppTheme) =>
       backgroundColor: 'transparent',
     },
     cardContainer: {
+      position: 'absolute',
+      left: 0,
+      right: 0,
       width: '100%',
       alignItems: 'center',
       paddingHorizontal: theme.spacing.base,
-      paddingBottom: theme.spacing.xl,
     },
     card: {
       width: '100%',


### PR DESCRIPTION
## Objetivo
Evita que el cuadro de texto del tutorial tape el elemento que se está explicando. La tarjeta ahora se recoloca automáticamente arriba o abajo del foco según el espacio disponible en pantalla.

## Cambios principales
* El overlay del tutorial calcula la posición vertical de la tarjeta en función del rectángulo resaltado y del alto disponible.
* La tarjeta se mide en tiempo real para poder decidir si conviene mostrarla arriba o abajo del objetivo.
* Se mantiene la tarjeta dentro de los límites visibles de la pantalla para evitar cortes en bordes superior e inferior.
* Se actualiza el test de `RootLayout` para mockear `usePathname` de `expo-router`, que ahora usa `TutorialProvider`.

## UI / UX (Solo si aplica)
* Se elimina el anclaje fijo al pie de pantalla para que la ayuda acompañe mejor al contenido que explica.
* Se conserva el estilo visual existente del tutorial sin cambiar tokens ni la identidad de la interfaz.

## Testing
* `npm test` en `frontend`: 10 suites y 29 tests superados.
* `npm run lint` en `frontend`: sin errores, con warnings preexistentes fuera de este cambio.

## Changelog
* No se actualizó ningún archivo en `changelog/` en este cambio.