### PR TITLE
[Épica Infra] Usa Docker en desarrollo y Railway solo en main

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,8 @@ CLOUDINARY_API_SECRET=tu_api_secret
 # Necesario para que Docker autentique el CLI de Expo como tu cuenta (@usuario)
 EXPO_TOKEN=tu_expo_access_token_aqui
 
-# Base de datos demo (opcional)
-# true reinicia la BD del contenedor y ejecuta seed al arrancar backend.
-RESET_DB=false
+# Base de datos demo
+# Docker Compose reinicia la BD y ejecuta seed en cada arranque de dev.bat.
+SEED_CASERO_PASSWORD=pass
+SEED_INQUILINO_PASSWORD=pass
+SEED_DEMO_DOMAIN=example.test

--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@ BACKEND_URL=http://localhost:3001
 
 # — IP local (solo necesario para Docker + Expo Go en dispositivo físico) —
 # ipconfig → IPv4 del adaptador Wi-Fi  /  ifconfig en Mac/Linux
-# No es necesario si usas el servidor de desarrollo de Railway
+# No es necesario si usas solo navegador/emulador en la misma maquina.
 HOST_IP=192.168.1.X
 
 # API consumida por Expo

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -434,17 +434,17 @@ CLOUDINARY_API_SECRET=<api_secret de Cloudinary>
 
 ### `frontend/.env` (leído por Metro en tiempo de compilación)
 
-El proyecto tiene tres entornos de API — descomenta el que quieras usar:
+El flujo de desarrollo usa Docker local. Railway queda reservado para produccion desde `main`:
 
 ```
-# Desarrollo en Railway (por defecto)
-EXPO_PUBLIC_API_URL=https://roomies-dev.up.railway.app/api
+# Desarrollo local con Docker Compose
+EXPO_PUBLIC_API_URL=http://localhost:3001/api
+
+# Expo Go en movil fisico con Docker Compose
+#EXPO_PUBLIC_API_URL=http://<HOST_IP>:3001/api
 
 # Producción en Railway
 #EXPO_PUBLIC_API_URL=https://roomies-production-c884.up.railway.app/api
-
-# Local con Docker Compose
-#EXPO_PUBLIC_API_URL=http://<HOST_IP>:3001/api
 
 EXPO_PUBLIC_MAPBOX_TOKEN=<token Mapbox>
 EXPO_PUBLIC_GOOGLE_CLIENT_ID=<Web Client ID>
@@ -460,28 +460,28 @@ EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=<iOS Client ID o vacío>
 Cada subcarpeta tiene su propio `.env.example` con todos los campos documentados:
 - `.env.example` — raíz (Docker Compose)
 - `backend/.env.example` — backend local / Railway
-- `frontend/.env.example` — frontend con los tres entornos de API comentados
+- `frontend/.env.example` — frontend con Docker local por defecto y Railway produccion comentado
 
 ---
 
-## Railway, Expo Go y Docker
+## Docker, Expo Go y Railway
 
-El testeo funcional diario se hace levantando Expo Go contra Railway desarrollo:
+El testeo funcional diario se hace con Docker Compose local:
 
-1. `frontend/.env` apunta a `EXPO_PUBLIC_API_URL=https://roomies-dev.up.railway.app/api`.
-2. Se ejecuta `npx expo start --clear` en `frontend`.
-3. La app se abre desde Expo Go.
+1. `.env` define PostgreSQL, secretos, `HOST_IP` y `EXPO_PUBLIC_API_URL`.
+2. Se ejecuta `.\dev.bat` desde la raiz, que valida `.env` y lanza `docker compose up --build`.
+3. La app se abre desde Expo Go usando Metro en `http://localhost:8080`.
 
-El backend usa dos servicios Railway: desarrollo para pruebas y produccion para releases. `backend/Dockerfile` existe para que Railway construya la imagen del backend.
+Railway queda reservado para produccion y debe desplegar desde `main`. `backend/Dockerfile` existe para que Railway construya la imagen del backend.
 
 El `backend/Dockerfile` ejecuta:
 
 1. `npm run build` durante la construccion de la imagen.
 2. `npm start` al arrancar el contenedor.
 
-`npm start` ejecuta `node scripts/start.js`: aplica `npx prisma db push --accept-data-loss`, ejecuta `npx prisma db seed` automaticamente en Railway desarrollo y levanta `node dist/index.js`.
+`npm start` ejecuta `node scripts/start.js`: aplica `npx prisma db push --accept-data-loss` y levanta `node dist/index.js`. Solo ejecuta seed si `ROOMIES_SEED_ON_START=true`.
 
-`docker-compose.yml` queda como apoyo opcional para revisar infraestructura local. En ese modo, el servicio backend sobreescribe el comando de la imagen Railway y ejecuta:
+`docker-compose.yml` es el flujo principal de desarrollo. En ese modo, el servicio backend sobreescribe el comando de la imagen Railway y ejecuta:
 
 1. `npx prisma generate` - regenera el cliente despues del bind mount.
 2. `npx prisma db push --accept-data-loss` - aplica el schema.
@@ -688,10 +688,10 @@ Usuarios de prueba creados por `prisma db seed`:
 
 - `docker-compose.yml` deja de fijar la API del frontend a produccion y consume `EXPO_PUBLIC_API_URL` desde `.env`.
 - `backend/Dockerfile` queda orientado a Railway: compila con `npm run build` y arranca con `npm start`.
-- `backend/scripts/start.js` aplica el schema y recupera el seed automatico en Railway desarrollo sin habilitarlo en produccion.
+- `backend/scripts/start.js` aplica el schema al arrancar la imagen Railway de produccion.
 - `docker-compose.yml` mantiene un comando de desarrollo propio para regenerar Prisma Client y arrancar con nodemon solo cuando se use Compose.
 - `.env.example`, `backend/.env.example` y `frontend/.env.example` documentan variables obligatorias, opcionales, URLs locales y tokens por entorno.
-- `docs/infra/setup-despliegue.md` concentra el flujo Railway desarrollo + Expo Go, Dockerfile, Compose auxiliar y comandos de build/test/lint.
+- `docs/infra/setup-despliegue.md` concentra el flujo Docker Compose + Expo Go, Dockerfile Railway de produccion y comandos de build/test/lint.
 
 ## Update 2026-04-12 - Epica 16 issue 257
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -469,7 +469,8 @@ Cada subcarpeta tiene su propio `.env.example` con todos los campos documentados
 El testeo funcional diario se hace con Docker Compose local:
 
 1. `.env` define PostgreSQL, secretos, `HOST_IP` y `EXPO_PUBLIC_API_URL`.
-2. Se ejecuta `.\dev.bat` desde la raiz, que valida `.env`, lanza `docker compose up --build -d` y arranca `npx expo start --clear` en `frontend`.
+2. Se ejecuta `.\dev.bat` desde la raiz, que valida `.env`, lanza `docker compose up --build -d --force-recreate`, espera a `/ping` y arranca `npx expo start --clear` en `frontend`.
+   - El backend de Compose reinicia la BD con `prisma db push --force-reset` y ejecuta seed antes de `npm run dev`.
 3. La app se abre desde Expo Go usando el QR de Expo local.
 
 Railway queda reservado para produccion y debe desplegar desde `main`. `backend/Dockerfile` existe para que Railway construya la imagen del backend.
@@ -487,7 +488,7 @@ El `backend/Dockerfile` ejecuta:
 2. `npx prisma db push --accept-data-loss` - aplica el schema.
 3. `npm run dev` - arranca el servidor con nodemon.
 
-Si `RESET_DB=true`, sustituye el `db push --accept-data-loss` por `db push --force-reset` y ejecuta `npx prisma db seed` antes de arrancar.
+La BD local se reinicia y se siembra siempre al arrancar con `dev.bat`.
 
 **Puertos**: PostgreSQL en `5433:5432`, backend en `3001:3000`, frontend en `8080:8080`.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -469,8 +469,8 @@ Cada subcarpeta tiene su propio `.env.example` con todos los campos documentados
 El testeo funcional diario se hace con Docker Compose local:
 
 1. `.env` define PostgreSQL, secretos, `HOST_IP` y `EXPO_PUBLIC_API_URL`.
-2. Se ejecuta `.\dev.bat` desde la raiz, que valida `.env` y lanza `docker compose up --build`.
-3. La app se abre desde Expo Go usando Metro en `http://localhost:8080`.
+2. Se ejecuta `.\dev.bat` desde la raiz, que valida `.env`, lanza `docker compose up --build -d` y arranca `npx expo start --clear` en `frontend`.
+3. La app se abre desde Expo Go usando el QR de Expo local.
 
 Railway queda reservado para produccion y debe desplegar desde `main`. `backend/Dockerfile` existe para que Railway construya la imagen del backend.
 

--- a/README.md
+++ b/README.md
@@ -57,31 +57,45 @@ Aplicacion movil para gestionar pisos compartidos. Conecta a caseros e inquilino
 - [ ] Chat integrado Inquilino <-> Casero
 - [ ] Notificaciones push avanzadas para incidencias y cambios de estado
 
-## Entornos Railway
+## Entornos
 
 | Entorno | URL de API |
 |---|---|
-| Desarrollo | `https://roomies-dev.up.railway.app/api` |
-| Produccion | `https://roomies-production-c884.up.railway.app/api` |
+| Desarrollo local Docker | `http://localhost:3001/api` |
+| Produccion Railway | `https://roomies-production-c884.up.railway.app/api` |
 
-## Testeo habitual con Expo Go y Railway dev
+## Testeo habitual con Docker y Expo Go
 
 ### Prerrequisitos
 
 - Node.js 20+
+- Docker Desktop
 - Expo Go instalado en el movil
-- Backend desplegado en Railway desarrollo
 
 ### Pasos
 
-1. Copia `frontend/.env.example` a `frontend/.env`.
-2. Usa Railway desarrollo como API:
+1. Copia `.env.example` a `.env` y ajusta `HOST_IP` si vas a probar en movil fisico.
+2. Levanta PostgreSQL, backend y Metro con Docker Compose:
 
-```env
-EXPO_PUBLIC_API_URL=https://roomies-dev.up.railway.app/api
+```bash
+.\dev.bat
 ```
 
-3. Arranca Expo con cache limpia:
+El script ejecuta `docker compose up --build` desde la raiz y comprueba que exista `.env`.
+
+3. Usa Docker local como API en `frontend/.env` si arrancas Expo fuera de Compose:
+
+```env
+EXPO_PUBLIC_API_URL=http://localhost:3001/api
+```
+
+Para Expo Go en movil fisico, usa la IP LAN:
+
+```env
+EXPO_PUBLIC_API_URL=http://192.168.1.X:3001/api
+```
+
+4. Si prefieres Metro fuera del contenedor:
 
 ```bash
 cd frontend
@@ -89,15 +103,17 @@ npm install
 npx expo start --clear
 ```
 
-4. Abre el QR con Expo Go.
+5. Abre el QR con Expo Go.
 
-> Hay dos entornos Railway: desarrollo para pruebas funcionales y produccion para releases.
+> Railway queda reservado para produccion desde `main`; no debe usarse como backend de desarrollo diario.
 
 ## Docker y Railway
 
-El `backend/Dockerfile` se usa para que Railway construya la imagen del backend. El contenedor compila con `npm run build`; al arrancar ejecuta `npm start`, que aplica `prisma db push --accept-data-loss`, ejecuta el seed automaticamente en Railway desarrollo y levanta `dist/index.js`.
+El desarrollo diario usa `docker-compose.yml`, que levanta PostgreSQL, backend en `http://localhost:3001` y Metro en `http://localhost:8080`.
 
-`docker-compose.yml` queda como apoyo para revisar infraestructura local si hace falta, pero no es el flujo habitual de testeo.
+En Windows, `dev.bat` levanta todos los contenedores con un solo comando.
+
+El `backend/Dockerfile` se usa para que Railway construya la imagen del backend de produccion desde `main`. El contenedor compila con `npm run build`; al arrancar ejecuta `npm start`, aplica `prisma db push --accept-data-loss` y levanta `dist/index.js`.
 
 Consulta `docs/infra/setup-despliegue.md` para el detalle completo de variables, URLs por entorno y despliegue.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Aplicacion movil para gestionar pisos compartidos. Conecta a caseros e inquilino
 .\dev.bat
 ```
 
-El script ejecuta `docker compose up --build` desde la raiz y comprueba que exista `.env`.
+El script ejecuta `docker compose up --build -d` desde la raiz, comprueba que exista `.env` y despues lanza `npx expo start --clear` en `frontend`.
 
 3. Usa Docker local como API en `frontend/.env` si arrancas Expo fuera de Compose:
 
@@ -109,9 +109,9 @@ npx expo start --clear
 
 ## Docker y Railway
 
-El desarrollo diario usa `docker-compose.yml`, que levanta PostgreSQL, backend en `http://localhost:3001` y Metro en `http://localhost:8080`.
+El desarrollo diario usa `docker-compose.yml`, que levanta PostgreSQL, backend en `http://localhost:3001` y el servicio frontend de Compose. El `.bat` deja Docker en segundo plano y abre Expo local para que tengas el QR y los logs a mano.
 
-En Windows, `dev.bat` levanta todos los contenedores con un solo comando.
+En Windows, `dev.bat` levanta los contenedores y Expo con un solo comando.
 
 El `backend/Dockerfile` se usa para que Railway construya la imagen del backend de produccion desde `main`. El contenedor compila con `npm run build`; al arrancar ejecuta `npm start`, aplica `prisma db push --accept-data-loss` y levanta `dist/index.js`.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Aplicacion movil para gestionar pisos compartidos. Conecta a caseros e inquilino
 .\dev.bat
 ```
 
-El script ejecuta `docker compose up --build -d` desde la raiz, comprueba que exista `.env` y despues lanza `npx expo start --clear` en `frontend`.
+El script ejecuta `docker compose up --build -d --force-recreate` desde la raiz. El backend reinicia la BD con `prisma db push --force-reset`, ejecuta `npx prisma db seed`, espera a que responda y despues lanza `npx expo start --clear` en `frontend`.
 
 3. Usa Docker local como API en `frontend/.env` si arrancas Expo fuera de Compose:
 
@@ -112,6 +112,13 @@ npx expo start --clear
 El desarrollo diario usa `docker-compose.yml`, que levanta PostgreSQL, backend en `http://localhost:3001` y el servicio frontend de Compose. El `.bat` deja Docker en segundo plano y abre Expo local para que tengas el QR y los logs a mano.
 
 En Windows, `dev.bat` levanta los contenedores y Expo con un solo comando.
+
+Credenciales locales tras el seed:
+
+| Rol | Email | Password |
+|---|---|---|
+| CASERO | `casero@example.test` | `pass` |
+| INQUILINO | `ana@example.test` | `pass` |
 
 El `backend/Dockerfile` se usa para que Railway construya la imagen del backend de produccion desde `main`. El contenedor compila con `npm run build`; al arrancar ejecuta `npm start`, aplica `prisma db push --accept-data-loss` y levanta `dist/index.js`.
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -42,3 +42,5 @@ CLOUDINARY_API_SECRET=tu_api_secret
 SEED_CASERO_PASSWORD=pass
 SEED_INQUILINO_PASSWORD=pass
 SEED_DEMO_DOMAIN=example.test
+# Solo para arranques controlados donde quieras sembrar al iniciar npm start.
+ROOMIES_SEED_ON_START=false

--- a/backend/scripts/start.js
+++ b/backend/scripts/start.js
@@ -20,18 +20,11 @@ const run = (label, command, args) => {
   }
 };
 
-const normalized = (value) => (value ?? '').toLowerCase();
-const railwayEnvironment = normalized(
-  process.env.ROOMIES_APP_ENV ??
-    process.env.RAILWAY_ENVIRONMENT_NAME ??
-    process.env.RAILWAY_ENVIRONMENT,
-);
 const seedOnStart = process.env.ROOMIES_SEED_ON_START === 'true';
-const isRailwayDevelopment = ['development', 'dev', 'desarrollo'].includes(railwayEnvironment);
 
 run('prisma db push', npx, ['prisma', 'db', 'push', '--accept-data-loss']);
 
-if (isRailwayDevelopment || seedOnStart) {
+if (seedOnStart) {
   run('prisma db seed', npx, ['prisma', 'db', 'seed']);
 }
 

--- a/dev.bat
+++ b/dev.bat
@@ -1,0 +1,28 @@
+@echo off
+setlocal
+
+cd /d "%~dp0"
+
+if not exist ".env" (
+  echo No existe .env en la raiz del proyecto.
+  echo Copia .env.example a .env y ajusta HOST_IP, secretos y tokens antes de levantar Docker.
+  echo.
+  pause
+  exit /b 1
+)
+
+echo Levantando Roomies con Docker Compose...
+echo Backend: http://localhost:3001/api
+echo Metro:   http://localhost:8080
+echo.
+
+docker info >nul 2>&1
+if errorlevel 1 (
+  echo Docker Desktop no esta arrancado o no responde.
+  echo Abre Docker Desktop y vuelve a ejecutar .\dev.bat.
+  echo.
+  pause
+  exit /b 1
+)
+
+docker compose up --build

--- a/dev.bat
+++ b/dev.bat
@@ -11,8 +11,19 @@ if not exist ".env" (
   exit /b 1
 )
 
+set "ROOMIES_HOST_IP="
+for /f "usebackq tokens=1,* delims==" %%A in (".env") do (
+  if /I "%%A"=="HOST_IP" set "ROOMIES_HOST_IP=%%B"
+)
+
+set "ROOMIES_API_URL=http://localhost:3001/api"
+if defined ROOMIES_HOST_IP (
+  if not "%ROOMIES_HOST_IP%"=="192.168.1.X" set "ROOMIES_API_URL=http://%ROOMIES_HOST_IP%:3001/api"
+)
+
 echo Levantando Roomies con Docker Compose...
 echo Backend: http://localhost:3001/api
+echo API Expo: %ROOMIES_API_URL%
 echo.
 
 docker info >nul 2>&1
@@ -24,7 +35,7 @@ if errorlevel 1 (
   exit /b 1
 )
 
-docker compose up --build -d
+docker compose up --build -d --force-recreate
 if errorlevel 1 (
   echo No se pudieron levantar los contenedores.
   echo Revisa la salida anterior de Docker Compose.
@@ -34,8 +45,26 @@ if errorlevel 1 (
 )
 
 echo.
+echo Esperando a que el backend responda...
+for /l %%I in (1,1,30) do (
+  powershell -NoProfile -Command "try { $r = Invoke-WebRequest -UseBasicParsing http://localhost:3001/ping -TimeoutSec 2; if ($r.StatusCode -eq 200) { exit 0 } else { exit 1 } } catch { exit 1 }" >nul 2>&1
+  if not errorlevel 1 goto backend_ready
+  timeout /t 2 >nul
+)
+
+echo El backend no respondio en http://localhost:3001/ping.
+echo Revisa los logs con: docker compose logs backend --tail=120
+echo.
+pause
+exit /b 1
+
+:backend_ready
+echo Backend listo. La BD se ha reiniciado y el seed se ha ejecutado durante el arranque.
+
+echo.
 echo Contenedores levantados. Arrancando Expo local...
 echo.
 
 cd frontend
+set "EXPO_PUBLIC_API_URL=%ROOMIES_API_URL%"
 npx expo start --clear

--- a/dev.bat
+++ b/dev.bat
@@ -13,7 +13,6 @@ if not exist ".env" (
 
 echo Levantando Roomies con Docker Compose...
 echo Backend: http://localhost:3001/api
-echo Metro:   http://localhost:8080
 echo.
 
 docker info >nul 2>&1
@@ -25,4 +24,18 @@ if errorlevel 1 (
   exit /b 1
 )
 
-docker compose up --build
+docker compose up --build -d
+if errorlevel 1 (
+  echo No se pudieron levantar los contenedores.
+  echo Revisa la salida anterior de Docker Compose.
+  echo.
+  pause
+  exit /b 1
+)
+
+echo.
+echo Contenedores levantados. Arrancando Expo local...
+echo.
+
+cd frontend
+npx expo start --clear

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - "8080:8080"
     command: npx expo start --host lan --port 8080 --clear
     environment:
-      EXPO_PUBLIC_API_URL: ${EXPO_PUBLIC_API_URL:-https://roomies-dev.up.railway.app/api}
+      EXPO_PUBLIC_API_URL: ${EXPO_PUBLIC_API_URL:-http://localhost:3001/api}
       REACT_NATIVE_PACKAGER_HOSTNAME: ${HOST_IP}
       EXPO_PUBLIC_MAPBOX_TOKEN: ${EXPO_PUBLIC_MAPBOX_TOKEN}
       EXPO_PUBLIC_GOOGLE_CLIENT_ID: ${EXPO_PUBLIC_GOOGLE_CLIENT_ID:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     build: ./backend
     ports:
       - "3001:3000"
-    command: sh -c "npx prisma generate && if [ \"${RESET_DB:-false}\" = \"true\" ]; then until npx prisma db push --force-reset; do echo 'DB not ready, retrying...'; sleep 3; done && npx prisma db seed; else until npx prisma db push --accept-data-loss; do echo 'DB not ready, retrying...'; sleep 3; done; fi && npm run dev"
+    command: sh -c "npx prisma generate && until npx prisma db push --force-reset; do echo 'DB not ready, retrying...'; sleep 3; done && npx prisma db seed && npm run dev"
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
       JWT_SECRET: ${JWT_SECRET}
@@ -30,7 +30,9 @@ services:
       CLOUDINARY_CLOUD_NAME: ${CLOUDINARY_CLOUD_NAME:-}
       CLOUDINARY_API_KEY: ${CLOUDINARY_API_KEY:-}
       CLOUDINARY_API_SECRET: ${CLOUDINARY_API_SECRET:-}
-      RESET_DB: ${RESET_DB:-false}
+      SEED_CASERO_PASSWORD: ${SEED_CASERO_PASSWORD:-pass}
+      SEED_INQUILINO_PASSWORD: ${SEED_INQUILINO_PASSWORD:-pass}
+      SEED_DEMO_DOMAIN: ${SEED_DEMO_DOMAIN:-example.test}
     depends_on:
       db:
         condition: service_healthy
@@ -44,7 +46,7 @@ services:
       - "8080:8080"
     command: npx expo start --host lan --port 8080 --clear
     environment:
-      EXPO_PUBLIC_API_URL: ${EXPO_PUBLIC_API_URL:-http://localhost:3001/api}
+      EXPO_PUBLIC_API_URL: ${EXPO_PUBLIC_API_URL:-http://${HOST_IP}:3001/api}
       REACT_NATIVE_PACKAGER_HOSTNAME: ${HOST_IP}
       EXPO_PUBLIC_MAPBOX_TOKEN: ${EXPO_PUBLIC_MAPBOX_TOKEN}
       EXPO_PUBLIC_GOOGLE_CLIENT_ID: ${EXPO_PUBLIC_GOOGLE_CLIENT_ID:-}

--- a/docs/backend/setup.md
+++ b/docs/backend/setup.md
@@ -97,7 +97,7 @@ Estos valores permiten importar controladores, rutas y Prisma sin depender de `.
 
 ## Despliegue en Railway
 
-El backend se prueba y despliega en Railway. En este proyecto Railway usa `backend/Dockerfile` para construir la imagen; el Dockerfile compila con `npm run build` y el contenedor arranca con `npm start`.
+El backend se desarrolla y prueba contra Docker local. Railway queda reservado para produccion desde `main`. En este proyecto Railway usa `backend/Dockerfile` para construir la imagen; el Dockerfile compila con `npm run build` y el contenedor arranca con `npm start`.
 
 ### 1. Base de datos
 
@@ -138,6 +138,8 @@ npx prisma db push --accept-data-loss
 node dist/index.js
 ```
 
+Solo ejecuta `npx prisma db seed` al arrancar si `ROOMIES_SEED_ON_START=true`; no se debe activar en Railway produccion salvo una carga controlada.
+
 ### 5. Cron jobs incluidos en el arranque
 
 Al levantar `src/index.ts`, el backend inicia dos tareas programadas:
@@ -157,7 +159,7 @@ https://<nombre-proyecto>.up.railway.app
 
 ### 7. Conectar el frontend
 
-Actualiza `frontend/.env` con la URL generada:
+Actualiza `frontend/.env` con la URL generada solo para builds o validaciones de produccion:
 
 ```env
 EXPO_PUBLIC_API_URL=https://<nombre-proyecto>.up.railway.app/api
@@ -197,7 +199,7 @@ npx expo start --clear
 | `ItemInventario.revisado_por_inquilino_id` y `revisado_por_inquilino_en` auditan la conformidad | El casero puede saber quien valido un item y cuando; los inquilinos no pueden validar dormitorios ajenos. |
 | Importes monetarios siguen como `Float` por compatibilidad MVP | La logica de reparto convierte a centimos antes de comparar o dividir. Migrar a `Decimal` o centimos enteros queda pendiente de migracion coordinada con frontend, API y datos existentes. |
 
-El seed de demo esta pensado para desarrollo local y Railway desarrollo: usa emails `example.test`, contrasenas obvias documentadas y se bloquea en `NODE_ENV=production` o Railway no desarrollo salvo que se fuerce con `ROOMIES_ALLOW_PRODUCTION_SEED=true`.
+El seed de demo esta pensado para desarrollo local: usa emails `example.test`, contrasenas obvias documentadas y se bloquea en `NODE_ENV=production` o Railway salvo que se fuerce con `ROOMIES_ALLOW_PRODUCTION_SEED=true`.
 
 ## Update 2026-04-09 - Backend real
 

--- a/docs/changelog/EpicaInfra/infra-docker-dev-railway-main.md
+++ b/docs/changelog/EpicaInfra/infra-docker-dev-railway-main.md
@@ -1,0 +1,21 @@
+# Infra - Docker en desarrollo y Railway en main
+
+## Objetivo
+
+Reducir costes de Railway evitando despliegues de desarrollo y recuperar Docker Compose como flujo principal para cambios diarios.
+
+## Cambios principales
+
+- `docker-compose.yml` deja de usar Railway desarrollo como fallback de `EXPO_PUBLIC_API_URL` y apunta a `http://localhost:3001/api`.
+- `frontend/.env.example`, `README.md`, `docs/frontend/setup.md`, `docs/infra/setup-despliegue.md`, `docs/backend/setup.md` y `CONTEXT.md` documentan Docker local para desarrollo y Railway solo para produccion desde `main`.
+- `frontend/utils/apiUrl.ts` y sus tests usan `http://localhost:3001/api` como fallback local, alineado con el puerto publicado por Compose.
+- `backend/scripts/start.js` deja de ejecutar seed automaticamente por nombre de entorno Railway; solo lo hace con `ROOMIES_SEED_ON_START=true`.
+- `dev.bat` levanta todos los contenedores con `docker compose up --build` desde la raiz y avisa si falta `.env`.
+
+## Verificacion
+
+- `docker compose config --quiet`.
+- `npm test -- apiUrl.test.ts --runInBand` en `frontend`.
+- `cmd /c dev.bat` valida el wrapper; en esta maquina se detiene correctamente avisando que Docker Desktop no esta arrancado.
+- `docker compose up --build -d` levanta `db`, `backend` y `frontend` con Docker Desktop activo.
+- `Invoke-WebRequest http://localhost:3001/ping` devuelve `200 OK` con cuerpo `pong`.

--- a/docs/changelog/EpicaInfra/infra-docker-dev-railway-main.md
+++ b/docs/changelog/EpicaInfra/infra-docker-dev-railway-main.md
@@ -10,7 +10,8 @@ Reducir costes de Railway evitando despliegues de desarrollo y recuperar Docker 
 - `frontend/.env.example`, `README.md`, `docs/frontend/setup.md`, `docs/infra/setup-despliegue.md`, `docs/backend/setup.md` y `CONTEXT.md` documentan Docker local para desarrollo y Railway solo para produccion desde `main`.
 - `frontend/utils/apiUrl.ts` y sus tests usan `http://localhost:3001/api` como fallback local, alineado con el puerto publicado por Compose.
 - `backend/scripts/start.js` deja de ejecutar seed automaticamente por nombre de entorno Railway; solo lo hace con `ROOMIES_SEED_ON_START=true`.
-- `dev.bat` levanta los contenedores con `docker compose up --build -d` desde la raiz, avisa si falta `.env` y ejecuta `npx expo start --clear` en `frontend`.
+- `dev.bat` levanta los contenedores con `docker compose up --build -d --force-recreate` desde la raiz, avisa si falta `.env`, espera a `/ping` y ejecuta `npx expo start --clear` en `frontend`.
+- `docker-compose.yml` reinicia la BD con `prisma db push --force-reset` y ejecuta seed en cada arranque del backend de desarrollo.
 
 ## Verificacion
 
@@ -19,4 +20,6 @@ Reducir costes de Railway evitando despliegues de desarrollo y recuperar Docker 
 - `cmd /c dev.bat` valida el wrapper; en esta maquina se detiene correctamente avisando que Docker Desktop no esta arrancado.
 - `docker compose up --build -d` levanta `db`, `backend` y `frontend` con Docker Desktop activo.
 - `Invoke-WebRequest http://localhost:3001/ping` devuelve `200 OK` con cuerpo `pong`.
+- `docker compose up --build -d --force-recreate` recrea contenedores, reinicia schema con `force-reset` y ejecuta seed antes de arrancar backend.
+- `Invoke-RestMethod` contra `POST /api/auth/login` con `casero@example.test / pass` devuelve token.
 - `npx expo --version` en `frontend` resuelve correctamente el CLI local.

--- a/docs/changelog/EpicaInfra/infra-docker-dev-railway-main.md
+++ b/docs/changelog/EpicaInfra/infra-docker-dev-railway-main.md
@@ -10,7 +10,7 @@ Reducir costes de Railway evitando despliegues de desarrollo y recuperar Docker 
 - `frontend/.env.example`, `README.md`, `docs/frontend/setup.md`, `docs/infra/setup-despliegue.md`, `docs/backend/setup.md` y `CONTEXT.md` documentan Docker local para desarrollo y Railway solo para produccion desde `main`.
 - `frontend/utils/apiUrl.ts` y sus tests usan `http://localhost:3001/api` como fallback local, alineado con el puerto publicado por Compose.
 - `backend/scripts/start.js` deja de ejecutar seed automaticamente por nombre de entorno Railway; solo lo hace con `ROOMIES_SEED_ON_START=true`.
-- `dev.bat` levanta todos los contenedores con `docker compose up --build` desde la raiz y avisa si falta `.env`.
+- `dev.bat` levanta los contenedores con `docker compose up --build -d` desde la raiz, avisa si falta `.env` y ejecuta `npx expo start --clear` en `frontend`.
 
 ## Verificacion
 
@@ -19,3 +19,4 @@ Reducir costes de Railway evitando despliegues de desarrollo y recuperar Docker 
 - `cmd /c dev.bat` valida el wrapper; en esta maquina se detiene correctamente avisando que Docker Desktop no esta arrancado.
 - `docker compose up --build -d` levanta `db`, `backend` y `frontend` con Docker Desktop activo.
 - `Invoke-WebRequest http://localhost:3001/ping` devuelve `200 OK` con cuerpo `pong`.
+- `npx expo --version` en `frontend` resuelve correctamente el CLI local.

--- a/docs/frontend/setup.md
+++ b/docs/frontend/setup.md
@@ -5,7 +5,7 @@
 - Node.js 20+
 - Expo Go o una build nativa para probar la app
 - Cuenta en `expo.dev` si vas a generar builds con EAS
-- Backend desplegado en Railway desarrollo para testeo funcional diario
+- Docker Desktop para el backend y PostgreSQL de desarrollo
 
 ## Variables de entorno
 
@@ -13,12 +13,12 @@ Copia `frontend/.env.example` a `frontend/.env`.
 
 | Entorno | URL |
 |---|---|
-| Testeo diario | `https://roomies-dev.up.railway.app/api` |
-| Produccion | `https://roomies-production-c884.up.railway.app/api` |
-| Local auxiliar | `http://localhost:3001/api` o `http://<TU_IP>:3001/api` |
+| Desarrollo Docker local | `http://localhost:3001/api` |
+| Desarrollo Docker en movil fisico | `http://<TU_IP>:3001/api` |
+| Produccion Railway | `https://roomies-production-c884.up.railway.app/api` |
 
 ```env
-EXPO_PUBLIC_API_URL=https://roomies-dev.up.railway.app/api
+EXPO_PUBLIC_API_URL=http://localhost:3001/api
 
 EXPO_PUBLIC_MAPBOX_TOKEN=pk.ey...
 EXPO_PUBLIC_GOOGLE_CLIENT_ID=<web_client_id>
@@ -40,7 +40,15 @@ Variables obligatorias para flujos completos:
 
 ## Instalacion y testeo con Expo Go
 
-El flujo habitual es levantar solo Expo y consumir Railway desarrollo:
+El flujo habitual es levantar backend y base de datos con Docker Compose desde la raiz:
+
+```bash
+.\dev.bat
+```
+
+El script ejecuta `docker compose up --build` desde la raiz. Compose publica la API en `http://localhost:3001/api` y Metro en `http://localhost:8080`. Para un movil fisico, `EXPO_PUBLIC_API_URL` debe apuntar a la IP LAN de la maquina, por ejemplo `http://192.168.1.50:3001/api`, no a `localhost`.
+
+Si se prefiere arrancar Metro fuera del contenedor:
 
 ```bash
 cd frontend
@@ -48,17 +56,7 @@ npm install
 npx expo start --clear
 ```
 
-Abre el QR desde Expo Go. No hace falta levantar backend ni base de datos local para pruebas funcionales habituales.
-
-### Docker Compose auxiliar
-
-Docker Compose no es el flujo habitual de testeo. Si se necesita revisar integracion local de contenedores, desde la raiz del repo:
-
-```bash
-docker-compose up --build
-```
-
-Metro queda accesible para Expo Go en `http://localhost:8080`. El compose lee `EXPO_PUBLIC_API_URL` desde el `.env` raiz; para un movil fisico debe apuntar al host LAN, por ejemplo `http://192.168.1.50:3001/api`, no a `localhost`.
+Railway queda reservado para produccion desde `main`.
 
 ## Tests y calidad
 

--- a/docs/frontend/setup.md
+++ b/docs/frontend/setup.md
@@ -46,7 +46,7 @@ El flujo habitual es levantar backend y base de datos con Docker Compose desde l
 .\dev.bat
 ```
 
-El script ejecuta `docker compose up --build` desde la raiz. Compose publica la API en `http://localhost:3001/api` y Metro en `http://localhost:8080`. Para un movil fisico, `EXPO_PUBLIC_API_URL` debe apuntar a la IP LAN de la maquina, por ejemplo `http://192.168.1.50:3001/api`, no a `localhost`.
+El script ejecuta `docker compose up --build -d` desde la raiz y despues `npx expo start --clear` en `frontend`. Compose publica la API en `http://localhost:3001/api`. Para un movil fisico, `EXPO_PUBLIC_API_URL` debe apuntar a la IP LAN de la maquina, por ejemplo `http://192.168.1.50:3001/api`, no a `localhost`.
 
 Si se prefiere arrancar Metro fuera del contenedor:
 

--- a/docs/frontend/setup.md
+++ b/docs/frontend/setup.md
@@ -46,7 +46,7 @@ El flujo habitual es levantar backend y base de datos con Docker Compose desde l
 .\dev.bat
 ```
 
-El script ejecuta `docker compose up --build -d` desde la raiz y despues `npx expo start --clear` en `frontend`. Compose publica la API en `http://localhost:3001/api`. Para un movil fisico, `EXPO_PUBLIC_API_URL` debe apuntar a la IP LAN de la maquina, por ejemplo `http://192.168.1.50:3001/api`, no a `localhost`.
+El script ejecuta `docker compose up --build -d --force-recreate` desde la raiz. El backend reinicia la BD, ejecuta el seed y despues el script lanza `npx expo start --clear` en `frontend`. Compose publica la API en `http://localhost:3001/api`. Para un movil fisico, `EXPO_PUBLIC_API_URL` debe apuntar a la IP LAN de la maquina, por ejemplo `http://192.168.1.50:3001/api`, no a `localhost`.
 
 Si se prefiere arrancar Metro fuera del contenedor:
 

--- a/docs/infra/setup-despliegue.md
+++ b/docs/infra/setup-despliegue.md
@@ -64,7 +64,9 @@ npx expo start --clear
 .\dev.bat
 ```
 
-`dev.bat` se ejecuta desde la raiz, valida que exista `.env`, lanza `docker compose up --build -d` y despues ejecuta `npx expo start --clear` en `frontend`.
+`dev.bat` se ejecuta desde la raiz, valida que exista `.env`, lanza `docker compose up --build -d --force-recreate`, espera a `http://localhost:3001/ping` y despues ejecuta `npx expo start --clear` en `frontend`.
+
+En Compose de desarrollo el backend siempre reinicia la BD con `npx prisma db push --force-reset` y ejecuta `npx prisma db seed` antes de arrancar `npm run dev`.
 
 3. En `frontend/.env`, apunta a Docker local si usas Metro fuera del contenedor:
 
@@ -93,7 +95,7 @@ El servicio `backend` de Compose sobreescribe el comando de la imagen de Railway
 2. `npx prisma db push --accept-data-loss`
 3. `npm run dev`
 
-Si `RESET_DB=true`, ejecuta `npx prisma db push --force-reset` y `npx prisma db seed` antes de arrancar.
+La BD local se reinicia y se siembra siempre al arrancar con `dev.bat`.
 
 ## Backend local opcional
 

--- a/docs/infra/setup-despliegue.md
+++ b/docs/infra/setup-despliegue.md
@@ -64,7 +64,7 @@ npx expo start --clear
 .\dev.bat
 ```
 
-`dev.bat` se ejecuta desde la raiz, valida que exista `.env` y lanza `docker compose up --build`.
+`dev.bat` se ejecuta desde la raiz, valida que exista `.env`, lanza `docker compose up --build -d` y despues ejecuta `npx expo start --clear` en `frontend`.
 
 3. En `frontend/.env`, apunta a Docker local si usas Metro fuera del contenedor:
 

--- a/docs/infra/setup-despliegue.md
+++ b/docs/infra/setup-despliegue.md
@@ -2,7 +2,7 @@
 
 ## Objetivo
 
-Esta guia concentra el flujo real de testeo con Expo Go contra Railway desarrollo, las variables de entorno, Dockerfile de Railway y despliegue de Roomies. Debe mantenerse alineada con:
+Esta guia concentra el flujo real de desarrollo con Docker Compose, las variables de entorno, Dockerfile de Railway y despliegue de Roomies. Debe mantenerse alineada con:
 
 - `docker-compose.yml`
 - `.env.example`
@@ -15,9 +15,9 @@ Esta guia concentra el flujo real de testeo con Expo Go contra Railway desarroll
 
 | Servicio | URL habitual |
 |---|---|
-| Backend Railway desarrollo | `https://roomies-dev.up.railway.app/api` |
-| Backend Railway produccion | `https://roomies-production-c884.up.railway.app/api` |
-| Expo local para Expo Go | Metro generado por `npx expo start --clear` |
+| Backend desarrollo Docker | `http://localhost:3001/api` |
+| Backend produccion Railway | `https://roomies-production-c884.up.railway.app/api` |
+| Expo local para Expo Go | `http://localhost:8080` con Compose o Metro generado por `npx expo start --clear` |
 
 URLs auxiliares si se revisa infraestructura local:
 
@@ -31,10 +31,10 @@ URLs auxiliares si se revisa infraestructura local:
 
 ### Frontend `.env` para Expo Go
 
-El flujo normal de testeo usa `frontend/.env` con Railway desarrollo:
+El flujo normal de testeo usa Docker local:
 
 ```env
-EXPO_PUBLIC_API_URL=https://roomies-dev.up.railway.app/api
+EXPO_PUBLIC_API_URL=http://localhost:3001/api
 EXPO_PUBLIC_MAPBOX_TOKEN=pk.ey...
 EXPO_PUBLIC_GOOGLE_CLIENT_ID=<web_client_id>
 EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID=<android_client_id>
@@ -43,7 +43,7 @@ EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=
 
 | Variable | Obligatoria | Uso |
 |---|---|---|
-| `EXPO_PUBLIC_API_URL` | Si | API Railway desarrollo para testeo diario o produccion para builds release. |
+| `EXPO_PUBLIC_API_URL` | Si | API local Docker en desarrollo o API Railway de produccion para builds release. |
 | `EXPO_PUBLIC_MAPBOX_TOKEN` | Si para autocompletado | Token publico de Mapbox. |
 | `EXPO_PUBLIC_GOOGLE_CLIENT_ID` | Si para Google OAuth | Web Client ID usado por Expo. |
 | `EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID` | Recomendado | Client ID Android. |
@@ -57,31 +57,35 @@ npx expo start --clear
 
 ## Testeo diario
 
-1. Comprueba que los cambios de backend esten desplegados en Railway desarrollo.
-2. En `frontend/.env`, apunta a:
+1. Copia `.env.example` a `.env` y ajusta secretos, `HOST_IP` y tokens publicos.
+2. Levanta PostgreSQL, backend y Metro:
 
-```env
-EXPO_PUBLIC_API_URL=https://roomies-dev.up.railway.app/api
+```bash
+.\dev.bat
 ```
 
-3. Arranca Expo:
+`dev.bat` se ejecuta desde la raiz, valida que exista `.env` y lanza `docker compose up --build`.
+
+3. En `frontend/.env`, apunta a Docker local si usas Metro fuera del contenedor:
+
+```env
+EXPO_PUBLIC_API_URL=http://localhost:3001/api
+```
+
+Para Expo Go en movil fisico:
+
+```env
+EXPO_PUBLIC_API_URL=http://<HOST_IP>:3001/api
+```
+
+4. Si no usas el Metro del contenedor, arranca Expo:
 
 ```bash
 cd frontend
 npx expo start --clear
 ```
 
-4. Abre la app desde Expo Go y valida contra Railway desarrollo.
-
-## Docker Compose opcional
-
-`docker-compose.yml` no es el flujo habitual de testeo. Queda para revisar integracion local si alguna vez hace falta levantar PostgreSQL, backend y Metro en contenedores.
-
-Si se usa, copia `.env.example` a `.env`, ajusta las variables y ejecuta:
-
-```bash
-docker-compose up --build
-```
+5. Abre la app desde Expo Go y valida contra Docker local.
 
 El servicio `backend` de Compose sobreescribe el comando de la imagen de Railway para trabajar en modo desarrollo:
 
@@ -126,7 +130,7 @@ npm test
 
 ### Backend Railway
 
-El backend se despliega con `backend/Dockerfile`; Railway lo usa para construir la imagen. Configura el servicio con root directory `/backend` y variables:
+Railway queda reservado para produccion y debe desplegar desde `main`. El backend se despliega con `backend/Dockerfile`; Railway lo usa para construir la imagen. Configura el servicio con root directory `/backend` y variables:
 
 - `DATABASE_URL`
 - `JWT_SECRET`
@@ -138,9 +142,11 @@ El backend se despliega con `backend/Dockerfile`; Railway lo usa para construir 
 - `CLOUDINARY_API_KEY`
 - `CLOUDINARY_API_SECRET`
 
-El Dockerfile ejecuta `npm run build`. Al arrancar, `npm start` aplica `npx prisma db push --accept-data-loss`, ejecuta `npx prisma db seed` cuando `ROOMIES_APP_ENV` o `RAILWAY_ENVIRONMENT_NAME` identifica desarrollo (`development`, `dev` o `desarrollo`) y levanta `node dist/index.js`.
+El Dockerfile ejecuta `npm run build`. Al arrancar, `npm start` aplica `npx prisma db push --accept-data-loss` y levanta `node dist/index.js`.
 
-El seed queda bloqueado en Railway produccion salvo override explicito con `ROOMIES_ALLOW_PRODUCTION_SEED=true`. Si Railway dev esta montado como servicio/proyecto separado y el nombre automatico del entorno no es de desarrollo, define `ROOMIES_APP_ENV=development` solo en el backend de desarrollo.
+No configures servicios Railway contra `dev` para desarrollo diario. Si existe un Railway de pruebas, mantenerlo pausado o desconectado de auto-deploy para evitar costes; Docker local cubre el flujo de cambios en desarrollo.
+
+El seed automatico queda desactivado por defecto en `npm start`. Solo se ejecuta si `ROOMIES_SEED_ON_START=true`, y no debe habilitarse en produccion salvo una carga controlada.
 
 ### Frontend EAS
 

--- a/docs/release/epica-16-regresion-final.md
+++ b/docs/release/epica-16-regresion-final.md
@@ -16,7 +16,7 @@ Cerrar la revision integral de calidad con una comprobacion transversal de los f
 
 ## Checklist manual de producto
 
-Usar Railway desarrollo como backend y Expo Go o build nativa segun el modulo a revisar. Marcar cada punto en la PR con OK, N/A o issue de seguimiento.
+Usar Docker Compose local como backend de desarrollo y Expo Go o build nativa segun el modulo a revisar. Marcar cada punto en la PR con OK, N/A o issue de seguimiento.
 
 | Flujo | Validacion manual minima | Estado |
 |---|---|---|
@@ -83,7 +83,7 @@ Usar Railway desarrollo como backend y Expo Go o build nativa segun el modulo a 
 | Riesgo | Decision |
 |---|---|
 | Push real no se valida en Expo Go. | Documentado: requiere build nativa o development build. Checklist manual obliga a validarlo en entorno compatible antes de release. |
-| Tests smoke no sustituyen E2E con base real. | Decision documentada: se cubren rutas, permisos y servicios criticos con mocks; persistencia real queda en checklist manual contra Railway desarrollo. |
+| Tests smoke no sustituyen E2E con base real. | Decision documentada: se cubren rutas, permisos y servicios criticos con mocks; persistencia real queda en checklist manual contra Docker Compose local. |
 | Mojibake historico visible en algunos textos/docs. | Revisado en #255 y documentado como deuda de limpieza continua si aparece en areas no tocadas. |
 | Importes usan `Float` en Prisma. | Revisado en #250; no se migra en esta epica por riesgo de cambio de datos, se mantiene test de centimos y decision documentada. |
 | Docker Compose no se levanta durante la suite automatica. | Se valida `docker compose config --quiet`; levantar servicios queda como paso manual opcional por coste y duracion. |

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -5,12 +5,14 @@
 # Elige el entorno segun el flujo:
 
 # Desarrollo local con Docker Compose (recomendado en dev)
-EXPO_PUBLIC_API_URL=http://localhost:3001/api
+EXPO_PUBLIC_API_URL=http://192.168.1.X:3001/api
 
 # Expo Go en movil fisico con Docker Compose:
 #EXPO_PUBLIC_API_URL=http://192.168.1.X:3001/api
 # Android emulator:
 #EXPO_PUBLIC_API_URL=http://10.0.2.2:3001/api
+# Web/local en la misma maquina:
+#EXPO_PUBLIC_API_URL=http://localhost:3001/api
 
 # Producción (Railway, rama main)
 #EXPO_PUBLIC_API_URL=https://roomies-production-c884.up.railway.app/api

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -2,22 +2,18 @@
 # cp .env.example .env
 
 # — API URL —
-# Elige UNO de los tres entornos (descomenta el que quieras usar):
+# Elige el entorno segun el flujo:
 
-# Producción (Railway)
-#EXPO_PUBLIC_API_URL=https://roomies-production-c884.up.railway.app/api
+# Desarrollo local con Docker Compose (recomendado en dev)
+EXPO_PUBLIC_API_URL=http://localhost:3001/api
 
-# Desarrollo en Railway (rama dev)
-#EXPO_PUBLIC_API_URL=https://roomies-dev.up.railway.app/api
-
-# Desarrollo local (Docker Compose en la misma máquina/red)
+# Expo Go en movil fisico con Docker Compose:
 #EXPO_PUBLIC_API_URL=http://192.168.1.X:3001/api
 # Android emulator:
 #EXPO_PUBLIC_API_URL=http://10.0.2.2:3001/api
-# Web/local en la misma maquina:
-#EXPO_PUBLIC_API_URL=http://localhost:3001/api
 
-EXPO_PUBLIC_API_URL=https://roomies-dev.up.railway.app/api
+# Producción (Railway, rama main)
+#EXPO_PUBLIC_API_URL=https://roomies-production-c884.up.railway.app/api
 
 # — Mapbox —
 # Obtén tu token en https://account.mapbox.com (necesario para autocompletado de dirección)

--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -1,1 +1,1 @@
-process.env.EXPO_PUBLIC_API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3000/api';
+process.env.EXPO_PUBLIC_API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3001/api';

--- a/frontend/utils/__tests__/apiUrl.test.ts
+++ b/frontend/utils/__tests__/apiUrl.test.ts
@@ -8,7 +8,7 @@ describe('getApiBaseUrl', () => {
   });
 
   it('permite localhost solo fuera de produccion', () => {
-    expect(getApiBaseUrl({ NODE_ENV: 'test' })).toBe('http://localhost:3000/api');
+    expect(getApiBaseUrl({ NODE_ENV: 'test' })).toBe('http://localhost:3001/api');
   });
 
   it('falla en produccion si falta EXPO_PUBLIC_API_URL', () => {

--- a/frontend/utils/apiUrl.ts
+++ b/frontend/utils/apiUrl.ts
@@ -1,4 +1,4 @@
-const LOCAL_DEV_API_URL = 'http://localhost:3000/api';
+const LOCAL_DEV_API_URL = 'http://localhost:3001/api';
 
 type ApiEnv = {
   EXPO_PUBLIC_API_URL?: string;


### PR DESCRIPTION
## Objetivo
Reducir el coste de Railway en el día a día volviendo a usar Docker Compose como flujo principal de desarrollo, y dejando Railway únicamente para despliegues de `main` en producción.

## Cambios principales
* `docker-compose.yml` deja de apuntar a Railway dev y usa API local por defecto.
* `dev.bat` levanta los contenedores con `docker compose up --build -d` y arranca `npx expo start --clear` desde `frontend`.
* `backend/scripts/start.js` ya no ejecuta seed automáticamente por detectar entornos Railway; solo lo hace con `ROOMIES_SEED_ON_START=true`.
* Se actualizan `README.md`, `docs/infra/setup-despliegue.md`, `docs/frontend/setup.md`, `docs/backend/setup.md`, `CONTEXT.md` y los `.env.example` para reflejar el nuevo flujo.
* Se ajusta el fallback local del frontend a `http://localhost:3001/api` y se actualizan sus tests.

## UI / UX (Solo si aplica)
* No aplica.

## Changelog
* `docs/changelog/EpicaInfra/infra-docker-dev-railway-main.md`