### PR TITLE
[Épica 17] Permite editar y eliminar gastos fijos

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -61,11 +61,11 @@ Aplicación móvil de gestión de pisos compartidos. Hay dos roles:
 
 ### Cobros, mensualidades y push (Epica 12)
 
-- El backend expone `GET /api/viviendas/:viviendaId/gastos`, `POST /api/viviendas/:viviendaId/gastos`, `GET /api/viviendas/:viviendaId/deudas`, `PATCH /api/viviendas/:viviendaId/deudas/:deudaId/saldar`, `GET /api/viviendas/:viviendaId/gastos-recurrentes`, `POST /api/viviendas/:viviendaId/gastos-recurrentes` y `GET /api/viviendas/:viviendaId/cobros`.
+- El backend expone `GET /api/viviendas/:viviendaId/gastos`, `POST /api/viviendas/:viviendaId/gastos`, `GET /api/viviendas/:viviendaId/deudas`, `PATCH /api/viviendas/:viviendaId/deudas/:deudaId/saldar`, `GET/POST/PATCH/DELETE /api/viviendas/:viviendaId/gastos-recurrentes` y `GET /api/viviendas/:viviendaId/cobros`.
 - `GastoRecurrente` guarda mensualidades activas por vivienda y el cron diario de las `02:00` las transforma en `Gasto` normal con reparto automatico entre inquilinos activos.
 - `Deuda` incorpora `justificante_url`; el deudor puede subir imagen con `POST /api/deudas/:deudaId/justificante` usando `multipart/form-data` en el campo `justificante`.
 - El casero dispone de una pestana global `Cobros` con selector de vivienda, resumen mensual de pagado/pendiente y visualizacion del justificante cuando existe.
-- Las mensualidades se gestionan desde el resumen de cada vivienda del casero; el inquilino no ve ni crea gastos recurrentes.
+- Las mensualidades se gestionan desde el resumen de cada vivienda del casero; el casero puede crear, editar y eliminar gastos fijos, y el inquilino no ve ni crea gastos recurrentes.
 - El frontend del inquilino mantiene la pestana `Gastos` para gastos puntuales, deudas, facturas originales y bottom sheet de justificante antes de marcar una deuda como pagada.
 - El backend expone `PATCH /api/usuarios/me/push-token` y el alias legado `PUT /api/usuarios/push-token` para registrar el `expo_push_token` del usuario autenticado.
 - El frontend sincroniza el token push desde `app/_layout.tsx`, login, registro y selector de rol; en Expo Go el registro se omite y solo funciona en dispositivo fisico o build nativa.
@@ -390,6 +390,8 @@ Tablón de anuncios por vivienda. Todos los miembros de la vivienda (casero e in
 | PATCH  | `/viviendas/:viviendaId/deudas/:deudaId/saldar` | Si | Marca una deuda como `PAGADA`; solo el deudor puede hacerlo |
 | GET    | `/viviendas/:viviendaId/gastos-recurrentes` | Si | Lista mensualidades activas o inactivas de la vivienda |
 | POST   | `/viviendas/:viviendaId/gastos-recurrentes` | Si | Crea una mensualidad recurrente con `concepto`, `importe` y `dia_del_mes` |
+| PATCH  | `/viviendas/:viviendaId/gastos-recurrentes/:gastoRecurrenteId` | Si | Edita `concepto`, `importe`, `dia_del_mes` o `activo` de una mensualidad recurrente |
+| DELETE | `/viviendas/:viviendaId/gastos-recurrentes/:gastoRecurrenteId` | Si | Elimina una mensualidad recurrente sin afectar gastos ya generados |
 | GET    | `/viviendas/:viviendaId/cobros` | Si | Dashboard mensual del casero con resumen pagado o pendiente y detalle de justificantes |
 
 ### Deudas - `/deudas`
@@ -652,6 +654,8 @@ Usuarios de prueba creados por `prisma db seed`:
 | ------------------ | ----------- | --------- |
 | casero@test.com    | `casero123` | CASERO    |
 | inquilino@test.com | `inquilino123` | INQUILINO |
+
+El seed demo crea gastos puntuales, deudas del casero, deudas entre inquilinos y mensualidades de servicios. No crea la mensualidad de alquiler, porque el alquiler por habitacion se gestiona con `Habitacion.precio` y cargos de alquiler propios.
 
 ---
 

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -410,15 +410,6 @@ async function main() {
   await prisma.gastoRecurrente.createMany({
     data: [
       {
-        concepto: "Alquiler mensual",
-        importe: 1800,
-        tipo: TipoGasto.FACTURA_MENSUAL,
-        dia_del_mes: 1,
-        vivienda_id: vivienda.id,
-        pagador_id: casero.id,
-        activo: true,
-      },
-      {
         concepto: "Internet fibra",
         importe: 60,
         tipo: TipoGasto.FACTURA_MENSUAL,
@@ -454,7 +445,7 @@ async function main() {
 
   Datos de prueba creados:
     - 5 gastos con deudas pendientes y pagadas
-    - 3 mensualidades (2 activas y 1 inactiva)
+    - 2 mensualidades (1 activa y 1 inactiva)
     - deudas del casero para probar cobros y justificantes
     - deudas entre inquilinos para probar balance del piso
   `);

--- a/backend/src/controllers/gasto-recurrente.controller.ts
+++ b/backend/src/controllers/gasto-recurrente.controller.ts
@@ -84,3 +84,133 @@ export const crearGastoRecurrente: express.RequestHandler = async (req, res) => 
 
   res.status(201).json(gastoRecurrente);
 };
+
+export const actualizarGastoRecurrente: express.RequestHandler = async (req, res) => {
+  const viviendaId = obtenerParamNumerico(req.params.viviendaId);
+  const gastoRecurrenteId = obtenerParamNumerico(req.params.gastoRecurrenteId);
+  const usuarioId = req.usuario!.id;
+  const { concepto, importe, dia_del_mes, activo } = req.body as {
+    concepto?: string;
+    importe?: number;
+    dia_del_mes?: number;
+    activo?: boolean;
+  };
+
+  if (!Number.isInteger(viviendaId) || viviendaId <= 0) {
+    res.status(400).json({ error: 'viviendaId invÃ¡lido.' });
+    return;
+  }
+
+  if (!Number.isInteger(gastoRecurrenteId) || gastoRecurrenteId <= 0) {
+    res.status(400).json({ error: 'gastoRecurrenteId invÃ¡lido.' });
+    return;
+  }
+
+  const esCasero = await usuarioEsCaseroDeVivienda(viviendaId, usuarioId);
+  if (!esCasero) {
+    res.status(403).json({ error: 'Solo el casero puede modificar gastos fijos de esta vivienda.' });
+    return;
+  }
+
+  const gastoRecurrente = await prisma.gastoRecurrente.findFirst({
+    where: { id: gastoRecurrenteId, vivienda_id: viviendaId },
+    select: { id: true },
+  });
+
+  if (!gastoRecurrente) {
+    res.status(404).json({ error: 'Gasto fijo no encontrado.' });
+    return;
+  }
+
+  const data: {
+    concepto?: string;
+    importe?: number;
+    dia_del_mes?: number;
+    activo?: boolean;
+  } = {};
+
+  if (concepto !== undefined) {
+    if (!concepto.trim()) {
+      res.status(400).json({ error: 'concepto no puede estar vacÃ­o.' });
+      return;
+    }
+    data.concepto = concepto.trim();
+  }
+
+  if (importe !== undefined) {
+    if (typeof importe !== 'number' || importe <= 0) {
+      res.status(400).json({ error: 'importe debe ser mayor que 0.' });
+      return;
+    }
+    data.importe = importe;
+  }
+
+  if (dia_del_mes !== undefined) {
+    if (!Number.isInteger(dia_del_mes) || dia_del_mes < 1 || dia_del_mes > 31) {
+      res.status(400).json({ error: 'dia_del_mes debe ser un entero entre 1 y 31.' });
+      return;
+    }
+    data.dia_del_mes = dia_del_mes;
+  }
+
+  if (activo !== undefined) {
+    if (typeof activo !== 'boolean') {
+      res.status(400).json({ error: 'activo debe ser booleano.' });
+      return;
+    }
+    data.activo = activo;
+  }
+
+  if (Object.keys(data).length === 0) {
+    res.status(400).json({ error: 'No hay campos vÃ¡lidos para actualizar.' });
+    return;
+  }
+
+  const gastoActualizado = await prisma.gastoRecurrente.update({
+    where: { id: gastoRecurrenteId },
+    data,
+    include: {
+      pagador: { select: { id: true, nombre: true, apellidos: true } },
+    },
+  });
+
+  res.status(200).json(gastoActualizado);
+};
+
+export const eliminarGastoRecurrente: express.RequestHandler = async (req, res) => {
+  const viviendaId = obtenerParamNumerico(req.params.viviendaId);
+  const gastoRecurrenteId = obtenerParamNumerico(req.params.gastoRecurrenteId);
+  const usuarioId = req.usuario!.id;
+
+  if (!Number.isInteger(viviendaId) || viviendaId <= 0) {
+    res.status(400).json({ error: 'viviendaId invÃ¡lido.' });
+    return;
+  }
+
+  if (!Number.isInteger(gastoRecurrenteId) || gastoRecurrenteId <= 0) {
+    res.status(400).json({ error: 'gastoRecurrenteId invÃ¡lido.' });
+    return;
+  }
+
+  const esCasero = await usuarioEsCaseroDeVivienda(viviendaId, usuarioId);
+  if (!esCasero) {
+    res.status(403).json({ error: 'Solo el casero puede eliminar gastos fijos de esta vivienda.' });
+    return;
+  }
+
+  const gastoRecurrente = await prisma.gastoRecurrente.findFirst({
+    where: { id: gastoRecurrenteId, vivienda_id: viviendaId },
+    select: { id: true },
+  });
+
+  if (!gastoRecurrente) {
+    res.status(404).json({ error: 'Gasto fijo no encontrado.' });
+    return;
+  }
+
+  await prisma.gastoRecurrente.delete({
+    where: { id: gastoRecurrenteId },
+  });
+
+  res.status(200).json({ ok: true, gasto_recurrente_id: gastoRecurrenteId });
+};

--- a/backend/src/routes/gasto-recurrente.routes.ts
+++ b/backend/src/routes/gasto-recurrente.routes.ts
@@ -2,7 +2,9 @@ import express from 'express';
 import { verificarToken } from '../middlewares/auth.middleware';
 import { protegerModuloVivienda } from '../middlewares/module.guard';
 import {
+  actualizarGastoRecurrente,
   crearGastoRecurrente,
+  eliminarGastoRecurrente,
   listarGastosRecurrentes,
 } from '../controllers/gasto-recurrente.controller';
 
@@ -11,5 +13,17 @@ const gastosActivos = protegerModuloVivienda('gastos');
 
 router.get('/:viviendaId/gastos-recurrentes', verificarToken, gastosActivos, listarGastosRecurrentes);
 router.post('/:viviendaId/gastos-recurrentes', verificarToken, gastosActivos, crearGastoRecurrente);
+router.patch(
+  '/:viviendaId/gastos-recurrentes/:gastoRecurrenteId',
+  verificarToken,
+  gastosActivos,
+  actualizarGastoRecurrente,
+);
+router.delete(
+  '/:viviendaId/gastos-recurrentes/:gastoRecurrenteId',
+  verificarToken,
+  gastosActivos,
+  eliminarGastoRecurrente,
+);
 
 export default router;

--- a/backend/tests/gasto-recurrente.test.ts
+++ b/backend/tests/gasto-recurrente.test.ts
@@ -1,0 +1,151 @@
+import assert from 'node:assert/strict';
+import type express from 'express';
+import { beforeEach, describe, test, vi } from 'vitest';
+
+type UsuarioTest = { id: number; rol: 'CASERO' | 'INQUILINO' };
+type Handler = express.RequestHandler;
+
+const prisma = vi.hoisted(() => ({
+  vivienda: {
+    findFirst: async (_args: unknown): Promise<unknown> => {
+      throw new Error('Unexpected prisma call: vivienda.findFirst');
+    },
+  },
+  gastoRecurrente: {
+    findFirst: async (_args: unknown): Promise<unknown> => {
+      throw new Error('Unexpected prisma call: gastoRecurrente.findFirst');
+    },
+    update: async (_args: unknown): Promise<unknown> => {
+      throw new Error('Unexpected prisma call: gastoRecurrente.update');
+    },
+    delete: async (_args: unknown): Promise<unknown> => {
+      throw new Error('Unexpected prisma call: gastoRecurrente.delete');
+    },
+  },
+}));
+
+vi.mock('../src/lib/prisma', () => ({ prisma }));
+
+const {
+  actualizarGastoRecurrente,
+  eliminarGastoRecurrente,
+} = await import('../src/controllers/gasto-recurrente.controller');
+
+let ultimoFindFirst: unknown = null;
+let ultimoUpdate: unknown = null;
+let ultimoDelete: unknown = null;
+
+function resetPrisma() {
+  ultimoFindFirst = null;
+  ultimoUpdate = null;
+  ultimoDelete = null;
+
+  prisma.vivienda.findFirst = async () => ({ id: 1, casero_id: 99 });
+  prisma.gastoRecurrente.findFirst = async (args: unknown) => {
+    ultimoFindFirst = args;
+    return { id: 12 };
+  };
+  prisma.gastoRecurrente.update = async (args: unknown) => {
+    ultimoUpdate = args;
+    return { id: 12, ...(args as { data: unknown }).data };
+  };
+  prisma.gastoRecurrente.delete = async (args: unknown) => {
+    ultimoDelete = args;
+    return { id: 12 };
+  };
+}
+
+beforeEach(() => {
+  resetPrisma();
+});
+
+function request({
+  usuario,
+  params = {},
+  body = {},
+}: {
+  usuario: UsuarioTest;
+  params?: Record<string, string>;
+  body?: Record<string, unknown>;
+}) {
+  return {
+    usuario,
+    params,
+    body,
+  } as unknown as express.Request;
+}
+
+function response() {
+  const res = {
+    statusCode: 200,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  };
+
+  return res as unknown as express.Response & typeof res;
+}
+
+async function invoke(handler: Handler, req: express.Request) {
+  const res = response();
+  await handler(req, res, () => undefined);
+  return res;
+}
+
+describe('gastos recurrentes', () => {
+  test('permite al casero actualizar un gasto fijo de su vivienda', async () => {
+    const res = await invoke(
+      actualizarGastoRecurrente,
+      request({
+        usuario: { id: 99, rol: 'CASERO' },
+        params: { viviendaId: '1', gastoRecurrenteId: '12' },
+        body: { concepto: 'Internet fibra plus', importe: 65, dia_del_mes: 7 },
+      }),
+    );
+
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual((ultimoFindFirst as { where: unknown }).where, { id: 12, vivienda_id: 1 });
+    assert.deepEqual((ultimoUpdate as { where: unknown; data: unknown }).where, { id: 12 });
+    assert.deepEqual((ultimoUpdate as { data: unknown }).data, {
+      concepto: 'Internet fibra plus',
+      importe: 65,
+      dia_del_mes: 7,
+    });
+  });
+
+  test('rechaza editar gastos fijos de otra vivienda', async () => {
+    prisma.vivienda.findFirst = async () => null;
+
+    const res = await invoke(
+      actualizarGastoRecurrente,
+      request({
+        usuario: { id: 50, rol: 'CASERO' },
+        params: { viviendaId: '1', gastoRecurrenteId: '12' },
+        body: { concepto: 'Internet' },
+      }),
+    );
+
+    assert.equal(res.statusCode, 403);
+    assert.equal(ultimoUpdate, null);
+  });
+
+  test('permite al casero eliminar un gasto fijo de su vivienda', async () => {
+    const res = await invoke(
+      eliminarGastoRecurrente,
+      request({
+        usuario: { id: 99, rol: 'CASERO' },
+        params: { viviendaId: '1', gastoRecurrenteId: '12' },
+      }),
+    );
+
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(ultimoDelete, { where: { id: 12 } });
+    assert.deepEqual(res.body, { ok: true, gasto_recurrente_id: 12 });
+  });
+});

--- a/backend/tests/release-regression.test.ts
+++ b/backend/tests/release-regression.test.ts
@@ -54,6 +54,8 @@ const rutasProtegidas: Array<{
   { metodo: 'get', ruta: '/api/viviendas/1/cobros', flujo: 'cobros consultar' },
   { metodo: 'get', ruta: '/api/viviendas/1/gastos-recurrentes', flujo: 'mensualidades listar' },
   { metodo: 'post', ruta: '/api/viviendas/1/gastos-recurrentes', flujo: 'mensualidades crear' },
+  { metodo: 'patch', ruta: '/api/viviendas/1/gastos-recurrentes/1', flujo: 'mensualidades editar' },
+  { metodo: 'delete', ruta: '/api/viviendas/1/gastos-recurrentes/1', flujo: 'mensualidades eliminar' },
   { metodo: 'get', ruta: '/api/viviendas/1/inventario', flujo: 'inventario listar' },
   { metodo: 'post', ruta: '/api/viviendas/1/inventario', flujo: 'inventario crear item' },
   { metodo: 'patch', ruta: '/api/inventario/1/conformidad', flujo: 'inventario conformidad' },

--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -1334,6 +1334,51 @@ Crea una mensualidad recurrente para la vivienda como `FACTURA_MENSUAL`. Es un f
 
 ---
 
+### PATCH `/viviendas/:viviendaId/gastos-recurrentes/:gastoRecurrenteId`
+
+Actualiza una mensualidad recurrente de la vivienda. Es un flujo exclusivo del casero propietario.
+
+**Auth requerida:** Si - `Authorization: Bearer <token>`
+
+**Body (JSON):**
+
+Todos los campos son opcionales, pero debe enviarse al menos uno.
+
+| Campo | Tipo | Requerido | Descripcion |
+|---|---|---|---|
+| `concepto` | string | No | Nuevo nombre de la mensualidad; no puede estar vacio |
+| `importe` | number | No | Importe total, mayor que `0` |
+| `dia_del_mes` | number | No | Entero entre `1` y `31` |
+| `activo` | boolean | No | Activa o desactiva la generacion automatica |
+
+**Respuestas:**
+
+| Codigo | Descripcion |
+|---|---|
+| `200` | Mensualidad actualizada, incluyendo `pagador { id, nombre, apellidos }`. |
+| `400` | Parametros invalidos, payload invalido o sin campos actualizables. |
+| `403` | No eres el casero propietario de la vivienda. |
+| `404` | Gasto fijo no encontrado en esa vivienda. |
+
+---
+
+### DELETE `/viviendas/:viviendaId/gastos-recurrentes/:gastoRecurrenteId`
+
+Elimina una mensualidad recurrente de la vivienda. No borra gastos ya generados por el cron; solo impide nuevas generaciones desde esa plantilla.
+
+**Auth requerida:** Si - `Authorization: Bearer <token>`
+
+**Respuestas:**
+
+| Codigo | Descripcion |
+|---|---|
+| `200` | `{ "ok": true, "gasto_recurrente_id": number }`. |
+| `400` | `viviendaId` o `gastoRecurrenteId` invalidos. |
+| `403` | No eres el casero propietario de la vivienda. |
+| `404` | Gasto fijo no encontrado en esa vivienda. |
+
+---
+
 ### GET `/viviendas/:viviendaId/cobros`
 
 Devuelve el dashboard financiero mensual del casero para una vivienda.

--- a/docs/backend/setup.md
+++ b/docs/backend/setup.md
@@ -217,7 +217,7 @@ El seed de demo esta pensado para desarrollo local: usa emails `example.test`, c
 ## Update 2026-04-10 - Epica 12 (cobros y push)
 
 - `GastoRecurrente` forma parte del schema y su cron diario se inicia automaticamente al arrancar el backend.
-- Las mensualidades recurrentes son gestionadas por el casero propietario de la vivienda; al generarse, el casero queda como acreedor y se reparte entre inquilinos activos.
+- Las mensualidades recurrentes son gestionadas por el casero propietario de la vivienda con `GET/POST/PATCH/DELETE /api/viviendas/:viviendaId/gastos-recurrentes`; al generarse, el casero queda como acreedor y se reparte entre inquilinos activos.
 - `POST /api/deudas/:deudaId/justificante` reutiliza Cloudinary para guardar comprobantes en `roomies-justificantes`.
 - `PATCH /api/usuarios/me/push-token` permite registrar o limpiar el `expo_push_token` del usuario autenticado.
 - El cron mensual del dia 5 a las 12:00 envia recordatorios push de pago pendiente usando `expo-server-sdk`.

--- a/docs/changelog/Epica17/bugfix-gastos-fijos-sin-issue.md
+++ b/docs/changelog/Epica17/bugfix-gastos-fijos-sin-issue.md
@@ -1,0 +1,14 @@
+# Bugfix sin issue - Gastos fijos editables
+
+## Objetivo
+
+Permitir que el casero pueda cambiar y eliminar gastos fijos desde el resumen de vivienda, y limpiar el seed para no crear el alquiler mensual como mensualidad recurrente de ejemplo.
+
+## Cambios
+
+- `backend/src/controllers/gasto-recurrente.controller.ts`: añadidos handlers para actualizar y eliminar gastos recurrentes validando vivienda, propietario y payload.
+- `backend/src/routes/gasto-recurrente.routes.ts`: expuestos `PATCH` y `DELETE` para `/api/viviendas/:viviendaId/gastos-recurrentes/:gastoRecurrenteId`.
+- `frontend/app/casero/vivienda/[id]/(tabs)/index.tsx`: el modal de gasto fijo ahora sirve para crear y editar, y cada gasto activo muestra acciones de editar y eliminar.
+- `backend/prisma/seed.ts`: eliminado el gasto recurrente de alquiler mensual del seed demo.
+- `backend/tests/gasto-recurrente.test.ts` y `backend/tests/release-regression.test.ts`: cobertura de edición, eliminación y rutas protegidas.
+- `docs/backend/api.md`, `docs/backend/setup.md`, `docs/frontend/setup.md` y `CONTEXT.md`: documentados los endpoints de edición/eliminación, el comportamiento frontend y el seed sin alquiler mensual demo.

--- a/docs/frontend/setup.md
+++ b/docs/frontend/setup.md
@@ -308,8 +308,9 @@ La app usa `expo-notifications`.
 
 ### Mensualidades del casero
 
-- `casero/vivienda/[id]/(tabs)/index.tsx` lista y crea gastos fijos de la vivienda con `GET/POST /api/viviendas/:viviendaId/gastos-recurrentes`.
+- `casero/vivienda/[id]/(tabs)/index.tsx` lista, crea, edita y elimina gastos fijos de la vivienda con `GET`, `POST`, `PATCH` y `DELETE /api/viviendas/:viviendaId/gastos-recurrentes`.
 - El alta de mensualidad vive en el contexto de una vivienda concreta para que el backend pueda validar al casero propietario.
+- El mismo modal se reutiliza para crear y editar; cada tarjeta activa muestra acciones de editar y eliminar.
 - El inquilino no carga ni crea mensualidades recurrentes desde su tab de gastos.
 
 ### Gastos del inquilino

--- a/frontend/app/casero/vivienda/[id]/(tabs)/index.tsx
+++ b/frontend/app/casero/vivienda/[id]/(tabs)/index.tsx
@@ -141,6 +141,7 @@ export default function ResumenViviendaTab() {
   const [loading, setLoading] = useState(true);
   const [codigosRevelados, setCodigosRevelados] = useState<Record<number, boolean>>({});
   const [mensualidadModalVisible, setMensualidadModalVisible] = useState(false);
+  const [mensualidadEditando, setMensualidadEditando] = useState<GastoRecurrente | null>(null);
   const [conceptoMensualidad, setConceptoMensualidad] = useState('');
   const [importeMensualidad, setImporteMensualidad] = useState('');
   const [diaMensualidad, setDiaMensualidad] = useState('');
@@ -283,9 +284,26 @@ export default function ResumenViviendaTab() {
 
   const cerrarModalMensualidad = () => {
     setMensualidadModalVisible(false);
+    setMensualidadEditando(null);
     setConceptoMensualidad('');
     setImporteMensualidad('');
     setDiaMensualidad('');
+  };
+
+  const abrirModalCrearMensualidad = () => {
+    setMensualidadEditando(null);
+    setConceptoMensualidad('');
+    setImporteMensualidad('');
+    setDiaMensualidad('');
+    setMensualidadModalVisible(true);
+  };
+
+  const abrirModalEditarMensualidad = (gasto: GastoRecurrente) => {
+    setMensualidadEditando(gasto);
+    setConceptoMensualidad(gasto.concepto);
+    setImporteMensualidad(String(gasto.importe).replace('.', ','));
+    setDiaMensualidad(String(gasto.dia_del_mes));
+    setMensualidadModalVisible(true);
   };
 
   const handleGuardarMensualidad = async () => {
@@ -311,26 +329,58 @@ export default function ResumenViviendaTab() {
 
     setGuardandoMensualidad(true);
     try {
-      await api.post(`/viviendas/${id}/gastos-recurrentes`, {
+      const payload = {
         concepto: conceptoMensualidad.trim(),
         importe: importeNum,
         dia_del_mes: diaNum,
-      });
+      };
+
+      if (mensualidadEditando) {
+        await api.patch(`/viviendas/${id}/gastos-recurrentes/${mensualidadEditando.id}`, payload);
+      } else {
+        await api.post(`/viviendas/${id}/gastos-recurrentes`, payload);
+      }
       await cargarGastosRecurrentes();
       cerrarModalMensualidad();
       Toast.show({
         type: 'success',
-        text1: 'Gasto fijo creado',
+        text1: mensualidadEditando ? 'Gasto fijo actualizado' : 'Gasto fijo creado',
         text2: `${conceptoMensualidad.trim()} · ${formatearImporte(importeNum)} · Día ${diaNum}`,
       });
     } catch (err: any) {
       Toast.show({
         type: 'error',
-        text1: err.response?.data?.error ?? 'No se pudo crear el gasto fijo.',
+        text1: err.response?.data?.error ?? 'No se pudo guardar el gasto fijo.',
       });
     } finally {
       setGuardandoMensualidad(false);
     }
+  };
+
+  const handleEliminarMensualidad = (gasto: GastoRecurrente) => {
+    Alert.alert(
+      'Eliminar gasto fijo',
+      `¿Quieres eliminar "${gasto.concepto}"? No se generarán más cargos automáticos desde este gasto fijo.`,
+      [
+        { text: 'Cancelar', style: 'cancel' },
+        {
+          text: 'Eliminar',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await api.delete(`/viviendas/${id}/gastos-recurrentes/${gasto.id}`);
+              setGastosRecurrentes((prev) => prev.filter((item) => item.id !== gasto.id));
+              Toast.show({ type: 'success', text1: 'Gasto fijo eliminado' });
+            } catch (err: any) {
+              Toast.show({
+                type: 'error',
+                text1: err.response?.data?.error ?? 'No se pudo eliminar el gasto fijo.',
+              });
+            }
+          },
+        },
+      ],
+    );
   };
 
   const puedeGuardarMensualidad =
@@ -409,7 +459,7 @@ export default function ResumenViviendaTab() {
           </View>
           <Pressable
             style={({ pressed }) => [styles.secondaryButton, pressed && styles.secondaryButtonPressed]}
-            onPress={() => setMensualidadModalVisible(true)}
+            onPress={abrirModalCrearMensualidad}
             accessibilityRole="button"
             accessibilityLabel="Crear nuevo gasto fijo"
           >
@@ -443,8 +493,33 @@ export default function ResumenViviendaTab() {
                   {formatearImporte(gasto.importe)} · Día {gasto.dia_del_mes}
                 </Text>
               </View>
-              <View style={styles.recurringBadge}>
-                <Text style={styles.recurringBadgeText}>Activa</Text>
+              <View style={styles.recurringActions}>
+                <View style={styles.recurringBadge}>
+                  <Text style={styles.recurringBadgeText}>Activa</Text>
+                </View>
+                <Pressable
+                  style={({ pressed }) => [
+                    styles.recurringIconButton,
+                    pressed && styles.secondaryButtonPressed,
+                  ]}
+                  onPress={() => abrirModalEditarMensualidad(gasto)}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Editar ${gasto.concepto}`}
+                >
+                  <Ionicons name="create-outline" size={18} color={theme.colors.primary} />
+                </Pressable>
+                <Pressable
+                  style={({ pressed }) => [
+                    styles.recurringIconButton,
+                    styles.recurringDeleteButton,
+                    pressed && styles.secondaryButtonPressed,
+                  ]}
+                  onPress={() => handleEliminarMensualidad(gasto)}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Eliminar ${gasto.concepto}`}
+                >
+                  <Ionicons name="trash-outline" size={18} color={theme.colors.danger} />
+                </Pressable>
               </View>
             </View>
           ))
@@ -586,7 +661,9 @@ export default function ResumenViviendaTab() {
           <Pressable style={{ flex: 1 }} onPress={cerrarModalMensualidad} />
           <View style={styles.modalSheet}>
             <View style={styles.modalHandle} />
-            <Text style={styles.modalTitulo}>Nuevo gasto fijo</Text>
+            <Text style={styles.modalTitulo}>
+              {mensualidadEditando ? 'Editar gasto fijo' : 'Nuevo gasto fijo'}
+            </Text>
             <Text style={styles.modalSubtitulo}>
               Configura un recibo recurrente para esta vivienda y Roomies se encargará del reparto.
             </Text>
@@ -632,7 +709,7 @@ export default function ResumenViviendaTab() {
                 style={styles.modalBoton}
               />
               <CustomButton
-                label="Crear"
+                label={mensualidadEditando ? 'Guardar' : 'Crear'}
                 onPress={handleGuardarMensualidad}
                 disabled={!puedeGuardarMensualidad}
                 loading={guardandoMensualidad}

--- a/frontend/styles/casero/vivienda/detalle.styles.ts
+++ b/frontend/styles/casero/vivienda/detalle.styles.ts
@@ -239,6 +239,23 @@ export const createStyles = (theme: AppTheme = DefaultAppTheme) => StyleSheet.cr
     textTransform: 'uppercase',
     letterSpacing: 0,
   },
+  recurringActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: theme.spacing.xs,
+    flexShrink: 0,
+  },
+  recurringIconButton: {
+    width: 40,
+    height: 40,
+    borderRadius: theme.radius.full,
+    backgroundColor: theme.colors.primaryLight,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  recurringDeleteButton: {
+    backgroundColor: theme.colors.dangerLight,
+  },
   recurringEmptyCard: {
     flexDirection: 'row',
     alignItems: 'flex-start',


### PR DESCRIPTION
**Descripción:**
## Objetivo
Resolver la limitación del flujo de gastos fijos para que el casero pueda modificar y eliminar mensualidades recurrentes desde el resumen de vivienda, y retirar del seed demo el alquiler mensual que ya no debe crearse como plantilla recurrente.

## Cambios principales
* Se añaden los endpoints `PATCH` y `DELETE` para `/api/viviendas/:viviendaId/gastos-recurrentes/:gastoRecurrenteId` con validación de propietario, vivienda y payload.
* Se amplía el resumen de vivienda del casero para reutilizar el modal de gastos fijos en modo creación y edición.
* Cada gasto fijo activo muestra acciones directas para editar y eliminar desde la tarjeta.
* Se elimina la mensualidad de `Alquiler mensual` del seed de desarrollo y se ajusta el resumen de datos demo.
* Se añaden pruebas específicas para edición, borrado y cobertura de rutas protegidas de gastos recurrentes.
* Se actualiza la documentación técnica para reflejar el flujo completo de gastos fijos y el estado real del seed.

## UI / UX (Solo si aplica)
* Se añaden acciones compactas con iconos y tints suaves para editar y eliminar, siguiendo los tokens de `Theme.ts`.
* El modal reutilizado mantiene el patrón visual existente y cambia de contexto entre crear y editar sin duplicar interfaz.

## Changelog
* `docs/changelog/Epica17/bugfix-gastos-fijos-sin-issue.md`