### PR TITLE
[Épica Fiscal] Calcular ocupación anual y prorrateos por vivienda

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -12,6 +12,7 @@ import gastoRecurrenteRoutes from './routes/gasto-recurrente.routes';
 import deudaRoutes from './routes/deuda.routes';
 import userRoutes from './routes/user.routes';
 import inventarioRoutes from './routes/inventario.routes';
+import fiscalRoutes from './routes/fiscal.routes';
 
 const app = express();
 
@@ -30,6 +31,7 @@ app.use('/api/anuncios', anuncioRoutes);
 app.use('/api/viviendas', limpiezaRoutes);
 app.use('/api/viviendas', gastoRoutes);
 app.use('/api/viviendas', gastoRecurrenteRoutes);
+app.use('/api/viviendas', fiscalRoutes);
 app.use('/api', deudaRoutes);
 app.use('/api', inventarioRoutes);
 app.use('/api/usuarios', userRoutes);

--- a/backend/src/controllers/fiscal.controller.ts
+++ b/backend/src/controllers/fiscal.controller.ts
@@ -1,0 +1,38 @@
+import express from 'express';
+import { obtenerFotoOcupacionFiscalVivienda } from '../services/fiscal.service';
+
+const obtenerParamNumerico = (valor: string | string[] | undefined) => {
+  const normalizado = Array.isArray(valor) ? valor[0] : valor;
+  if (!normalizado) return NaN;
+  return parseInt(normalizado, 10);
+};
+
+export const obtenerOcupacionFiscalVivienda: express.RequestHandler = async (req, res) => {
+  const viviendaId = obtenerParamNumerico(req.params.viviendaId);
+  const ejercicio = obtenerParamNumerico(req.query.ejercicio as string | string[] | undefined);
+  const usuario = req.usuario!;
+
+  if (usuario.rol !== 'CASERO') {
+    res.status(403).json({ error: 'Solo el casero puede consultar la ocupacion fiscal.' });
+    return;
+  }
+
+  if (!Number.isInteger(viviendaId) || viviendaId <= 0) {
+    res.status(400).json({ error: 'viviendaId invalido.' });
+    return;
+  }
+
+  if (!Number.isInteger(ejercicio) || ejercicio < 2000 || ejercicio > 2100) {
+    res.status(400).json({ error: 'ejercicio debe ser un ano natural valido.' });
+    return;
+  }
+
+  const foto = await obtenerFotoOcupacionFiscalVivienda(viviendaId, usuario.id, ejercicio);
+
+  if (!foto) {
+    res.status(404).json({ error: 'Vivienda no encontrada.' });
+    return;
+  }
+
+  res.status(200).json(foto);
+};

--- a/backend/src/routes/fiscal.routes.ts
+++ b/backend/src/routes/fiscal.routes.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+import { obtenerOcupacionFiscalVivienda } from '../controllers/fiscal.controller';
+import { verificarToken } from '../middlewares/auth.middleware';
+
+const router = express.Router();
+
+router.get('/:viviendaId/fiscal/ocupacion', verificarToken, obtenerOcupacionFiscalVivienda);
+
+export default router;

--- a/backend/src/services/fiscal.service.ts
+++ b/backend/src/services/fiscal.service.ts
@@ -1,0 +1,389 @@
+import { prisma } from '../lib/prisma';
+import { aCentimos, desdeCentimos, normalizarImporteMonetario } from './gasto.service';
+
+type InquilinoFiscal = {
+  id: number;
+  nombre: string;
+  apellidos: string | null;
+  documento_identidad?: string | null;
+};
+
+type HabitacionFiscal = {
+  id: number;
+  nombre: string;
+  tipo: string;
+  es_habitable: boolean;
+  precio: number | null;
+  inquilino_id: number | null;
+  inquilino?: InquilinoFiscal | null;
+};
+
+type GastoFiscal = {
+  id: number;
+  concepto: string;
+  importe: number;
+  tipo: string;
+  fecha_creacion: Date;
+  periodo_facturacion: string | null;
+  habitacion_cargo_id: number | null;
+  inquilino_cargo_id: number | null;
+  prorrateo_fiscal: number | null;
+  inquilino_cargo?: InquilinoFiscal | null;
+};
+
+export type FiscalEstadoOcupacion = 'SIN_ACTIVIDAD' | 'PARCIAL' | 'TODO_EL_ANO';
+
+export type FiscalRevision = {
+  codigo: 'SIN_PERIODO_FACTURACION' | 'OCUPACION_ACTUAL_SIN_CARGOS' | 'SIN_PRECIO_HABITACION';
+  mensaje: string;
+};
+
+export type FiscalPeriodoOcupacion = {
+  inicio: string;
+  fin: string;
+  dias: number;
+  periodo_facturacion: string;
+  gasto_id: number;
+  inquilino: InquilinoFiscal | null;
+  importe: number;
+};
+
+export type FiscalHabitacionOcupacion = {
+  id: number;
+  nombre: string;
+  tipo: string;
+  es_habitable: boolean;
+  precio: number | null;
+  dias_alquilados: number;
+  meses_equivalentes: number;
+  porcentaje_ocupacion: number;
+  estado: FiscalEstadoOcupacion;
+  requiere_revision: boolean;
+  revisiones: FiscalRevision[];
+  periodos: FiscalPeriodoOcupacion[];
+};
+
+export type FiscalGastoProrrateado = {
+  id: number;
+  concepto: string;
+  importe: number;
+  tipo: string;
+  fecha: string;
+  prorrateo: {
+    modo: 'MANUAL' | 'OCUPACION';
+    porcentaje: number;
+    importe_prorrateado: number;
+  };
+};
+
+export type FiscalFotoOcupacionVivienda = {
+  ejercicio: number;
+  periodo: {
+    inicio: string;
+    fin: string;
+    dias: number;
+  };
+  vivienda: {
+    id: number;
+    alias_nombre: string;
+    direccion: string;
+    codigo_postal: string;
+    ciudad: string;
+    provincia: string;
+  };
+  resumen: {
+    dias_alquilados: number;
+    meses_equivalentes: number;
+    porcentaje_ocupacion: number;
+    estado: FiscalEstadoOcupacion;
+    habitaciones_con_actividad: number;
+    habitaciones_requieren_revision: number;
+    requiere_revision: boolean;
+  };
+  habitaciones: FiscalHabitacionOcupacion[];
+  gastos_prorrateados: FiscalGastoProrrateado[];
+};
+
+type ConstruirFotoInput = {
+  ejercicio: number;
+  vivienda: {
+    id: number;
+    alias_nombre: string;
+    direccion: string;
+    codigo_postal: string;
+    ciudad: string;
+    provincia: string;
+    habitaciones: HabitacionFiscal[];
+  };
+  gastos: GastoFiscal[];
+};
+
+const MS_DIA = 24 * 60 * 60 * 1000;
+
+const isoFecha = (fecha: Date) => fecha.toISOString().slice(0, 10);
+
+const diasEntre = (inicio: Date, fin: Date) => Math.round((fin.getTime() - inicio.getTime()) / MS_DIA);
+
+const redondear = (valor: number, decimales = 2) => {
+  const factor = 10 ** decimales;
+  return Math.round((valor + Number.EPSILON) * factor) / factor;
+};
+
+const parsePeriodoMensual = (periodo: string) => {
+  const match = /^(\d{4})-(\d{2})$/.exec(periodo);
+  if (!match) return null;
+
+  const ano = Number(match[1]);
+  const mes = Number(match[2]);
+  if (!Number.isInteger(ano) || !Number.isInteger(mes) || mes < 1 || mes > 12) return null;
+
+  return {
+    inicio: new Date(Date.UTC(ano, mes - 1, 1)),
+    fin: new Date(Date.UTC(ano, mes, 1)),
+  };
+};
+
+const recortarPeriodo = (inicio: Date, fin: Date, inicioEjercicio: Date, finEjercicio: Date) => {
+  const inicioRecortado = new Date(Math.max(inicio.getTime(), inicioEjercicio.getTime()));
+  const finRecortado = new Date(Math.min(fin.getTime(), finEjercicio.getTime()));
+
+  if (finRecortado <= inicioRecortado) return null;
+  return { inicio: inicioRecortado, fin: finRecortado };
+};
+
+const calcularEstado = (diasAlquilados: number, diasEjercicio: number): FiscalEstadoOcupacion => {
+  if (diasAlquilados <= 0) return 'SIN_ACTIVIDAD';
+  return diasAlquilados >= diasEjercicio ? 'TODO_EL_ANO' : 'PARCIAL';
+};
+
+const calcularProrrateo = (importe: number, porcentaje: number) =>
+  desdeCentimos(Math.round(aCentimos(importe) * (porcentaje / 100)));
+
+const obtenerPorcentajeProrrateo = (manual: number | null, porcentajeOcupacion: number) => {
+  if (manual !== null && Number.isFinite(manual) && manual >= 0 && manual <= 100) {
+    return { modo: 'MANUAL' as const, porcentaje: redondear(manual, 4) };
+  }
+
+  return { modo: 'OCUPACION' as const, porcentaje: porcentajeOcupacion };
+};
+
+export const construirFotoOcupacionFiscal = ({
+  ejercicio,
+  vivienda,
+  gastos,
+}: ConstruirFotoInput): FiscalFotoOcupacionVivienda => {
+  const inicioEjercicio = new Date(Date.UTC(ejercicio, 0, 1));
+  const finEjercicio = new Date(Date.UTC(ejercicio + 1, 0, 1));
+  const diasEjercicio = diasEntre(inicioEjercicio, finEjercicio);
+  const cargosAlquiler = gastos.filter((gasto) => gasto.tipo === 'ALQUILER_HABITACION');
+  const revisionesVivienda: FiscalRevision[] = [];
+
+  const habitaciones = vivienda.habitaciones.map((habitacion) => {
+    const revisiones: FiscalRevision[] = [];
+    const cargosHabitacion = cargosAlquiler.filter((gasto) => gasto.habitacion_cargo_id === habitacion.id);
+    const periodos: FiscalPeriodoOcupacion[] = [];
+
+    for (const cargo of cargosHabitacion) {
+      if (!cargo.periodo_facturacion) {
+        const revision = {
+          codigo: 'SIN_PERIODO_FACTURACION' as const,
+          mensaje: `El cargo ${cargo.id} no tiene periodo_facturacion para calcular ocupacion anual.`,
+        };
+        revisiones.push(revision);
+        revisionesVivienda.push(revision);
+        continue;
+      }
+
+      const periodo = parsePeriodoMensual(cargo.periodo_facturacion);
+      if (!periodo) {
+        const revision = {
+          codigo: 'SIN_PERIODO_FACTURACION' as const,
+          mensaje: `El cargo ${cargo.id} tiene un periodo_facturacion no mensual: ${cargo.periodo_facturacion}.`,
+        };
+        revisiones.push(revision);
+        revisionesVivienda.push(revision);
+        continue;
+      }
+
+      const recortado = recortarPeriodo(periodo.inicio, periodo.fin, inicioEjercicio, finEjercicio);
+      if (!recortado) continue;
+
+      periodos.push({
+        inicio: isoFecha(recortado.inicio),
+        fin: isoFecha(recortado.fin),
+        dias: diasEntre(recortado.inicio, recortado.fin),
+        periodo_facturacion: cargo.periodo_facturacion,
+        gasto_id: cargo.id,
+        inquilino: cargo.inquilino_cargo ?? null,
+        importe: normalizarImporteMonetario(cargo.importe),
+      });
+    }
+
+    if (periodos.length === 0 && habitacion.inquilino_id !== null && habitacion.es_habitable) {
+      revisiones.push({
+        codigo: 'OCUPACION_ACTUAL_SIN_CARGOS',
+        mensaje: 'La habitacion tiene inquilino actual, pero no hay cargos de alquiler del ejercicio.',
+      });
+    }
+
+    if (periodos.length > 0 && (habitacion.precio === null || habitacion.precio <= 0)) {
+      revisiones.push({
+        codigo: 'SIN_PRECIO_HABITACION',
+        mensaje: 'La habitacion tiene actividad anual, pero no conserva precio mensual valido.',
+      });
+    }
+
+    const diasAlquilados = periodos.reduce((total, periodo) => total + periodo.dias, 0);
+    const porcentajeOcupacion = redondear((Math.min(diasAlquilados, diasEjercicio) / diasEjercicio) * 100, 4);
+
+    return {
+      id: habitacion.id,
+      nombre: habitacion.nombre,
+      tipo: habitacion.tipo,
+      es_habitable: habitacion.es_habitable,
+      precio: habitacion.precio,
+      dias_alquilados: diasAlquilados,
+      meses_equivalentes: redondear(diasAlquilados / (diasEjercicio / 12), 2),
+      porcentaje_ocupacion: porcentajeOcupacion,
+      estado: calcularEstado(diasAlquilados, diasEjercicio),
+      requiere_revision: revisiones.length > 0,
+      revisiones,
+      periodos: periodos.sort((a, b) => a.inicio.localeCompare(b.inicio)),
+    };
+  });
+
+  const diasAlquiladosVivienda = Math.max(0, ...habitaciones.map((habitacion) => habitacion.dias_alquilados));
+  const porcentajeOcupacionVivienda = redondear((Math.min(diasAlquiladosVivienda, diasEjercicio) / diasEjercicio) * 100, 4);
+  const gastosProrrateados = gastos
+    .filter((gasto) => gasto.tipo !== 'ALQUILER_HABITACION')
+    .map((gasto) => {
+      const prorrateo = obtenerPorcentajeProrrateo(gasto.prorrateo_fiscal, porcentajeOcupacionVivienda);
+
+      return {
+        id: gasto.id,
+        concepto: gasto.concepto,
+        importe: normalizarImporteMonetario(gasto.importe),
+        tipo: gasto.tipo,
+        fecha: isoFecha(gasto.fecha_creacion),
+        prorrateo: {
+          modo: prorrateo.modo,
+          porcentaje: prorrateo.porcentaje,
+          importe_prorrateado: calcularProrrateo(gasto.importe, prorrateo.porcentaje),
+        },
+      };
+    });
+
+  return {
+    ejercicio,
+    periodo: {
+      inicio: isoFecha(inicioEjercicio),
+      fin: isoFecha(finEjercicio),
+      dias: diasEjercicio,
+    },
+    vivienda: {
+      id: vivienda.id,
+      alias_nombre: vivienda.alias_nombre,
+      direccion: vivienda.direccion,
+      codigo_postal: vivienda.codigo_postal,
+      ciudad: vivienda.ciudad,
+      provincia: vivienda.provincia,
+    },
+    resumen: {
+      dias_alquilados: diasAlquiladosVivienda,
+      meses_equivalentes: redondear(diasAlquiladosVivienda / (diasEjercicio / 12), 2),
+      porcentaje_ocupacion: porcentajeOcupacionVivienda,
+      estado: calcularEstado(diasAlquiladosVivienda, diasEjercicio),
+      habitaciones_con_actividad: habitaciones.filter((habitacion) => habitacion.dias_alquilados > 0).length,
+      habitaciones_requieren_revision: habitaciones.filter((habitacion) => habitacion.requiere_revision).length,
+      requiere_revision:
+        revisionesVivienda.length > 0 || habitaciones.some((habitacion) => habitacion.requiere_revision),
+    },
+    habitaciones,
+    gastos_prorrateados: gastosProrrateados,
+  };
+};
+
+export const obtenerFotoOcupacionFiscalVivienda = async (
+  viviendaId: number,
+  caseroId: number,
+  ejercicio: number,
+) => {
+  const vivienda = await prisma.vivienda.findFirst({
+    where: { id: viviendaId, casero_id: caseroId },
+    select: {
+      id: true,
+      alias_nombre: true,
+      direccion: true,
+      codigo_postal: true,
+      ciudad: true,
+      provincia: true,
+      habitaciones: {
+        orderBy: { id: 'asc' },
+        select: {
+          id: true,
+          nombre: true,
+          tipo: true,
+          es_habitable: true,
+          precio: true,
+          inquilino_id: true,
+          inquilino: {
+            select: {
+              id: true,
+              nombre: true,
+              apellidos: true,
+              documento_identidad: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!vivienda) return null;
+
+  const inicioEjercicio = new Date(Date.UTC(ejercicio, 0, 1));
+  const finEjercicio = new Date(Date.UTC(ejercicio + 1, 0, 1));
+  const gastos = await prisma.gasto.findMany({
+    where: {
+      vivienda_id: viviendaId,
+      OR: [
+        {
+          tipo: 'ALQUILER_HABITACION',
+          periodo_facturacion: {
+            gte: `${ejercicio}-01`,
+            lte: `${ejercicio}-12`,
+          },
+        },
+        {
+          tipo: { not: 'ENTRE_COMPANEROS' },
+          fecha_creacion: {
+            gte: inicioEjercicio,
+            lt: finEjercicio,
+          },
+        },
+      ],
+    },
+    orderBy: [{ fecha_creacion: 'asc' }, { id: 'asc' }],
+    select: {
+      id: true,
+      concepto: true,
+      importe: true,
+      tipo: true,
+      fecha_creacion: true,
+      periodo_facturacion: true,
+      habitacion_cargo_id: true,
+      inquilino_cargo_id: true,
+      prorrateo_fiscal: true,
+      inquilino_cargo: {
+        select: {
+          id: true,
+          nombre: true,
+          apellidos: true,
+          documento_identidad: true,
+        },
+      },
+    },
+  });
+
+  return construirFotoOcupacionFiscal({ ejercicio, vivienda, gastos });
+};

--- a/backend/tests/fiscal.service.test.ts
+++ b/backend/tests/fiscal.service.test.ts
@@ -1,0 +1,184 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'vitest';
+import { construirFotoOcupacionFiscal } from '../src/services/fiscal.service';
+
+const viviendaBase = {
+  id: 1,
+  alias_nombre: 'Piso Centro',
+  direccion: 'Calle Luna 1',
+  codigo_postal: '28001',
+  ciudad: 'Madrid',
+  provincia: 'Madrid',
+};
+
+const inquilinoAna = {
+  id: 10,
+  nombre: 'Ana',
+  apellidos: 'Lopez',
+  documento_identidad: '11111111A',
+};
+
+const inquilinoLuis = {
+  id: 11,
+  nombre: 'Luis',
+  apellidos: 'Garcia',
+  documento_identidad: '22222222B',
+};
+
+const habitacionAzul = {
+  id: 7,
+  nombre: 'Habitacion azul',
+  tipo: 'DORMITORIO',
+  es_habitable: true,
+  precio: 450,
+  inquilino_id: null,
+  inquilino: null,
+};
+
+const habitacionVerde = {
+  id: 8,
+  nombre: 'Habitacion verde',
+  tipo: 'DORMITORIO',
+  es_habitable: true,
+  precio: 400,
+  inquilino_id: null,
+  inquilino: null,
+};
+
+const alquiler = ({
+  id,
+  mes,
+  habitacionId,
+  inquilino,
+  importe = 450,
+}: {
+  id: number;
+  mes: string;
+  habitacionId: number;
+  inquilino: typeof inquilinoAna;
+  importe?: number;
+}) => ({
+  id,
+  concepto: `Alquiler ${mes}`,
+  importe,
+  tipo: 'ALQUILER_HABITACION',
+  fecha_creacion: new Date(`${mes}-01T00:00:00.000Z`),
+  periodo_facturacion: mes,
+  habitacion_cargo_id: habitacionId,
+  inquilino_cargo_id: inquilino.id,
+  prorrateo_fiscal: null,
+  inquilino_cargo: inquilino,
+});
+
+describe('fiscal.service', () => {
+  test('calcula una foto anual con cambio de inquilino en la misma habitacion', () => {
+    const foto = construirFotoOcupacionFiscal({
+      ejercicio: 2026,
+      vivienda: {
+        ...viviendaBase,
+        habitaciones: [habitacionAzul],
+      },
+      gastos: [
+        alquiler({ id: 1, mes: '2026-01', habitacionId: 7, inquilino: inquilinoAna }),
+        alquiler({ id: 2, mes: '2026-02', habitacionId: 7, inquilino: inquilinoAna }),
+        alquiler({ id: 3, mes: '2026-03', habitacionId: 7, inquilino: inquilinoLuis }),
+      ],
+    });
+
+    assert.equal(foto.resumen.estado, 'PARCIAL');
+    assert.equal(foto.resumen.dias_alquilados, 90);
+    assert.equal(foto.habitaciones[0].periodos.length, 3);
+    assert.deepEqual(
+      foto.habitaciones[0].periodos.map((periodo) => periodo.inquilino?.id),
+      [10, 10, 11],
+    );
+    assert.equal(foto.habitaciones[0].requiere_revision, false);
+  });
+
+  test('distingue habitaciones vacias y viviendas sin actividad', () => {
+    const foto = construirFotoOcupacionFiscal({
+      ejercicio: 2026,
+      vivienda: {
+        ...viviendaBase,
+        habitaciones: [habitacionAzul, habitacionVerde],
+      },
+      gastos: [],
+    });
+
+    assert.equal(foto.resumen.estado, 'SIN_ACTIVIDAD');
+    assert.equal(foto.resumen.habitaciones_con_actividad, 0);
+    assert.equal(foto.resumen.requiere_revision, false);
+    assert.deepEqual(
+      foto.habitaciones.map((habitacion) => habitacion.estado),
+      ['SIN_ACTIVIDAD', 'SIN_ACTIVIDAD'],
+    );
+  });
+
+  test('calcula periodos parciales y prorrateos por ocupacion o porcentaje manual', () => {
+    const foto = construirFotoOcupacionFiscal({
+      ejercicio: 2026,
+      vivienda: {
+        ...viviendaBase,
+        habitaciones: [habitacionAzul],
+      },
+      gastos: [
+        alquiler({ id: 1, mes: '2026-01', habitacionId: 7, inquilino: inquilinoAna }),
+        alquiler({ id: 2, mes: '2026-02', habitacionId: 7, inquilino: inquilinoAna }),
+        {
+          id: 20,
+          concepto: 'Seguro hogar',
+          importe: 120,
+          tipo: 'FACTURA_PUNTUAL',
+          fecha_creacion: new Date('2026-02-10T00:00:00.000Z'),
+          periodo_facturacion: null,
+          habitacion_cargo_id: null,
+          inquilino_cargo_id: null,
+          prorrateo_fiscal: null,
+          inquilino_cargo: null,
+        },
+        {
+          id: 21,
+          concepto: 'IBI',
+          importe: 300,
+          tipo: 'FACTURA_PUNTUAL',
+          fecha_creacion: new Date('2026-03-10T00:00:00.000Z'),
+          periodo_facturacion: null,
+          habitacion_cargo_id: null,
+          inquilino_cargo_id: null,
+          prorrateo_fiscal: 25,
+          inquilino_cargo: null,
+        },
+      ],
+    });
+
+    assert.equal(foto.habitaciones[0].dias_alquilados, 59);
+    assert.equal(foto.habitaciones[0].meses_equivalentes, 1.94);
+    assert.equal(foto.resumen.porcentaje_ocupacion, 16.1644);
+    assert.deepEqual(foto.gastos_prorrateados, [
+      {
+        id: 20,
+        concepto: 'Seguro hogar',
+        importe: 120,
+        tipo: 'FACTURA_PUNTUAL',
+        fecha: '2026-02-10',
+        prorrateo: {
+          modo: 'OCUPACION',
+          porcentaje: 16.1644,
+          importe_prorrateado: 19.4,
+        },
+      },
+      {
+        id: 21,
+        concepto: 'IBI',
+        importe: 300,
+        tipo: 'FACTURA_PUNTUAL',
+        fecha: '2026-03-10',
+        prorrateo: {
+          modo: 'MANUAL',
+          porcentaje: 25,
+          importe_prorrateado: 75,
+        },
+      },
+    ]);
+  });
+});

--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -1445,6 +1445,95 @@ Devuelve el dashboard financiero mensual del casero para una vivienda.
 
 ---
 
+## Fiscal (`/viviendas/:viviendaId`)
+
+### GET `/viviendas/:viviendaId/fiscal/ocupacion?ejercicio=YYYY`
+
+Devuelve la foto anual de ocupacion fiscal de una vivienda, con detalle por habitacion y prorrateos deterministas para gastos del ejercicio.
+
+**Auth requerida:** Si - `Authorization: Bearer <token>`
+
+**Reglas de acceso:**
+- Solo el `CASERO` propietario de la vivienda puede consultar este endpoint.
+- `ejercicio` es obligatorio y representa un ano natural.
+
+**Comportamiento:**
+- Usa cargos `ALQUILER_HABITACION` con `periodo_facturacion` mensual (`YYYY-MM`) para calcular dias alquilados, meses equivalentes y porcentaje de ocupacion.
+- Distingue viviendas y habitaciones `SIN_ACTIVIDAD`, `PARCIAL` y `TODO_EL_ANO`.
+- Marca `requiere_revision` cuando faltan periodos de facturacion, hay ocupacion actual sin cargos del ejercicio o una habitacion con actividad no conserva precio valido.
+- Prorratea gastos del flujo del casero por porcentaje manual (`prorrateo_fiscal`) cuando existe; si no, usa el porcentaje anual de ocupacion de la vivienda.
+
+**Respuestas:**
+
+| Codigo | Descripcion |
+|---|---|
+| `200` | Foto anual de ocupacion fiscal. |
+| `400` | `viviendaId` o `ejercicio` invalidos. |
+| `403` | El usuario no es casero o no puede consultar fiscalidad de la vivienda. |
+| `404` | Vivienda no encontrada. |
+
+**Ejemplo respuesta 200:**
+```json
+{
+  "ejercicio": 2026,
+  "periodo": { "inicio": "2026-01-01", "fin": "2027-01-01", "dias": 365 },
+  "vivienda": {
+    "id": 3,
+    "alias_nombre": "Piso Centro",
+    "direccion": "Calle Mayor 10",
+    "codigo_postal": "28013",
+    "ciudad": "Madrid",
+    "provincia": "Madrid"
+  },
+  "resumen": {
+    "dias_alquilados": 90,
+    "meses_equivalentes": 2.96,
+    "porcentaje_ocupacion": 24.6575,
+    "estado": "PARCIAL",
+    "habitaciones_con_actividad": 1,
+    "habitaciones_requieren_revision": 0,
+    "requiere_revision": false
+  },
+  "habitaciones": [
+    {
+      "id": 7,
+      "nombre": "Habitacion azul",
+      "dias_alquilados": 90,
+      "meses_equivalentes": 2.96,
+      "porcentaje_ocupacion": 24.6575,
+      "estado": "PARCIAL",
+      "requiere_revision": false,
+      "periodos": [
+        {
+          "inicio": "2026-01-01",
+          "fin": "2026-02-01",
+          "dias": 31,
+          "periodo_facturacion": "2026-01",
+          "gasto_id": 18,
+          "importe": 450
+        }
+      ]
+    }
+  ],
+  "gastos_prorrateados": [
+    {
+      "id": 24,
+      "concepto": "Seguro hogar",
+      "importe": 120,
+      "tipo": "FACTURA_PUNTUAL",
+      "fecha": "2026-02-10",
+      "prorrateo": {
+        "modo": "OCUPACION",
+        "porcentaje": 24.6575,
+        "importe_prorrateado": 29.59
+      }
+    }
+  ]
+}
+```
+
+---
+
 ## Deudas (`/deudas`)
 
 ### POST `/deudas/:deudaId/justificante`

--- a/docs/changelog/EpicaFiscal/epica-fiscal-issue-325-ocupacion-prorrateos.md
+++ b/docs/changelog/EpicaFiscal/epica-fiscal-issue-325-ocupacion-prorrateos.md
@@ -1,0 +1,22 @@
+# Epica Fiscal - Issue 325 - Ocupacion y prorrateos por vivienda
+
+## Objetivo
+
+Preparar el backend para devolver una foto anual de ocupacion por vivienda y habitacion, incluyendo periodos parciales, cambios de inquilino y prorrateos revisables.
+
+## Cambios
+
+- Se anade un servicio fiscal testable que calcula dias alquilados, meses equivalentes, porcentaje de ocupacion y estado (`SIN_ACTIVIDAD`, `PARCIAL`, `TODO_EL_ANO`) por vivienda y habitacion.
+- La ocupacion anual se apoya en cargos `ALQUILER_HABITACION` con `periodo_facturacion` mensual, preservando el inquilino asociado al cargo cuando existe.
+- Se marcan revisiones manuales cuando faltan periodos de facturacion, existe ocupacion actual sin cargos del ejercicio o una habitacion con actividad no conserva precio valido.
+- Se calculan prorrateos de gastos por porcentaje manual (`prorrateo_fiscal`) o, si no existe, por porcentaje anual de ocupacion de la vivienda.
+- Se expone `GET /api/viviendas/:viviendaId/fiscal/ocupacion?ejercicio=YYYY` para caseros propietarios.
+- Se documenta el endpoint en `docs/backend/api.md`.
+
+## Validacion
+
+- Se anaden tests unitarios para cambio de inquilino, habitaciones vacias, periodos parciales y prorrateos manuales/por ocupacion.
+
+## Riesgos conocidos
+
+- El modelo actual no guarda historico explicito de altas y bajas de contrato; cuando faltan cargos mensuales suficientes, el backend marca revision manual en vez de inferir fechas.


### PR DESCRIPTION
**Descripción:**
## Objetivo
Esta PR añade una foto anual de ocupación fiscal por vivienda y habitación para poder calcular periodos alquilados, distinguir viviendas con actividad parcial o completa y preparar prorrateos revisables cuando falten datos o exista un porcentaje manual.

## Cambios principales
* Se incorpora un servicio fiscal backend para calcular días alquilados, meses equivalentes, porcentaje de ocupación y estado anual por vivienda y habitación.
* Se reutilizan los cargos `ALQUILER_HABITACION` como fuente de periodos mensuales y se conservan los datos del inquilino asociado a cada cargo.
* Se marcan revisiones manuales cuando faltan `periodo_facturacion`, hay ocupación actual sin cargos del ejercicio o una habitación con actividad no tiene precio válido.
* Se calculan prorrateos de gastos usando `prorrateo_fiscal` cuando existe; en caso contrario se aplica el porcentaje de ocupación anual de la vivienda.
* Se expone el endpoint `GET /api/viviendas/:viviendaId/fiscal/ocupacion?ejercicio=YYYY` para el casero propietario.
* Se añaden tests unitarios para cambios de inquilino, habitaciones vacías y periodos parciales con prorrateos deterministas.

## UI / UX (Solo si aplica)
* No aplica.

## Changelog
* `docs/changelog/EpicaFiscal/epica-fiscal-issue-325-ocupacion-prorrateos.md`