### PR TITLE
[Épica Fiscal] Añade el resumen fiscal anual por vivienda

### DIFF
--- a/backend/src/controllers/fiscal.controller.ts
+++ b/backend/src/controllers/fiscal.controller.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { obtenerFotoOcupacionFiscalVivienda } from '../services/fiscal.service';
+import { obtenerFotoOcupacionFiscalVivienda, obtenerResumenFiscalAnualVivienda } from '../services/fiscal.service';
 
 const obtenerParamNumerico = (valor: string | string[] | undefined) => {
   const normalizado = Array.isArray(valor) ? valor[0] : valor;
@@ -35,4 +35,34 @@ export const obtenerOcupacionFiscalVivienda: express.RequestHandler = async (req
   }
 
   res.status(200).json(foto);
+};
+
+export const obtenerResumenFiscalVivienda: express.RequestHandler = async (req, res) => {
+  const viviendaId = obtenerParamNumerico(req.params.viviendaId);
+  const ejercicio = obtenerParamNumerico(req.params.ejercicio);
+  const usuario = req.usuario!;
+
+  if (usuario.rol !== 'CASERO') {
+    res.status(403).json({ error: 'Solo el casero propietario puede consultar el resumen fiscal.' });
+    return;
+  }
+
+  if (!Number.isInteger(viviendaId) || viviendaId <= 0) {
+    res.status(400).json({ error: 'viviendaId invalido.' });
+    return;
+  }
+
+  if (!Number.isInteger(ejercicio) || ejercicio < 2000 || ejercicio > 2100) {
+    res.status(400).json({ error: 'ejercicio debe ser un ano natural valido.' });
+    return;
+  }
+
+  const resumen = await obtenerResumenFiscalAnualVivienda(viviendaId, usuario.id, ejercicio);
+
+  if (!resumen) {
+    res.status(404).json({ error: 'Vivienda no encontrada.' });
+    return;
+  }
+
+  res.status(200).json(resumen);
 };

--- a/backend/src/routes/fiscal.routes.ts
+++ b/backend/src/routes/fiscal.routes.ts
@@ -1,9 +1,10 @@
 import express from 'express';
-import { obtenerOcupacionFiscalVivienda } from '../controllers/fiscal.controller';
+import { obtenerOcupacionFiscalVivienda, obtenerResumenFiscalVivienda } from '../controllers/fiscal.controller';
 import { verificarToken } from '../middlewares/auth.middleware';
 
 const router = express.Router();
 
 router.get('/:viviendaId/fiscal/ocupacion', verificarToken, obtenerOcupacionFiscalVivienda);
+router.get('/:viviendaId/fiscal/:ejercicio', verificarToken, obtenerResumenFiscalVivienda);
 
 export default router;

--- a/backend/src/services/fiscal.service.ts
+++ b/backend/src/services/fiscal.service.ts
@@ -1,5 +1,12 @@
 import { prisma } from '../lib/prisma';
-import { aCentimos, desdeCentimos, normalizarImporteMonetario } from './gasto.service';
+import {
+  aCentimos,
+  CategoriaFiscalGastoRoomies,
+  desdeCentimos,
+  normalizarImporteMonetario,
+  TIPOS_GASTO_CASERO,
+  TipoGastoRoomies,
+} from './gasto.service';
 
 type InquilinoFiscal = {
   id: number;
@@ -23,6 +30,10 @@ type GastoFiscal = {
   concepto: string;
   importe: number;
   tipo: string;
+  factura_url?: string | null;
+  categoria_fiscal?: CategoriaFiscalGastoRoomies;
+  deducible_previsto?: boolean | null;
+  notas_fiscales?: string | null;
   fecha_creacion: Date;
   periodo_facturacion: string | null;
   habitacion_cargo_id: number | null;
@@ -118,6 +129,114 @@ type ConstruirFotoInput = {
   gastos: GastoFiscal[];
 };
 
+type CaseroFiscal = {
+  id: number;
+  nombre: string;
+  apellidos: string | null;
+  documento_identidad?: string | null;
+};
+
+type ViviendaResumenFiscal = {
+  id: number;
+  alias_nombre: string;
+  direccion: string;
+  codigo_postal: string;
+  ciudad: string;
+  provincia: string;
+  casero: CaseroFiscal;
+  habitaciones?: Array<{
+    id: number;
+    nombre: string;
+  }>;
+};
+
+type DeudaResumenFiscal = {
+  id: number;
+  importe: number;
+  estado: string;
+  justificante_url: string | null;
+  deudor: InquilinoFiscal;
+  gasto: GastoFiscal & {
+    habitacion_cargo?: { id: number; nombre: string } | null;
+    inquilino_cargo?: InquilinoFiscal | null;
+  };
+};
+
+export type FiscalAdvertenciaResumen = {
+  codigo:
+    | 'FALTA_FACTURA'
+    | 'FALTA_CATEGORIA'
+    | 'IMPORTE_PENDIENTE'
+    | 'PERIODO_INCOMPLETO'
+    | 'PRORRATEO_MANUAL';
+  mensaje: string;
+  gasto_id?: number;
+  deuda_id?: number;
+};
+
+type FiscalEstadoPagoResumen = 'COBRADO' | 'PENDIENTE' | 'ANULADO';
+type FiscalDeducibilidadResumen = 'NO_APLICA' | 'PENDIENTE_CLASIFICACION' | 'DEDUCIBLE' | 'NO_DEDUCIBLE';
+
+export type FiscalLineaResumen = {
+  id: string;
+  naturaleza: 'INGRESO' | 'GASTO_POTENCIALMENTE_DEDUCIBLE';
+  fuente: {
+    modelo: 'Deuda' | 'Gasto';
+    gasto_id: number;
+    deuda_id?: number;
+  };
+  concepto: string;
+  categoria: TipoGastoRoomies | CategoriaFiscalGastoRoomies | 'PENDIENTE_CLASIFICACION';
+  deducibilidad: FiscalDeducibilidadResumen;
+  importe: number;
+  moneda: 'EUR';
+  fecha: string;
+  periodo_facturacion: string | null;
+  estado_pago: FiscalEstadoPagoResumen;
+  factura_url: string | null;
+  justificante_url?: string | null;
+  habitacion?: {
+    id: number;
+    nombre: string;
+  } | null;
+  inquilino?: InquilinoFiscal | null;
+  advertencias: FiscalAdvertenciaResumen[];
+};
+
+export type FiscalResumenAnualVivienda = {
+  ejercicio: number;
+  generado_en: string;
+  vivienda: {
+    id: number;
+    alias_nombre: string;
+    direccion: string;
+    codigo_postal: string;
+    ciudad: string;
+    provincia: string;
+  };
+  casero: CaseroFiscal;
+  totales: {
+    ingresos: {
+      emitido: number;
+      cobrado: number;
+      pendiente: number;
+      anulado: number;
+      por_tipo: Record<string, number>;
+    };
+    gastos: {
+      potencialmente_deducible: number;
+      deducible_previsto: number;
+      no_deducible_previsto: number;
+      pendiente_clasificacion: number;
+      con_factura: number;
+      sin_factura: number;
+      por_categoria: Record<string, number>;
+    };
+  };
+  lineas: FiscalLineaResumen[];
+  advertencias: FiscalAdvertenciaResumen[];
+};
+
 const MS_DIA = 24 * 60 * 60 * 1000;
 
 const isoFecha = (fecha: Date) => fecha.toISOString().slice(0, 10);
@@ -158,6 +277,64 @@ const calcularEstado = (diasAlquilados: number, diasEjercicio: number): FiscalEs
 
 const calcularProrrateo = (importe: number, porcentaje: number) =>
   desdeCentimos(Math.round(aCentimos(importe) * (porcentaje / 100)));
+
+const sumarCentimos = (importes: number[]) =>
+  desdeCentimos(importes.reduce((total, importe) => total + aCentimos(importe), 0));
+
+const sumarEnMapa = (mapa: Record<string, number>, clave: string, importe: number) => {
+  mapa[clave] = sumarCentimos([mapa[clave] ?? 0, importe]);
+};
+
+const esPeriodoMensualDelEjercicio = (periodo: string | null, ejercicio: number) => {
+  if (!periodo) return false;
+  const periodoMensual = parsePeriodoMensual(periodo);
+  return periodoMensual !== null && periodo.startsWith(`${ejercicio}-`);
+};
+
+const construirAdvertenciasGasto = (gasto: GastoFiscal, ejercicio: number): FiscalAdvertenciaResumen[] => {
+  const advertencias: FiscalAdvertenciaResumen[] = [];
+
+  if (!gasto.factura_url) {
+    advertencias.push({
+      codigo: 'FALTA_FACTURA',
+      mensaje: `El gasto ${gasto.id} no tiene factura asociada.`,
+      gasto_id: gasto.id,
+    });
+  }
+
+  if ((gasto.categoria_fiscal ?? 'SIN_CLASIFICAR') === 'SIN_CLASIFICAR') {
+    advertencias.push({
+      codigo: 'FALTA_CATEGORIA',
+      mensaje: `El gasto ${gasto.id} esta sin categoria fiscal.`,
+      gasto_id: gasto.id,
+    });
+  }
+
+  if (gasto.tipo === 'ALQUILER_HABITACION' && !esPeriodoMensualDelEjercicio(gasto.periodo_facturacion, ejercicio)) {
+    advertencias.push({
+      codigo: 'PERIODO_INCOMPLETO',
+      mensaje: `El alquiler ${gasto.id} no conserva un periodo mensual valido del ejercicio.`,
+      gasto_id: gasto.id,
+    });
+  }
+
+  if (gasto.prorrateo_fiscal !== null && gasto.prorrateo_fiscal !== undefined) {
+    advertencias.push({
+      codigo: 'PRORRATEO_MANUAL',
+      mensaje: `El gasto ${gasto.id} usa prorrateo fiscal manual.`,
+      gasto_id: gasto.id,
+    });
+  }
+
+  return advertencias;
+};
+
+const deducibilidadDesdeGasto = (gasto: GastoFiscal): FiscalDeducibilidadResumen => {
+  if ((gasto.categoria_fiscal ?? 'SIN_CLASIFICAR') === 'SIN_CLASIFICAR') return 'PENDIENTE_CLASIFICACION';
+  if (gasto.deducible_previsto === true) return 'DEDUCIBLE';
+  if (gasto.deducible_previsto === false) return 'NO_DEDUCIBLE';
+  return 'PENDIENTE_CLASIFICACION';
+};
 
 const obtenerPorcentajeProrrateo = (manual: number | null, porcentajeOcupacion: number) => {
   if (manual !== null && Number.isFinite(manual) && manual >= 0 && manual <= 100) {
@@ -303,6 +480,151 @@ export const construirFotoOcupacionFiscal = ({
   };
 };
 
+export const construirResumenFiscalAnual = ({
+  ejercicio,
+  vivienda,
+  deudas,
+  gastos,
+  generadoEn = new Date(),
+}: {
+  ejercicio: number;
+  vivienda: ViviendaResumenFiscal;
+  deudas: DeudaResumenFiscal[];
+  gastos: GastoFiscal[];
+  generadoEn?: Date;
+}): FiscalResumenAnualVivienda => {
+  const ingresos = {
+    emitido: 0,
+    cobrado: 0,
+    pendiente: 0,
+    anulado: 0,
+    por_tipo: {} as Record<string, number>,
+  };
+  const gastosTotales = {
+    potencialmente_deducible: 0,
+    deducible_previsto: 0,
+    no_deducible_previsto: 0,
+    pendiente_clasificacion: 0,
+    con_factura: 0,
+    sin_factura: 0,
+    por_categoria: {} as Record<string, number>,
+  };
+
+  const lineasIngresos = deudas.map((deuda): FiscalLineaResumen => {
+    const importe = normalizarImporteMonetario(deuda.importe);
+    ingresos.emitido = sumarCentimos([ingresos.emitido, importe]);
+    sumarEnMapa(ingresos.por_tipo, deuda.gasto.tipo, importe);
+
+    if (deuda.estado === 'PAGADA') {
+      ingresos.cobrado = sumarCentimos([ingresos.cobrado, importe]);
+    } else {
+      ingresos.pendiente = sumarCentimos([ingresos.pendiente, importe]);
+    }
+
+    const advertencias = construirAdvertenciasGasto(deuda.gasto, ejercicio);
+    if (deuda.estado !== 'PAGADA') {
+      advertencias.push({
+        codigo: 'IMPORTE_PENDIENTE',
+        mensaje: `La deuda ${deuda.id} esta pendiente de cobro.`,
+        gasto_id: deuda.gasto.id,
+        deuda_id: deuda.id,
+      });
+    }
+
+    return {
+      id: `deuda-${deuda.id}`,
+      naturaleza: 'INGRESO',
+      fuente: {
+        modelo: 'Deuda',
+        gasto_id: deuda.gasto.id,
+        deuda_id: deuda.id,
+      },
+      concepto: deuda.gasto.concepto,
+      categoria: deuda.gasto.tipo as TipoGastoRoomies,
+      deducibilidad: 'NO_APLICA',
+      importe,
+      moneda: 'EUR',
+      fecha: isoFecha(deuda.gasto.fecha_creacion),
+      periodo_facturacion: deuda.gasto.periodo_facturacion,
+      estado_pago: deuda.estado === 'PAGADA' ? 'COBRADO' : 'PENDIENTE',
+      factura_url: deuda.gasto.factura_url ?? null,
+      justificante_url: deuda.justificante_url,
+      habitacion: deuda.gasto.habitacion_cargo ?? null,
+      inquilino: deuda.gasto.inquilino_cargo ?? deuda.deudor,
+      advertencias,
+    };
+  });
+
+  const lineasGastos = gastos.map((gasto): FiscalLineaResumen => {
+    const importe = normalizarImporteMonetario(gasto.importe);
+    const categoria = gasto.categoria_fiscal ?? 'SIN_CLASIFICAR';
+    const deducibilidad = deducibilidadDesdeGasto(gasto);
+
+    gastosTotales.potencialmente_deducible = sumarCentimos([gastosTotales.potencialmente_deducible, importe]);
+    sumarEnMapa(gastosTotales.por_categoria, categoria, importe);
+
+    if (gasto.factura_url) {
+      gastosTotales.con_factura = sumarCentimos([gastosTotales.con_factura, importe]);
+    } else {
+      gastosTotales.sin_factura = sumarCentimos([gastosTotales.sin_factura, importe]);
+    }
+
+    if (deducibilidad === 'DEDUCIBLE') {
+      gastosTotales.deducible_previsto = sumarCentimos([gastosTotales.deducible_previsto, importe]);
+    } else if (deducibilidad === 'NO_DEDUCIBLE') {
+      gastosTotales.no_deducible_previsto = sumarCentimos([gastosTotales.no_deducible_previsto, importe]);
+    } else {
+      gastosTotales.pendiente_clasificacion = sumarCentimos([gastosTotales.pendiente_clasificacion, importe]);
+    }
+
+    return {
+      id: `gasto-${gasto.id}`,
+      naturaleza: 'GASTO_POTENCIALMENTE_DEDUCIBLE',
+      fuente: {
+        modelo: 'Gasto',
+        gasto_id: gasto.id,
+      },
+      concepto: gasto.concepto,
+      categoria: categoria === 'SIN_CLASIFICAR' ? 'PENDIENTE_CLASIFICACION' : categoria,
+      deducibilidad,
+      importe,
+      moneda: 'EUR',
+      fecha: isoFecha(gasto.fecha_creacion),
+      periodo_facturacion: gasto.periodo_facturacion,
+      estado_pago: 'COBRADO',
+      factura_url: gasto.factura_url ?? null,
+      habitacion: null,
+      inquilino: null,
+      advertencias: construirAdvertenciasGasto(gasto, ejercicio),
+    };
+  });
+
+  const lineas = [...lineasIngresos, ...lineasGastos].sort((a, b) => {
+    const porFecha = a.fecha.localeCompare(b.fecha);
+    return porFecha !== 0 ? porFecha : a.id.localeCompare(b.id);
+  });
+
+  return {
+    ejercicio,
+    generado_en: generadoEn.toISOString(),
+    vivienda: {
+      id: vivienda.id,
+      alias_nombre: vivienda.alias_nombre,
+      direccion: vivienda.direccion,
+      codigo_postal: vivienda.codigo_postal,
+      ciudad: vivienda.ciudad,
+      provincia: vivienda.provincia,
+    },
+    casero: vivienda.casero,
+    totales: {
+      ingresos,
+      gastos: gastosTotales,
+    },
+    lineas,
+    advertencias: lineas.flatMap((linea) => linea.advertencias),
+  };
+};
+
 export const obtenerFotoOcupacionFiscalVivienda = async (
   viviendaId: number,
   caseroId: number,
@@ -386,4 +708,135 @@ export const obtenerFotoOcupacionFiscalVivienda = async (
   });
 
   return construirFotoOcupacionFiscal({ ejercicio, vivienda, gastos });
+};
+
+export const obtenerResumenFiscalAnualVivienda = async (
+  viviendaId: number,
+  caseroId: number,
+  ejercicio: number,
+) => {
+  const vivienda = await prisma.vivienda.findFirst({
+    where: { id: viviendaId, casero_id: caseroId },
+    select: {
+      id: true,
+      alias_nombre: true,
+      direccion: true,
+      codigo_postal: true,
+      ciudad: true,
+      provincia: true,
+      casero: {
+        select: {
+          id: true,
+          nombre: true,
+          apellidos: true,
+          documento_identidad: true,
+        },
+      },
+    },
+  });
+
+  if (!vivienda) return null;
+
+  const inicioEjercicio = new Date(Date.UTC(ejercicio, 0, 1));
+  const finEjercicio = new Date(Date.UTC(ejercicio + 1, 0, 1));
+  const filtroGastoEjercicio = {
+    tipo: { in: [...TIPOS_GASTO_CASERO] },
+    OR: [
+      {
+        fecha_creacion: {
+          gte: inicioEjercicio,
+          lt: finEjercicio,
+        },
+      },
+      {
+        periodo_facturacion: {
+          gte: `${ejercicio}-01`,
+          lte: `${ejercicio}-12`,
+        },
+      },
+    ],
+  };
+
+  const [deudas, gastos] = await Promise.all([
+    prisma.deuda.findMany({
+      where: {
+        acreedor_id: caseroId,
+        gasto: {
+          vivienda_id: viviendaId,
+          ...filtroGastoEjercicio,
+        },
+      },
+      orderBy: [{ gasto: { fecha_creacion: 'asc' } }, { id: 'asc' }],
+      include: {
+        deudor: {
+          select: {
+            id: true,
+            nombre: true,
+            apellidos: true,
+            documento_identidad: true,
+          },
+        },
+        gasto: {
+          select: {
+            id: true,
+            concepto: true,
+            importe: true,
+            tipo: true,
+            factura_url: true,
+            categoria_fiscal: true,
+            deducible_previsto: true,
+            notas_fiscales: true,
+            prorrateo_fiscal: true,
+            fecha_creacion: true,
+            periodo_facturacion: true,
+            habitacion_cargo_id: true,
+            inquilino_cargo_id: true,
+            habitacion_cargo: {
+              select: {
+                id: true,
+                nombre: true,
+              },
+            },
+            inquilino_cargo: {
+              select: {
+                id: true,
+                nombre: true,
+                apellidos: true,
+                documento_identidad: true,
+              },
+            },
+          },
+        },
+      },
+    }),
+    prisma.gasto.findMany({
+      where: {
+        vivienda_id: viviendaId,
+        ...filtroGastoEjercicio,
+      },
+      orderBy: [{ fecha_creacion: 'asc' }, { id: 'asc' }],
+      select: {
+        id: true,
+        concepto: true,
+        importe: true,
+        tipo: true,
+        factura_url: true,
+        categoria_fiscal: true,
+        deducible_previsto: true,
+        notas_fiscales: true,
+        prorrateo_fiscal: true,
+        fecha_creacion: true,
+        periodo_facturacion: true,
+        habitacion_cargo_id: true,
+        inquilino_cargo_id: true,
+      },
+    }),
+  ]);
+
+  return construirResumenFiscalAnual({
+    ejercicio,
+    vivienda,
+    deudas,
+    gastos,
+  });
 };

--- a/backend/tests/fiscal.controller.test.ts
+++ b/backend/tests/fiscal.controller.test.ts
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import type express from 'express';
+import { beforeEach, describe, test, vi } from 'vitest';
+
+type Handler = express.RequestHandler;
+type UsuarioTest = { id: number; rol: 'CASERO' | 'INQUILINO' };
+
+const fiscalService = vi.hoisted(() => ({
+  obtenerResumenFiscalAnualVivienda: vi.fn(),
+  obtenerFotoOcupacionFiscalVivienda: vi.fn(),
+}));
+
+vi.mock('../src/services/fiscal.service', () => fiscalService);
+
+const { obtenerResumenFiscalVivienda } = await import('../src/controllers/fiscal.controller');
+
+function request({
+  usuario,
+  params = {},
+}: {
+  usuario: UsuarioTest;
+  params?: Record<string, string>;
+}) {
+  return {
+    usuario,
+    params,
+  } as unknown as express.Request;
+}
+
+function response() {
+  const res = {
+    statusCode: 200,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  };
+
+  return res as unknown as express.Response & typeof res;
+}
+
+async function invoke(handler: Handler, req: express.Request) {
+  const res = response();
+  await handler(req, res, () => undefined);
+  return res;
+}
+
+beforeEach(() => {
+  fiscalService.obtenerResumenFiscalAnualVivienda.mockReset();
+});
+
+describe('fiscal.controller', () => {
+  test('rechaza el resumen anual para inquilinos', async () => {
+    const res = await invoke(
+      obtenerResumenFiscalVivienda,
+      request({
+        usuario: { id: 12, rol: 'INQUILINO' },
+        params: { viviendaId: '1', ejercicio: '2026' },
+      }),
+    );
+
+    assert.equal(res.statusCode, 403);
+    assert.deepEqual(res.body, { error: 'Solo el casero propietario puede consultar el resumen fiscal.' });
+    assert.equal(fiscalService.obtenerResumenFiscalAnualVivienda.mock.calls.length, 0);
+  });
+
+  test('devuelve 404 cuando la vivienda no pertenece al casero', async () => {
+    fiscalService.obtenerResumenFiscalAnualVivienda.mockResolvedValueOnce(null);
+
+    const res = await invoke(
+      obtenerResumenFiscalVivienda,
+      request({
+        usuario: { id: 99, rol: 'CASERO' },
+        params: { viviendaId: '7', ejercicio: '2026' },
+      }),
+    );
+
+    assert.equal(res.statusCode, 404);
+    assert.deepEqual(res.body, { error: 'Vivienda no encontrada.' });
+    assert.deepEqual(fiscalService.obtenerResumenFiscalAnualVivienda.mock.calls[0], [7, 99, 2026]);
+  });
+
+  test('devuelve el resumen fiscal anual para el casero propietario', async () => {
+    const resumen = {
+      ejercicio: 2026,
+      vivienda: { id: 7 },
+      totales: {
+        ingresos: { emitido: 100, cobrado: 60, pendiente: 40, anulado: 0, por_tipo: {} },
+      },
+      lineas: [],
+      advertencias: [],
+    };
+    fiscalService.obtenerResumenFiscalAnualVivienda.mockResolvedValueOnce(resumen);
+
+    const res = await invoke(
+      obtenerResumenFiscalVivienda,
+      request({
+        usuario: { id: 99, rol: 'CASERO' },
+        params: { viviendaId: '7', ejercicio: '2026' },
+      }),
+    );
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body, resumen);
+    assert.deepEqual(fiscalService.obtenerResumenFiscalAnualVivienda.mock.calls[0], [7, 99, 2026]);
+  });
+});

--- a/backend/tests/fiscal.service.test.ts
+++ b/backend/tests/fiscal.service.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'vitest';
-import { construirFotoOcupacionFiscal } from '../src/services/fiscal.service';
+import { construirFotoOcupacionFiscal, construirResumenFiscalAnual } from '../src/services/fiscal.service';
 
 const viviendaBase = {
   id: 1,
@@ -180,5 +180,103 @@ describe('fiscal.service', () => {
         },
       },
     ]);
+  });
+
+  test('construye resumen anual con totales en centimos, categorias y pendientes', () => {
+    const resumen = construirResumenFiscalAnual({
+      ejercicio: 2026,
+      generadoEn: new Date('2026-05-01T10:00:00.000Z'),
+      vivienda: {
+        ...viviendaBase,
+        casero: {
+          id: 99,
+          nombre: 'Clara',
+          apellidos: 'Propietaria',
+          documento_identidad: '99999999Z',
+        },
+      },
+      deudas: [
+        {
+          id: 1,
+          importe: 10.005,
+          estado: 'PAGADA',
+          justificante_url: 'https://cdn.test/justificante-1.jpg',
+          deudor: inquilinoAna,
+          gasto: {
+            ...alquiler({ id: 101, mes: '2026-01', habitacionId: 7, inquilino: inquilinoAna, importe: 20.01 }),
+            factura_url: 'https://cdn.test/factura-101.pdf',
+            categoria_fiscal: 'SIN_CLASIFICAR',
+            deducible_previsto: null,
+            notas_fiscales: null,
+          },
+        },
+        {
+          id: 2,
+          importe: 10.005,
+          estado: 'PENDIENTE',
+          justificante_url: null,
+          deudor: inquilinoLuis,
+          gasto: {
+            ...alquiler({ id: 101, mes: '2026-01', habitacionId: 7, inquilino: inquilinoAna, importe: 20.01 }),
+            factura_url: 'https://cdn.test/factura-101.pdf',
+            categoria_fiscal: 'SIN_CLASIFICAR',
+            deducible_previsto: null,
+            notas_fiscales: null,
+          },
+        },
+      ],
+      gastos: [
+        {
+          id: 201,
+          concepto: 'Seguro hogar',
+          importe: 120.335,
+          tipo: 'FACTURA_PUNTUAL',
+          factura_url: 'https://cdn.test/seguro.pdf',
+          categoria_fiscal: 'SEGUROS',
+          deducible_previsto: true,
+          notas_fiscales: 'Poliza anual',
+          fecha_creacion: new Date('2026-02-10T00:00:00.000Z'),
+          periodo_facturacion: null,
+          habitacion_cargo_id: null,
+          inquilino_cargo_id: null,
+          prorrateo_fiscal: 75,
+          inquilino_cargo: null,
+        },
+        {
+          id: 202,
+          concepto: 'Reparacion sin clasificar',
+          importe: 80,
+          tipo: 'FACTURA_PUNTUAL',
+          factura_url: null,
+          categoria_fiscal: 'SIN_CLASIFICAR',
+          deducible_previsto: null,
+          notas_fiscales: null,
+          fecha_creacion: new Date('2026-03-10T00:00:00.000Z'),
+          periodo_facturacion: null,
+          habitacion_cargo_id: null,
+          inquilino_cargo_id: null,
+          prorrateo_fiscal: null,
+          inquilino_cargo: null,
+        },
+      ],
+    });
+
+    assert.equal(resumen.generado_en, '2026-05-01T10:00:00.000Z');
+    assert.equal(resumen.totales.ingresos.emitido, 20.02);
+    assert.equal(resumen.totales.ingresos.cobrado, 10.01);
+    assert.equal(resumen.totales.ingresos.pendiente, 10.01);
+    assert.equal(resumen.totales.ingresos.por_tipo.ALQUILER_HABITACION, 20.02);
+    assert.equal(resumen.totales.gastos.potencialmente_deducible, 200.34);
+    assert.equal(resumen.totales.gastos.deducible_previsto, 120.34);
+    assert.equal(resumen.totales.gastos.pendiente_clasificacion, 80);
+    assert.equal(resumen.totales.gastos.con_factura, 120.34);
+    assert.equal(resumen.totales.gastos.sin_factura, 80);
+    assert.equal(resumen.totales.gastos.por_categoria.SEGUROS, 120.34);
+    assert.equal(resumen.totales.gastos.por_categoria.SIN_CLASIFICAR, 80);
+    assert.equal(resumen.lineas.length, 4);
+    assert.ok(resumen.advertencias.some((advertencia) => advertencia.codigo === 'IMPORTE_PENDIENTE'));
+    assert.ok(resumen.advertencias.some((advertencia) => advertencia.codigo === 'FALTA_CATEGORIA'));
+    assert.ok(resumen.advertencias.some((advertencia) => advertencia.codigo === 'FALTA_FACTURA'));
+    assert.ok(resumen.advertencias.some((advertencia) => advertencia.codigo === 'PRORRATEO_MANUAL'));
   });
 });

--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -1447,6 +1447,79 @@ Devuelve el dashboard financiero mensual del casero para una vivienda.
 
 ## Fiscal (`/viviendas/:viviendaId`)
 
+### GET `/viviendas/:viviendaId/fiscal/:ejercicio`
+
+Devuelve el resumen fiscal anual del propietario para una vivienda concreta, con totales auditables, detalle linea a linea y advertencias de revision.
+
+**Auth requerida:** Si - `Authorization: Bearer <token>`
+
+**Reglas de acceso:**
+- Solo el `CASERO` propietario de la vivienda puede consultar este endpoint.
+- `ejercicio` es obligatorio en la ruta y representa un ano natural.
+- Los importes se suman en centimos y se devuelven normalizados a euros.
+
+**Comportamiento:**
+- Los ingresos parten de `Deuda` donde el acreedor es el casero y el `Gasto.tipo` pertenece al flujo del propietario (`ALQUILER_HABITACION`, `FACTURA_MENSUAL`, `CARGO_RECURRENTE`, `FACTURA_PUNTUAL`).
+- Se separan ingresos `emitido`, `cobrado`, `pendiente` y `anulado`, con desglose por tipo de gasto.
+- Los gastos potencialmente deducibles se agrupan por `categoria_fiscal`, factura disponible y deducibilidad prevista.
+- Las lineas incompletas no rompen el endpoint: se devuelven en `advertencias` con codigos `FALTA_FACTURA`, `FALTA_CATEGORIA`, `IMPORTE_PENDIENTE`, `PERIODO_INCOMPLETO` o `PRORRATEO_MANUAL`.
+
+**Respuestas:**
+
+| Codigo | Descripcion |
+|---|---|
+| `200` | Resumen fiscal anual de la vivienda. |
+| `400` | `viviendaId` o `ejercicio` invalidos. |
+| `403` | El usuario no es casero. |
+| `404` | Vivienda no encontrada para ese casero. |
+
+**Ejemplo respuesta 200:**
+```json
+{
+  "ejercicio": 2026,
+  "generado_en": "2026-05-06T10:00:00.000Z",
+  "vivienda": {
+    "id": 3,
+    "alias_nombre": "Piso Centro",
+    "direccion": "Calle Mayor 10",
+    "codigo_postal": "28013",
+    "ciudad": "Madrid",
+    "provincia": "Madrid"
+  },
+  "totales": {
+    "ingresos": {
+      "emitido": 900,
+      "cobrado": 450,
+      "pendiente": 450,
+      "anulado": 0,
+      "por_tipo": { "ALQUILER_HABITACION": 900 }
+    },
+    "gastos": {
+      "potencialmente_deducible": 120,
+      "deducible_previsto": 120,
+      "no_deducible_previsto": 0,
+      "pendiente_clasificacion": 0,
+      "con_factura": 120,
+      "sin_factura": 0,
+      "por_categoria": { "SEGUROS": 120 }
+    }
+  },
+  "lineas": [
+    {
+      "id": "deuda-41",
+      "naturaleza": "INGRESO",
+      "concepto": "Alquiler Habitacion azul 2026-01",
+      "categoria": "ALQUILER_HABITACION",
+      "importe": 450,
+      "estado_pago": "COBRADO",
+      "factura_url": "https://cdn.example/factura.pdf",
+      "advertencias": []
+    }
+  ],
+  "advertencias": []
+}
+```
+
 ### GET `/viviendas/:viviendaId/fiscal/ocupacion?ejercicio=YYYY`
 
 Devuelve la foto anual de ocupacion fiscal de una vivienda, con detalle por habitacion y prorrateos deterministas para gastos del ejercicio.

--- a/docs/changelog/EpicaFiscal/epica-fiscal-issue-326-resumen-anual.md
+++ b/docs/changelog/EpicaFiscal/epica-fiscal-issue-326-resumen-anual.md
@@ -1,0 +1,17 @@
+# Epica Fiscal - Issue 326 - Resumen fiscal anual
+
+Se expone el resumen fiscal anual del propietario por vivienda y ejercicio mediante `GET /api/viviendas/:viviendaId/fiscal/:ejercicio`.
+
+## Cambios principales
+
+- Se amplia el servicio fiscal con `construirResumenFiscalAnual`, que consolida ingresos desde `Deuda` y gastos potencialmente deducibles desde `Gasto`.
+- El endpoint queda protegido para casero propietario: los inquilinos reciben `403` y las viviendas ajenas no exponen datos.
+- Los importes se agregan en centimos y se devuelven normalizados a euros para evitar descuadres acumulados.
+- La respuesta incluye totales por estado de cobro, tipo de ingreso, categoria fiscal, factura disponible y deducibilidad prevista.
+- Las lineas incompletas se conservan con advertencias (`FALTA_FACTURA`, `FALTA_CATEGORIA`, `IMPORTE_PENDIENTE`, `PERIODO_INCOMPLETO`, `PRORRATEO_MANUAL`) en lugar de romper el resumen.
+- Se documenta el contrato del nuevo endpoint en `docs/backend/api.md`.
+
+## Verificacion
+
+- Tests unitarios de servicio para totales, categorias, pendientes, advertencias y redondeo monetario.
+- Tests de controller para permisos de inquilino, vivienda no perteneciente al casero y respuesta correcta del casero propietario.


### PR DESCRIPTION
## Objetivo
Esta PR añade un endpoint backend para que el casero propietario consulte el resumen fiscal anual de una vivienda con totales auditables, detalle línea a línea y advertencias de revisión sin romperse ante datos incompletos.

## Cambios principales
* Se implementa `GET /api/viviendas/:viviendaId/fiscal/:ejercicio` con validación de permisos para `CASERO` propietario.
* Se consolidan ingresos desde `Deuda` y gastos desde `Gasto`, con totales separados por estado, tipo y categoría fiscal.
* Se normalizan importes en céntimos para evitar descuadres por redondeo y se expone detalle suficiente para auditoría.
* Se añaden advertencias para casos de factura ausente, categoría sin clasificar, importes pendientes, periodos incompletos y prorrateo manual.
* Se incorporan tests de servicio y controlador para permisos, totales, redondeo y casos incompletos.
* Se documenta el nuevo contrato en `docs/backend/api.md` y se añade changelog en `docs/changelog/EpicaFiscal/epica-fiscal-issue-326-resumen-anual.md`.

## UI / UX (Solo si aplica)
* No aplica.

## Changelog
* `docs/changelog/EpicaFiscal/epica-fiscal-issue-326-resumen-anual.md`