### PR TITLE
**Título:** [Épica Fiscal] Exporta dossier fiscal anual para gestoría

### DIFF
--- a/backend/src/controllers/fiscal.controller.ts
+++ b/backend/src/controllers/fiscal.controller.ts
@@ -1,5 +1,10 @@
 import express from 'express';
-import { obtenerFotoOcupacionFiscalVivienda, obtenerResumenFiscalAnualVivienda } from '../services/fiscal.service';
+import {
+  generarBufferCsvExcel,
+  obtenerDossierFiscalVivienda,
+  obtenerFotoOcupacionFiscalVivienda,
+  obtenerResumenFiscalAnualVivienda,
+} from '../services/fiscal.service';
 
 const obtenerParamNumerico = (valor: string | string[] | undefined) => {
   const normalizado = Array.isArray(valor) ? valor[0] : valor;
@@ -65,4 +70,46 @@ export const obtenerResumenFiscalVivienda: express.RequestHandler = async (req, 
   }
 
   res.status(200).json(resumen);
+};
+
+export const exportarDossierFiscalVivienda: express.RequestHandler = async (req, res) => {
+  const viviendaId = obtenerParamNumerico(req.params.viviendaId);
+  const ejercicio = obtenerParamNumerico(req.params.ejercicio);
+  const usuario = req.usuario!;
+
+  if (usuario.rol !== 'CASERO') {
+    res.status(403).json({ error: 'Solo el casero propietario puede exportar el dossier fiscal.' });
+    return;
+  }
+
+  if (!Number.isInteger(viviendaId) || viviendaId <= 0) {
+    res.status(400).json({ error: 'viviendaId invalido.' });
+    return;
+  }
+
+  if (!Number.isInteger(ejercicio) || ejercicio < 2000 || ejercicio > 2100) {
+    res.status(400).json({ error: 'ejercicio debe ser un ano natural valido.' });
+    return;
+  }
+
+  const dossier = await obtenerDossierFiscalVivienda(viviendaId, usuario.id, ejercicio);
+
+  if (!dossier) {
+    res.status(404).json({ error: 'Vivienda no encontrada.' });
+    return;
+  }
+
+  if (req.query['formato'] === 'base64') {
+    res.status(200).json({
+      nombreArchivo: dossier.nombreArchivo,
+      mimeType: dossier.mimeType,
+      columnas: dossier.columnas,
+      contenidoBase64: generarBufferCsvExcel(dossier.contenido).toString('base64'),
+    });
+    return;
+  }
+
+  res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+  res.setHeader('Content-Disposition', `attachment; filename="${dossier.nombreArchivo}"`);
+  res.status(200).send(dossier.contenido);
 };

--- a/backend/src/routes/fiscal.routes.ts
+++ b/backend/src/routes/fiscal.routes.ts
@@ -1,10 +1,15 @@
 import express from 'express';
-import { obtenerOcupacionFiscalVivienda, obtenerResumenFiscalVivienda } from '../controllers/fiscal.controller';
+import {
+  exportarDossierFiscalVivienda,
+  obtenerOcupacionFiscalVivienda,
+  obtenerResumenFiscalVivienda,
+} from '../controllers/fiscal.controller';
 import { verificarToken } from '../middlewares/auth.middleware';
 
 const router = express.Router();
 
 router.get('/:viviendaId/fiscal/ocupacion', verificarToken, obtenerOcupacionFiscalVivienda);
+router.get('/:viviendaId/fiscal/:ejercicio/dossier', verificarToken, exportarDossierFiscalVivienda);
 router.get('/:viviendaId/fiscal/:ejercicio', verificarToken, obtenerResumenFiscalVivienda);
 
 export default router;

--- a/backend/src/services/fiscal.service.ts
+++ b/backend/src/services/fiscal.service.ts
@@ -237,7 +237,42 @@ export type FiscalResumenAnualVivienda = {
   advertencias: FiscalAdvertenciaResumen[];
 };
 
+export type FiscalDossierFiscal = {
+  nombreArchivo: string;
+  mimeType: 'text/csv';
+  contenido: string;
+  columnas: {
+    resumen: string[];
+    detalle: string[];
+  };
+};
+
 const MS_DIA = 24 * 60 * 60 * 1000;
+const MIME_CSV = 'text/csv' as const;
+const COLUMNAS_DOSSIER_RESUMEN = ['Clave', 'Valor', 'Moneda', 'Notas'] as const;
+const COLUMNAS_DOSSIER_DETALLE = [
+  'Linea ID',
+  'Naturaleza',
+  'Modelo origen',
+  'Gasto ID',
+  'Deuda ID',
+  'Concepto',
+  'Categoria',
+  'Deducibilidad',
+  'Importe',
+  'Moneda',
+  'Fecha',
+  'Periodo facturacion',
+  'Estado pago',
+  'Factura URL',
+  'Justificante URL',
+  'Habitacion ID',
+  'Habitacion',
+  'Inquilino ID',
+  'Inquilino',
+  'Documento inquilino',
+  'Advertencias',
+] as const;
 
 const isoFecha = (fecha: Date) => fecha.toISOString().slice(0, 10);
 
@@ -283,6 +318,125 @@ const sumarCentimos = (importes: number[]) =>
 
 const sumarEnMapa = (mapa: Record<string, number>, clave: string, importe: number) => {
   mapa[clave] = sumarCentimos([mapa[clave] ?? 0, importe]);
+};
+
+const escaparCsv = (valor: unknown) => {
+  const texto = String(valor ?? '');
+  const seguro = /^[=+\-@]/.test(texto) ? `'${texto}` : texto;
+  return `"${seguro.replace(/"/g, '""')}"`;
+};
+
+const limpiarNombreArchivo = (valor: string) =>
+  valor
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48);
+
+const nombreCompleto = (usuario: { nombre: string; apellidos: string | null } | null | undefined) =>
+  usuario ? `${usuario.nombre}${usuario.apellidos ? ` ${usuario.apellidos}` : ''}` : '';
+
+const serializarAdvertencias = (advertencias: FiscalAdvertenciaResumen[]) =>
+  advertencias.map((advertencia) => `${advertencia.codigo}: ${advertencia.mensaje}`).join(' | ');
+
+const filaCsv = (valores: readonly unknown[]) => valores.map(escaparCsv).join(';');
+
+const crearFilasMapa = (prefijo: string, valores: Record<string, number>) =>
+  Object.entries(valores)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([clave, valor]) => [`${prefijo}.${clave}`, valor, 'EUR', '']);
+
+const generarCsvDossierFiscal = (resumen: FiscalResumenAnualVivienda) => {
+  const filasResumen = [
+    ['ejercicio', resumen.ejercicio, '', 'Ano natural exportado'],
+    ['generado_en', resumen.generado_en, '', 'Fecha ISO de generacion'],
+    ['solicitante', nombreCompleto(resumen.casero), '', `usuario_id=${resumen.casero.id}`],
+    ['vivienda', resumen.vivienda.alias_nombre, '', `vivienda_id=${resumen.vivienda.id}`],
+    ['direccion', resumen.vivienda.direccion, '', `${resumen.vivienda.codigo_postal} ${resumen.vivienda.ciudad}`],
+    ['ingresos.emitido', resumen.totales.ingresos.emitido, 'EUR', 'Total facturado a inquilinos'],
+    ['ingresos.cobrado', resumen.totales.ingresos.cobrado, 'EUR', 'Total marcado como pagado'],
+    ['ingresos.pendiente', resumen.totales.ingresos.pendiente, 'EUR', 'Total pendiente de cobro'],
+    ['ingresos.anulado', resumen.totales.ingresos.anulado, 'EUR', 'Total anulado'],
+    ...crearFilasMapa('ingresos.por_tipo', resumen.totales.ingresos.por_tipo),
+    [
+      'gastos.potencialmente_deducible',
+      resumen.totales.gastos.potencialmente_deducible,
+      'EUR',
+      'Gastos del flujo propietario',
+    ],
+    ['gastos.deducible_previsto', resumen.totales.gastos.deducible_previsto, 'EUR', 'Marcados como deducibles'],
+    ['gastos.no_deducible_previsto', resumen.totales.gastos.no_deducible_previsto, 'EUR', 'Marcados como no deducibles'],
+    [
+      'gastos.pendiente_clasificacion',
+      resumen.totales.gastos.pendiente_clasificacion,
+      'EUR',
+      'Sin categoria fiscal o deducibilidad clara',
+    ],
+    ['gastos.con_factura', resumen.totales.gastos.con_factura, 'EUR', 'Con factura_url'],
+    ['gastos.sin_factura', resumen.totales.gastos.sin_factura, 'EUR', 'Sin factura_url'],
+    ...crearFilasMapa('gastos.por_categoria', resumen.totales.gastos.por_categoria),
+    ['revision.lineas_problematicas', resumen.lineas.filter((linea) => linea.advertencias.length > 0).length, '', ''],
+    ['revision.advertencias', resumen.advertencias.length, '', serializarAdvertencias(resumen.advertencias)],
+  ];
+
+  const filasDetalle = resumen.lineas.map((linea) => [
+    linea.id,
+    linea.naturaleza,
+    linea.fuente.modelo,
+    linea.fuente.gasto_id,
+    linea.fuente.deuda_id ?? '',
+    linea.concepto,
+    linea.categoria,
+    linea.deducibilidad,
+    linea.importe,
+    linea.moneda,
+    linea.fecha,
+    linea.periodo_facturacion ?? '',
+    linea.estado_pago,
+    linea.factura_url ?? '',
+    linea.justificante_url ?? '',
+    linea.habitacion?.id ?? '',
+    linea.habitacion?.nombre ?? '',
+    linea.inquilino?.id ?? '',
+    nombreCompleto(linea.inquilino),
+    linea.inquilino?.documento_identidad ?? '',
+    serializarAdvertencias(linea.advertencias),
+  ]);
+
+  const lineas = [
+    '# RESUMEN',
+    filaCsv(COLUMNAS_DOSSIER_RESUMEN),
+    ...filasResumen.map(filaCsv),
+    '',
+    '# DETALLE',
+    filaCsv(COLUMNAS_DOSSIER_DETALLE),
+    ...filasDetalle.map(filaCsv),
+  ];
+
+  return `\uFEFF${lineas.join('\r\n')}`;
+};
+
+export const generarBufferCsvExcel = (csv: string) =>
+  Buffer.concat([
+    Buffer.from([0xff, 0xfe]),
+    Buffer.from(csv.replace(/^\uFEFF/, ''), 'utf16le'),
+  ]);
+
+export const construirDossierFiscal = (resumen: FiscalResumenAnualVivienda): FiscalDossierFiscal => {
+  const viviendaSlug = limpiarNombreArchivo(resumen.vivienda.alias_nombre || `vivienda-${resumen.vivienda.id}`);
+  const fechaGeneracion = isoFecha(new Date(resumen.generado_en));
+
+  return {
+    nombreArchivo: `dossier-fiscal-${viviendaSlug}-${resumen.ejercicio}-${fechaGeneracion}.csv`,
+    mimeType: MIME_CSV,
+    contenido: generarCsvDossierFiscal(resumen),
+    columnas: {
+      resumen: [...COLUMNAS_DOSSIER_RESUMEN],
+      detalle: [...COLUMNAS_DOSSIER_DETALLE],
+    },
+  };
 };
 
 const esPeriodoMensualDelEjercicio = (periodo: string | null, ejercicio: number) => {
@@ -839,4 +993,14 @@ export const obtenerResumenFiscalAnualVivienda = async (
     deudas,
     gastos,
   });
+};
+
+export const obtenerDossierFiscalVivienda = async (
+  viviendaId: number,
+  caseroId: number,
+  ejercicio: number,
+) => {
+  const resumen = await obtenerResumenFiscalAnualVivienda(viviendaId, caseroId, ejercicio);
+  if (!resumen) return null;
+  return construirDossierFiscal(resumen);
 };

--- a/backend/tests/fiscal.controller.test.ts
+++ b/backend/tests/fiscal.controller.test.ts
@@ -8,22 +8,27 @@ type UsuarioTest = { id: number; rol: 'CASERO' | 'INQUILINO' };
 const fiscalService = vi.hoisted(() => ({
   obtenerResumenFiscalAnualVivienda: vi.fn(),
   obtenerFotoOcupacionFiscalVivienda: vi.fn(),
+  obtenerDossierFiscalVivienda: vi.fn(),
+  generarBufferCsvExcel: vi.fn((csv: string) => Buffer.from(`excel:${csv}`)),
 }));
 
 vi.mock('../src/services/fiscal.service', () => fiscalService);
 
-const { obtenerResumenFiscalVivienda } = await import('../src/controllers/fiscal.controller');
+const { exportarDossierFiscalVivienda, obtenerResumenFiscalVivienda } = await import('../src/controllers/fiscal.controller');
 
 function request({
   usuario,
   params = {},
+  query = {},
 }: {
   usuario: UsuarioTest;
   params?: Record<string, string>;
+  query?: Record<string, string>;
 }) {
   return {
     usuario,
     params,
+    query,
   } as unknown as express.Request;
 }
 
@@ -31,12 +36,22 @@ function response() {
   const res = {
     statusCode: 200,
     body: undefined as unknown,
+    sent: undefined as unknown,
+    headers: {} as Record<string, string>,
     status(code: number) {
       this.statusCode = code;
       return this;
     },
+    setHeader(nombre: string, valor: string) {
+      this.headers[nombre] = valor;
+      return this;
+    },
     json(payload: unknown) {
       this.body = payload;
+      return this;
+    },
+    send(payload: unknown) {
+      this.sent = payload;
       return this;
     },
   };
@@ -52,6 +67,8 @@ async function invoke(handler: Handler, req: express.Request) {
 
 beforeEach(() => {
   fiscalService.obtenerResumenFiscalAnualVivienda.mockReset();
+  fiscalService.obtenerDossierFiscalVivienda.mockReset();
+  fiscalService.generarBufferCsvExcel.mockClear();
 });
 
 describe('fiscal.controller', () => {
@@ -108,5 +125,67 @@ describe('fiscal.controller', () => {
     assert.equal(res.statusCode, 200);
     assert.equal(res.body, resumen);
     assert.deepEqual(fiscalService.obtenerResumenFiscalAnualVivienda.mock.calls[0], [7, 99, 2026]);
+  });
+
+  test('exporta dossier fiscal como csv descargable', async () => {
+    fiscalService.obtenerDossierFiscalVivienda.mockResolvedValueOnce({
+      nombreArchivo: 'dossier-fiscal-piso-centro-2026-2026-05-06.csv',
+      mimeType: 'text/csv',
+      contenido: '\uFEFF# RESUMEN\r\n# DETALLE',
+      columnas: {
+        resumen: ['Clave', 'Valor', 'Moneda', 'Notas'],
+        detalle: ['Linea ID', 'Advertencias'],
+      },
+    });
+
+    const res = await invoke(
+      exportarDossierFiscalVivienda,
+      request({
+        usuario: { id: 99, rol: 'CASERO' },
+        params: { viviendaId: '7', ejercicio: '2026' },
+      }),
+    );
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.headers['Content-Type'], 'text/csv; charset=utf-8');
+    assert.equal(
+      res.headers['Content-Disposition'],
+      'attachment; filename="dossier-fiscal-piso-centro-2026-2026-05-06.csv"',
+    );
+    assert.equal(res.sent, '\uFEFF# RESUMEN\r\n# DETALLE');
+    assert.deepEqual(fiscalService.obtenerDossierFiscalVivienda.mock.calls[0], [7, 99, 2026]);
+  });
+
+  test('exporta dossier fiscal en base64 para escritura movil', async () => {
+    fiscalService.obtenerDossierFiscalVivienda.mockResolvedValueOnce({
+      nombreArchivo: 'dossier-fiscal-piso-centro-2026-2026-05-06.csv',
+      mimeType: 'text/csv',
+      contenido: 'csv',
+      columnas: {
+        resumen: ['Clave'],
+        detalle: ['Linea ID'],
+      },
+    });
+
+    const res = await invoke(
+      exportarDossierFiscalVivienda,
+      request({
+        usuario: { id: 99, rol: 'CASERO' },
+        params: { viviendaId: '7', ejercicio: '2026' },
+        query: { formato: 'base64' },
+      }),
+    );
+
+    assert.equal(res.statusCode, 200);
+    assert.deepEqual(res.body, {
+      nombreArchivo: 'dossier-fiscal-piso-centro-2026-2026-05-06.csv',
+      mimeType: 'text/csv',
+      columnas: {
+        resumen: ['Clave'],
+        detalle: ['Linea ID'],
+      },
+      contenidoBase64: Buffer.from('excel:csv').toString('base64'),
+    });
+    assert.deepEqual(fiscalService.generarBufferCsvExcel.mock.calls[0], ['csv']);
   });
 });

--- a/backend/tests/fiscal.service.test.ts
+++ b/backend/tests/fiscal.service.test.ts
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'vitest';
-import { construirFotoOcupacionFiscal, construirResumenFiscalAnual } from '../src/services/fiscal.service';
+import {
+  construirDossierFiscal,
+  construirFotoOcupacionFiscal,
+  construirResumenFiscalAnual,
+  generarBufferCsvExcel,
+} from '../src/services/fiscal.service';
 
 const viviendaBase = {
   id: 1,
@@ -278,5 +283,69 @@ describe('fiscal.service', () => {
     assert.ok(resumen.advertencias.some((advertencia) => advertencia.codigo === 'FALTA_CATEGORIA'));
     assert.ok(resumen.advertencias.some((advertencia) => advertencia.codigo === 'FALTA_FACTURA'));
     assert.ok(resumen.advertencias.some((advertencia) => advertencia.codigo === 'PRORRATEO_MANUAL'));
+  });
+
+  test('exporta dossier fiscal con secciones, columnas estables y lineas marcadas', () => {
+    const resumen = construirResumenFiscalAnual({
+      ejercicio: 2026,
+      generadoEn: new Date('2026-05-06T08:30:00.000Z'),
+      vivienda: {
+        ...viviendaBase,
+        casero: {
+          id: 99,
+          nombre: 'Clara',
+          apellidos: 'Propietaria',
+          documento_identidad: '99999999Z',
+        },
+      },
+      deudas: [
+        {
+          id: 7,
+          importe: 450,
+          estado: 'PENDIENTE',
+          justificante_url: null,
+          deudor: inquilinoAna,
+          gasto: {
+            ...alquiler({ id: 101, mes: '2026-01', habitacionId: 7, inquilino: inquilinoAna, importe: 450 }),
+            factura_url: 'https://cdn.test/alquiler.pdf',
+            categoria_fiscal: 'SIN_CLASIFICAR',
+            deducible_previsto: null,
+            notas_fiscales: null,
+          },
+        },
+      ],
+      gastos: [
+        {
+          id: 201,
+          concepto: '=Formula peligrosa',
+          importe: 80,
+          tipo: 'FACTURA_PUNTUAL',
+          factura_url: null,
+          categoria_fiscal: 'SIN_CLASIFICAR',
+          deducible_previsto: null,
+          notas_fiscales: null,
+          fecha_creacion: new Date('2026-03-10T00:00:00.000Z'),
+          periodo_facturacion: null,
+          habitacion_cargo_id: null,
+          inquilino_cargo_id: null,
+          prorrateo_fiscal: null,
+          inquilino_cargo: null,
+        },
+      ],
+    });
+
+    const dossier = construirDossierFiscal(resumen);
+
+    assert.equal(dossier.nombreArchivo, 'dossier-fiscal-piso-centro-2026-2026-05-06.csv');
+    assert.equal(dossier.mimeType, 'text/csv');
+    assert.deepEqual(dossier.columnas.resumen, ['Clave', 'Valor', 'Moneda', 'Notas']);
+    assert.ok(dossier.columnas.detalle.includes('Advertencias'));
+    assert.match(dossier.contenido, /# RESUMEN/);
+    assert.match(dossier.contenido, /# DETALLE/);
+    assert.match(dossier.contenido, /"revision\.lineas_problematicas";"2";"";""/);
+    assert.match(dossier.contenido, /"deuda-7";"INGRESO";"Deuda";"101";"7"/);
+    assert.match(dossier.contenido, /IMPORTE_PENDIENTE/);
+    assert.match(dossier.contenido, /"'=Formula peligrosa"/);
+    assert.equal(generarBufferCsvExcel(dossier.contenido).subarray(0, 2).toString('hex'), 'fffe');
   });
 });

--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -1520,6 +1520,39 @@ Devuelve el resumen fiscal anual del propietario para una vivienda concreta, con
 }
 ```
 
+### GET `/viviendas/:viviendaId/fiscal/:ejercicio/dossier`
+
+Descarga un dossier fiscal anual en CSV compatible con Excel para revisar o enviar a gestoria.
+
+**Auth requerida:** Si - `Authorization: Bearer <token>`
+
+**Reglas de acceso:**
+- Solo el `CASERO` propietario de la vivienda puede exportar este dossier.
+- `ejercicio` es obligatorio en la ruta y representa un ano natural.
+- El nombre del archivo sigue el formato `dossier-fiscal-{vivienda}-{ejercicio}-{fecha-generacion}.csv`.
+
+**Query params:**
+
+| Parametro | Valor | Descripcion |
+|---|---|---|
+| `formato` | `base64` | Devuelve JSON con el CSV codificado en base64 y bytes compatibles con Excel para escritura movil. |
+
+**Contenido del CSV:**
+- Seccion `RESUMEN`, con columnas estables: `Clave`, `Valor`, `Moneda`, `Notas`.
+- Seccion `DETALLE`, con columnas estables: `Linea ID`, `Naturaleza`, `Modelo origen`, `Gasto ID`, `Deuda ID`, `Concepto`, `Categoria`, `Deducibilidad`, `Importe`, `Moneda`, `Fecha`, `Periodo facturacion`, `Estado pago`, `Factura URL`, `Justificante URL`, `Habitacion ID`, `Habitacion`, `Inquilino ID`, `Inquilino`, `Documento inquilino`, `Advertencias`.
+- Las lineas con importes pendientes, facturas ausentes, categorias fiscales pendientes, periodos incompletos o prorrateos manuales quedan marcadas en la columna `Advertencias`.
+- Las referencias documentales se incluyen como URL (`factura_url` y `justificante_url`) sin duplicar archivos pesados.
+
+**Respuestas:**
+
+| Codigo | Descripcion |
+|---|---|
+| `200` | Devuelve `text/csv; charset=utf-8` con `Content-Disposition` de descarga. |
+| `200` | Con `formato=base64`, devuelve `{ nombreArchivo, mimeType, columnas, contenidoBase64 }`. |
+| `400` | `viviendaId` o `ejercicio` invalidos. |
+| `403` | El usuario no es casero. |
+| `404` | Vivienda no encontrada para ese casero. |
+
 ### GET `/viviendas/:viviendaId/fiscal/ocupacion?ejercicio=YYYY`
 
 Devuelve la foto anual de ocupacion fiscal de una vivienda, con detalle por habitacion y prorrateos deterministas para gastos del ejercicio.

--- a/docs/changelog/EpicaFiscal/epica-fiscal-issue-327-dossier-fiscal.md
+++ b/docs/changelog/EpicaFiscal/epica-fiscal-issue-327-dossier-fiscal.md
@@ -1,0 +1,17 @@
+# Epica Fiscal - Issue 327 - Dossier fiscal para gestoria
+
+Se anade la exportacion anual del dossier fiscal de una vivienda mediante `GET /api/viviendas/:viviendaId/fiscal/:ejercicio/dossier`.
+
+## Cambios principales
+
+- El servicio fiscal reutiliza el resumen anual existente y lo transforma en un CSV compatible con Excel.
+- El dossier incluye una seccion `RESUMEN` con totales, vivienda, solicitante, fecha de generacion y contadores de revision.
+- La seccion `DETALLE` mantiene columnas estables para ingresos y gastos, con referencias a facturas y justificantes como URL.
+- Las lineas pendientes de cobro, sin factura, sin categoria, con periodo incompleto o prorrateo manual se marcan en la columna `Advertencias`.
+- El endpoint soporta descarga directa `text/csv` y `formato=base64` para escritura movil.
+- `docs/backend/api.md` documenta el contrato, columnas y respuestas.
+
+## Verificacion
+
+- Tests unitarios del servicio para secciones, columnas, nombre de archivo, advertencias y proteccion ante formula injection en CSV.
+- Tests de controller para descarga CSV y respuesta base64.


### PR DESCRIPTION
**Descripción:**
## Objetivo
Añade la exportación anual del dossier fiscal de una vivienda para que el casero pueda revisar, descargar o enviar a su gestoría un resumen práctico con totales, detalle por línea y advertencias de revisión.

## Cambios principales
* Se incorpora `GET /api/viviendas/:viviendaId/fiscal/:ejercicio/dossier` en backend.
* El dossier se genera en CSV compatible con Excel con dos secciones: `RESUMEN` y `DETALLE`.
* Se incluyen totales por vivienda, ingresos, gastos por categoría, líneas problemáticas y referencias a facturas o justificantes cuando existen.
* Se añade salida `formato=base64` para escritura móvil y descarga directa con nombre de archivo estable.
* Se amplían tests de servicio y controller para validar contenido mínimo, columnas, permisos y codificación segura del CSV.
* Se documenta el contrato en `docs/backend/api.md`.

## UI / UX (Solo si aplica)
* No aplica.

## Changelog
* `docs/changelog/EpicaFiscal/epica-fiscal-issue-327-dossier-fiscal.md`