### PR TITLE
[Épica Fiscal] Añade modo fiscal para casero

### DIFF
--- a/backend/src/services/fiscal.service.ts
+++ b/backend/src/services/fiscal.service.ts
@@ -195,6 +195,12 @@ export type FiscalLineaResumen = {
   estado_pago: FiscalEstadoPagoResumen;
   factura_url: string | null;
   justificante_url?: string | null;
+  metadata_fiscal?: {
+    categoria_fiscal: CategoriaFiscalGastoRoomies;
+    deducible_previsto: boolean | null;
+    notas_fiscales: string | null;
+    prorrateo_fiscal: number | null;
+  };
   habitacion?: {
     id: number;
     nombre: string;
@@ -747,6 +753,12 @@ export const construirResumenFiscalAnual = ({
       periodo_facturacion: gasto.periodo_facturacion,
       estado_pago: 'COBRADO',
       factura_url: gasto.factura_url ?? null,
+      metadata_fiscal: {
+        categoria_fiscal: categoria,
+        deducible_previsto: gasto.deducible_previsto ?? null,
+        notas_fiscales: gasto.notas_fiscales ?? null,
+        prorrateo_fiscal: gasto.prorrateo_fiscal ?? null,
+      },
       habitacion: null,
       inquilino: null,
       advertencias: construirAdvertenciasGasto(gasto, ejercicio),

--- a/docs/changelog/EpicaFiscal/epica-fiscal-issue-328-modo-fiscal-casero.md
+++ b/docs/changelog/EpicaFiscal/epica-fiscal-issue-328-modo-fiscal-casero.md
@@ -1,0 +1,10 @@
+# Epica Fiscal - Issue 328 - Modo fiscal para casero
+
+Se anade la primera experiencia frontend del modo fiscal para propietarios desde el area de casero.
+
+## Cambios
+
+- Se incorpora la pestana `Fiscal` para caseros con viviendas con modulo de gastos activo.
+- La pantalla permite seleccionar vivienda y ejercicio, consultar resumen anual, ocupacion, avisos y lineas revisables.
+- Se permite exportar el dossier fiscal CSV en formato movil y revisar metadatos fiscales de gastos.
+- El resumen fiscal del backend expone los metadatos actuales necesarios para prellenar la edicion sin perder notas o prorrateos.

--- a/frontend/app/__tests__/fiscal.test.tsx
+++ b/frontend/app/__tests__/fiscal.test.tsx
@@ -1,0 +1,183 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import CaseroFiscalScreen from '../casero/(tabs)/fiscal';
+
+const mockApiGet = jest.fn();
+const mockApiPatch = jest.fn();
+const mockToastShow = jest.fn();
+const mockUseEffect = React.useEffect;
+
+jest.mock('expo-router', () => ({
+  useFocusEffect: (callback: () => void | (() => void)) => {
+    mockUseEffect(() => callback(), [callback]);
+  },
+}));
+
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: function MockIonicons() {
+    return null;
+  },
+}));
+
+jest.mock('expo-file-system/legacy', () => ({
+  cacheDirectory: 'file:///tmp/',
+  EncodingType: { Base64: 'base64' },
+  StorageAccessFramework: {
+    requestDirectoryPermissionsAsync: jest.fn(),
+    createFileAsync: jest.fn(),
+  },
+  writeAsStringAsync: jest.fn(),
+}));
+
+jest.mock('react-native-toast-message', () => ({
+  show: (...args: unknown[]) => mockToastShow(...args),
+}));
+
+jest.mock('@/services/api', () => ({
+  get: (...args: unknown[]) => mockApiGet(...args),
+  patch: (...args: unknown[]) => mockApiPatch(...args),
+}));
+
+jest.mock('@/contexts/ThemeContext', () => {
+  const { DefaultAppTheme } = jest.requireActual('@/constants/theme');
+  return {
+    useAppTheme: () => ({ theme: DefaultAppTheme }),
+  };
+});
+
+const vivienda = {
+  id: 7,
+  alias_nombre: 'Piso Centro',
+  direccion: 'Calle Mayor 1',
+  mod_gastos: true,
+};
+
+const resumen = {
+  ejercicio: 2026,
+  generado_en: '2026-05-06T10:00:00.000Z',
+  vivienda: {
+    id: 7,
+    alias_nombre: 'Piso Centro',
+    direccion: 'Calle Mayor 1',
+    codigo_postal: '28001',
+    ciudad: 'Madrid',
+    provincia: 'Madrid',
+  },
+  totales: {
+    ingresos: {
+      emitido: 900,
+      cobrado: 700,
+      pendiente: 200,
+      anulado: 0,
+      por_tipo: {},
+    },
+    gastos: {
+      potencialmente_deducible: 120,
+      deducible_previsto: 0,
+      no_deducible_previsto: 0,
+      pendiente_clasificacion: 120,
+      con_factura: 0,
+      sin_factura: 120,
+      por_categoria: {},
+    },
+  },
+  lineas: [
+    {
+      id: 'gasto-11',
+      naturaleza: 'GASTO_POTENCIALMENTE_DEDUCIBLE',
+      fuente: { modelo: 'Gasto', gasto_id: 11 },
+      concepto: 'Seguro hogar',
+      categoria: 'PENDIENTE_CLASIFICACION',
+      deducibilidad: 'PENDIENTE_CLASIFICACION',
+      importe: 120,
+      moneda: 'EUR',
+      fecha: '2026-02-01',
+      periodo_facturacion: null,
+      estado_pago: 'COBRADO',
+      factura_url: null,
+      metadata_fiscal: {
+        categoria_fiscal: 'SIN_CLASIFICAR',
+        deducible_previsto: null,
+        notas_fiscales: 'Pendiente gestor',
+        prorrateo_fiscal: 75,
+      },
+      advertencias: [{ codigo: 'FALTA_FACTURA', mensaje: 'Falta factura.' }],
+    },
+  ],
+  advertencias: [{ codigo: 'FALTA_FACTURA', mensaje: 'Falta factura.' }],
+};
+
+const ocupacion = {
+  ejercicio: 2026,
+  resumen: {
+    dias_alquilados: 180,
+    meses_equivalentes: 6,
+    porcentaje_ocupacion: 49.31,
+    estado: 'PARCIAL',
+    habitaciones_con_actividad: 1,
+    habitaciones_requieren_revision: 0,
+    requiere_revision: false,
+  },
+  habitaciones: [
+    {
+      id: 1,
+      nombre: 'Habitacion A',
+      tipo: 'DORMITORIO',
+      es_habitable: true,
+      precio: 450,
+      dias_alquilados: 180,
+      meses_equivalentes: 6,
+      porcentaje_ocupacion: 49.31,
+      estado: 'PARCIAL',
+      requiere_revision: false,
+      revisiones: [],
+    },
+  ],
+  gastos_prorrateados: [],
+};
+
+describe('CaseroFiscalScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockApiGet.mockImplementation((url: string) => {
+      if (url === '/viviendas') return Promise.resolve({ data: [vivienda] });
+      if (url === '/viviendas/7/fiscal/2026') return Promise.resolve({ data: resumen });
+      if (url === '/viviendas/7/fiscal/ocupacion') return Promise.resolve({ data: ocupacion });
+      return Promise.reject(new Error(`URL inesperada: ${url}`));
+    });
+  });
+
+  it('renderiza resumen fiscal, ocupacion y lineas revisables', async () => {
+    render(<CaseroFiscalScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Preparacion fiscal/)).toBeTruthy();
+      expect(screen.getAllByText('Piso Centro').length).toBeGreaterThan(0);
+      expect(screen.getByText('Gastos a clasificar')).toBeTruthy();
+      expect(screen.getByText('Seguro hogar')).toBeTruthy();
+      expect(screen.getByText('Ocupacion y prorrateos')).toBeTruthy();
+    });
+  });
+
+  it('prepara la actualizacion de metadatos fiscales y recarga el resumen', async () => {
+    mockApiPatch.mockResolvedValueOnce({ data: { id: 11 } });
+
+    render(<CaseroFiscalScreen />);
+
+    await screen.findByText('Seguro hogar');
+    fireEvent.press(screen.getByText('Clasificar'));
+    await screen.findByText('Revisar gasto');
+    fireEvent.press(screen.getByText('Seguros'));
+    fireEvent.press(screen.getByText('Preparar como deducible'));
+    fireEvent.press(screen.getByText('Guardar'));
+
+    await waitFor(() => {
+      expect(mockApiPatch).toHaveBeenCalledWith('/viviendas/7/gastos/11', {
+        categoria_fiscal: 'SEGUROS',
+        deducible_previsto: true,
+        notas_fiscales: 'Pendiente gestor',
+        prorrateo_fiscal: 75,
+      });
+    });
+  });
+});

--- a/frontend/app/__tests__/navigation-smoke.test.tsx
+++ b/frontend/app/__tests__/navigation-smoke.test.tsx
@@ -75,6 +75,7 @@ describe('smoke navegacion principal', () => {
     });
     expect(ultimaScreen('viviendas').options.title).toBe('Viviendas');
     expect(ultimaScreen('cobros').options.href).toBeUndefined();
+    expect(ultimaScreen('fiscal').options.href).toBeUndefined();
     expect(ultimaScreen('inventario').options.href).toBeNull();
     expect(ultimaScreen('tablon').options.href).toBeNull();
     expect(ultimaScreen('perfil').options.title).toBe('Perfil');

--- a/frontend/app/casero/(tabs)/_layout.tsx
+++ b/frontend/app/casero/(tabs)/_layout.tsx
@@ -107,6 +107,16 @@ export default function CaseroTabsLayout() {
         }}
       />
       <Tabs.Screen
+        name="fiscal"
+        options={{
+          title: 'Fiscal',
+          href: modulos.gastos ? undefined : null,
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="briefcase-outline" size={size} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
         name="inventario"
         options={{
           title: 'Invent.',

--- a/frontend/app/casero/(tabs)/fiscal.tsx
+++ b/frontend/app/casero/(tabs)/fiscal.tsx
@@ -1,0 +1,1022 @@
+import { useCallback, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Linking,
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  Share,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import * as FileSystem from 'expo-file-system/legacy';
+import { useFocusEffect } from 'expo-router';
+import Toast from 'react-native-toast-message';
+import { CustomButton } from '@/components/common/CustomButton';
+import { LoadingScreen } from '@/components/common/LoadingScreen';
+import { AppTheme } from '@/constants/theme';
+import { useAppTheme } from '@/contexts/ThemeContext';
+import api from '@/services/api';
+import { createStyles, getFiscalStatusColors } from '@/styles/casero/fiscal.styles';
+
+type FiscalStyles = ReturnType<typeof createStyles>;
+type FiscalStatusColors = ReturnType<typeof getFiscalStatusColors>;
+
+type Vivienda = {
+  id: number;
+  alias_nombre: string;
+  direccion: string;
+  mod_gastos: boolean;
+};
+
+type CategoriaFiscal =
+  | 'FINANCIACION_INTERESES'
+  | 'CONSERVACION_REPARACION'
+  | 'COMUNIDAD'
+  | 'IBI_TASAS'
+  | 'SEGUROS'
+  | 'SUMINISTROS'
+  | 'SERVICIOS_PROFESIONALES'
+  | 'LIMPIEZA'
+  | 'MOBILIARIO_ENSERES'
+  | 'AMORTIZACION'
+  | 'OTROS'
+  | 'SIN_CLASIFICAR';
+
+type Deducibilidad = 'NO_APLICA' | 'PENDIENTE_CLASIFICACION' | 'DEDUCIBLE' | 'NO_DEDUCIBLE';
+
+type FiscalAdvertencia = {
+  codigo: string;
+  mensaje: string;
+  gasto_id?: number;
+  deuda_id?: number;
+};
+
+type FiscalLinea = {
+  id: string;
+  naturaleza: 'INGRESO' | 'GASTO_POTENCIALMENTE_DEDUCIBLE';
+  fuente: {
+    modelo: 'Deuda' | 'Gasto';
+    gasto_id: number;
+    deuda_id?: number;
+  };
+  concepto: string;
+  categoria: string;
+  deducibilidad: Deducibilidad;
+  importe: number;
+  moneda: 'EUR';
+  fecha: string;
+  periodo_facturacion: string | null;
+  estado_pago: 'COBRADO' | 'PENDIENTE' | 'ANULADO';
+  factura_url: string | null;
+  justificante_url?: string | null;
+  metadata_fiscal?: {
+    categoria_fiscal: CategoriaFiscal;
+    deducible_previsto: boolean | null;
+    notas_fiscales: string | null;
+    prorrateo_fiscal: number | null;
+  };
+  habitacion?: { id: number; nombre: string } | null;
+  inquilino?: { id: number; nombre: string; apellidos: string | null } | null;
+  advertencias: FiscalAdvertencia[];
+};
+
+type FiscalResumen = {
+  ejercicio: number;
+  generado_en: string;
+  vivienda: {
+    id: number;
+    alias_nombre: string;
+    direccion: string;
+    codigo_postal: string;
+    ciudad: string;
+    provincia: string;
+  };
+  totales: {
+    ingresos: {
+      emitido: number;
+      cobrado: number;
+      pendiente: number;
+      anulado: number;
+      por_tipo: Record<string, number>;
+    };
+    gastos: {
+      potencialmente_deducible: number;
+      deducible_previsto: number;
+      no_deducible_previsto: number;
+      pendiente_clasificacion: number;
+      con_factura: number;
+      sin_factura: number;
+      por_categoria: Record<string, number>;
+    };
+  };
+  lineas: FiscalLinea[];
+  advertencias: FiscalAdvertencia[];
+};
+
+type FiscalOcupacion = {
+  ejercicio: number;
+  resumen: {
+    dias_alquilados: number;
+    meses_equivalentes: number;
+    porcentaje_ocupacion: number;
+    estado: 'SIN_ACTIVIDAD' | 'PARCIAL' | 'TODO_EL_ANO';
+    habitaciones_con_actividad: number;
+    habitaciones_requieren_revision: number;
+    requiere_revision: boolean;
+  };
+  habitaciones: {
+    id: number;
+    nombre: string;
+    tipo: string;
+    es_habitable: boolean;
+    precio: number | null;
+    dias_alquilados: number;
+    meses_equivalentes: number;
+    porcentaje_ocupacion: number;
+    estado: 'SIN_ACTIVIDAD' | 'PARCIAL' | 'TODO_EL_ANO';
+    requiere_revision: boolean;
+    revisiones: { codigo: string; mensaje: string }[];
+  }[];
+  gastos_prorrateados: {
+    id: number;
+    concepto: string;
+    importe: number;
+    tipo: string;
+    fecha: string;
+    prorrateo: {
+      modo: 'MANUAL' | 'OCUPACION';
+      porcentaje: number;
+      importe_prorrateado: number;
+    };
+  }[];
+};
+
+type DossierFiscalResponse = {
+  nombreArchivo: string;
+  mimeType: string;
+  contenidoBase64: string;
+};
+
+type EditorFiscal = {
+  linea: FiscalLinea;
+  categoria: CategoriaFiscal;
+  deducible: 'pendiente' | 'si' | 'no';
+  notas: string;
+  prorrateo: string;
+};
+
+const CATEGORIAS: { value: CategoriaFiscal; label: string }[] = [
+  { value: 'SIN_CLASIFICAR', label: 'Pendiente de clasificar' },
+  { value: 'FINANCIACION_INTERESES', label: 'Financiacion e intereses' },
+  { value: 'CONSERVACION_REPARACION', label: 'Conservacion y reparacion' },
+  { value: 'COMUNIDAD', label: 'Comunidad' },
+  { value: 'IBI_TASAS', label: 'IBI y tasas' },
+  { value: 'SEGUROS', label: 'Seguros' },
+  { value: 'SUMINISTROS', label: 'Suministros' },
+  { value: 'SERVICIOS_PROFESIONALES', label: 'Servicios profesionales' },
+  { value: 'LIMPIEZA', label: 'Limpieza' },
+  { value: 'MOBILIARIO_ENSERES', label: 'Mobiliario y enseres' },
+  { value: 'AMORTIZACION', label: 'Amortizacion' },
+  { value: 'OTROS', label: 'Otros' },
+];
+
+const EJERCICIO_ACTUAL = new Date().getFullYear();
+
+const formatearImporte = (importe: number) =>
+  importe.toLocaleString('es-ES', { style: 'currency', currency: 'EUR' });
+
+const formatearFecha = (fechaIso: string) =>
+  new Date(fechaIso).toLocaleDateString('es-ES', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
+
+const formatearPorcentaje = (porcentaje: number) =>
+  `${porcentaje.toLocaleString('es-ES', { maximumFractionDigits: 1 })}%`;
+
+const etiquetaCategoria = (categoria: string) =>
+  CATEGORIAS.find((item) => item.value === categoria)?.label ??
+  (categoria === 'PENDIENTE_CLASIFICACION' ? 'Pendiente de clasificar' : categoria);
+
+const etiquetaDeducibilidad = (deducibilidad: Deducibilidad) => {
+  if (deducibilidad === 'DEDUCIBLE') return 'Preparado como deducible';
+  if (deducibilidad === 'NO_DEDUCIBLE') return 'Marcado no deducible';
+  if (deducibilidad === 'PENDIENTE_CLASIFICACION') return 'Pendiente de revisar';
+  return 'No aplica';
+};
+
+const nombreCompleto = (nombre: string, apellidos: string | null) =>
+  apellidos ? `${nombre} ${apellidos}` : nombre;
+
+const normalizarProrrateo = (valor: string) => {
+  const limpio = valor.trim();
+  if (!limpio) return { valido: true, valor: null };
+
+  const numero = Number(limpio.replace(',', '.'));
+  return {
+    valido: Number.isFinite(numero) && numero >= 0 && numero <= 100,
+    valor: numero,
+  };
+};
+
+export default function CaseroFiscalScreen() {
+  const { theme } = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const statusColors = useMemo(() => getFiscalStatusColors(theme), [theme]);
+  const [viviendas, setViviendas] = useState<Vivienda[]>([]);
+  const [hayViviendas, setHayViviendas] = useState(false);
+  const [viviendaSeleccionadaId, setViviendaSeleccionadaId] = useState<number | null>(null);
+  const [ejercicio, setEjercicio] = useState(EJERCICIO_ACTUAL);
+  const [resumen, setResumen] = useState<FiscalResumen | null>(null);
+  const [ocupacion, setOcupacion] = useState<FiscalOcupacion | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadingFiscal, setLoadingFiscal] = useState(false);
+  const [errorFiscal, setErrorFiscal] = useState<string | null>(null);
+  const [exportando, setExportando] = useState(false);
+  const [editor, setEditor] = useState<EditorFiscal | null>(null);
+  const [guardando, setGuardando] = useState(false);
+
+  const viviendaSeleccionada = useMemo(
+    () => viviendas.find((vivienda) => vivienda.id === viviendaSeleccionadaId) ?? null,
+    [viviendaSeleccionadaId, viviendas],
+  );
+
+  const lineasGasto = useMemo(
+    () => resumen?.lineas.filter((linea) => linea.naturaleza === 'GASTO_POTENCIALMENTE_DEDUCIBLE') ?? [],
+    [resumen],
+  );
+
+  const lineasIngreso = useMemo(
+    () => resumen?.lineas.filter((linea) => linea.naturaleza === 'INGRESO') ?? [],
+    [resumen],
+  );
+
+  const pendientesRevision = resumen?.advertencias.length ?? 0;
+  const documentosAusentes = resumen?.lineas.filter((linea) => !linea.factura_url).length ?? 0;
+  const puedeExportar = !!resumen && !exportando && !loadingFiscal;
+
+  const cargarFiscal = useCallback(async (viviendaId: number, ejercicioObjetivo: number) => {
+    setLoadingFiscal(true);
+    try {
+      const [resumenResponse, ocupacionResponse] = await Promise.all([
+        api.get<FiscalResumen>(`/viviendas/${viviendaId}/fiscal/${ejercicioObjetivo}`),
+        api.get<FiscalOcupacion>(`/viviendas/${viviendaId}/fiscal/ocupacion`, {
+          params: { ejercicio: ejercicioObjetivo },
+        }),
+      ]);
+
+      setResumen(resumenResponse.data);
+      setOcupacion(ocupacionResponse.data);
+      setErrorFiscal(null);
+    } catch (error: any) {
+      const mensaje = error.response?.data?.error ?? 'No se pudo cargar el modo fiscal.';
+      setResumen(null);
+      setOcupacion(null);
+      setErrorFiscal(mensaje);
+      Toast.show({ type: 'error', text1: mensaje });
+    } finally {
+      setLoadingFiscal(false);
+    }
+  }, []);
+
+  const cargarContexto = useCallback(async () => {
+    setLoading(true);
+    try {
+      const { data } = await api.get<Vivienda[]>('/viviendas');
+      const viviendasConGastos = data.filter((vivienda) => vivienda.mod_gastos);
+      setHayViviendas(data.length > 0);
+      setViviendas(viviendasConGastos);
+
+      if (viviendasConGastos.length === 0) {
+        setViviendaSeleccionadaId(null);
+        setResumen(null);
+        setOcupacion(null);
+        setErrorFiscal(null);
+        return;
+      }
+
+      const viviendaInicial =
+        viviendasConGastos.find((vivienda) => vivienda.id === viviendaSeleccionadaId) ??
+        viviendasConGastos[0];
+
+      setViviendaSeleccionadaId(viviendaInicial.id);
+      await cargarFiscal(viviendaInicial.id, ejercicio);
+    } catch {
+      setViviendas([]);
+      setHayViviendas(false);
+      setViviendaSeleccionadaId(null);
+      setResumen(null);
+      setOcupacion(null);
+      setErrorFiscal('No se pudieron cargar tus viviendas.');
+      Toast.show({ type: 'error', text1: 'No se pudieron cargar tus viviendas.' });
+    } finally {
+      setLoading(false);
+    }
+  }, [cargarFiscal, ejercicio, viviendaSeleccionadaId]);
+
+  useFocusEffect(
+    useCallback(() => {
+      cargarContexto();
+    }, [cargarContexto]),
+  );
+
+  const cambiarVivienda = async (viviendaId: number) => {
+    setViviendaSeleccionadaId(viviendaId);
+    await cargarFiscal(viviendaId, ejercicio);
+  };
+
+  const cambiarEjercicio = async (delta: number) => {
+    const siguiente = Math.min(2100, Math.max(2000, ejercicio + delta));
+    setEjercicio(siguiente);
+    if (viviendaSeleccionadaId) {
+      await cargarFiscal(viviendaSeleccionadaId, siguiente);
+    }
+  };
+
+  const guardarArchivoCsv = async (contenidoBase64: string, nombreArchivo: string, mimeType: string) => {
+    if (Platform.OS === 'web' && typeof document !== 'undefined') {
+      const bytes = Uint8Array.from(atob(contenidoBase64), (char) => char.charCodeAt(0));
+      const blob = new Blob([bytes], { type: mimeType });
+      const url = URL.createObjectURL(blob);
+      const enlace = document.createElement('a');
+      enlace.href = url;
+      enlace.download = nombreArchivo;
+      enlace.click();
+      URL.revokeObjectURL(url);
+      return;
+    }
+
+    if (Platform.OS === 'android') {
+      const permisos = await FileSystem.StorageAccessFramework.requestDirectoryPermissionsAsync();
+      if (!permisos.granted) {
+        throw new Error('Selecciona una carpeta para guardar el archivo.');
+      }
+
+      const nombreSinExtension = nombreArchivo.replace(/\.csv$/i, '');
+      const uri = await FileSystem.StorageAccessFramework.createFileAsync(
+        permisos.directoryUri,
+        nombreSinExtension,
+        mimeType,
+      );
+      await FileSystem.writeAsStringAsync(uri, contenidoBase64, {
+        encoding: FileSystem.EncodingType.Base64,
+      });
+      return;
+    }
+
+    const uri = `${FileSystem.cacheDirectory ?? ''}${nombreArchivo}`;
+    await FileSystem.writeAsStringAsync(uri, contenidoBase64, {
+      encoding: FileSystem.EncodingType.Base64,
+    });
+
+    await Share.share({ title: nombreArchivo, url: uri });
+  };
+
+  const exportarDossier = async () => {
+    if (!viviendaSeleccionadaId) return;
+
+    setExportando(true);
+    try {
+      const { data } = await api.get<DossierFiscalResponse>(
+        `/viviendas/${viviendaSeleccionadaId}/fiscal/${ejercicio}/dossier`,
+        { params: { formato: 'base64' } },
+      );
+
+      await guardarArchivoCsv(data.contenidoBase64, data.nombreArchivo, data.mimeType);
+      Toast.show({
+        type: 'success',
+        text1: 'Dossier fiscal preparado',
+        text2: Platform.OS === 'android' ? 'Archivo CSV guardado.' : 'CSV listo para compartir o abrir.',
+      });
+    } catch (error: any) {
+      Toast.show({
+        type: 'error',
+        text1: error.response?.data?.error ?? error.message ?? 'No se pudo exportar el dossier fiscal.',
+      });
+    } finally {
+      setExportando(false);
+    }
+  };
+
+  const abrirEditor = (linea: FiscalLinea) => {
+    const metadata = linea.metadata_fiscal;
+    const categoria =
+      metadata?.categoria_fiscal ??
+      (CATEGORIAS.some((item) => item.value === linea.categoria)
+        ? (linea.categoria as CategoriaFiscal)
+        : 'SIN_CLASIFICAR');
+    const deducible =
+      metadata?.deducible_previsto === true
+        ? 'si'
+        : metadata?.deducible_previsto === false
+          ? 'no'
+          : linea.deducibilidad === 'DEDUCIBLE'
+            ? 'si'
+            : linea.deducibilidad === 'NO_DEDUCIBLE'
+              ? 'no'
+              : 'pendiente';
+
+    setEditor({
+      linea,
+      categoria,
+      deducible,
+      notas: metadata?.notas_fiscales ?? '',
+      prorrateo:
+        metadata?.prorrateo_fiscal !== null && metadata?.prorrateo_fiscal !== undefined
+          ? String(metadata.prorrateo_fiscal).replace('.', ',')
+          : '',
+    });
+  };
+
+  const guardarMetadataFiscal = async () => {
+    if (!editor || !viviendaSeleccionadaId) return;
+
+    const prorrateo = normalizarProrrateo(editor.prorrateo);
+    if (!prorrateo.valido) {
+      Toast.show({ type: 'error', text1: 'El prorrateo debe estar entre 0 y 100.' });
+      return;
+    }
+
+    setGuardando(true);
+    try {
+      await api.patch(`/viviendas/${viviendaSeleccionadaId}/gastos/${editor.linea.fuente.gasto_id}`, {
+        categoria_fiscal: editor.categoria,
+        deducible_previsto:
+          editor.deducible === 'pendiente' ? null : editor.deducible === 'si',
+        notas_fiscales: editor.notas.trim() ? editor.notas.trim() : null,
+        prorrateo_fiscal: prorrateo.valor,
+      });
+
+      setEditor(null);
+      await cargarFiscal(viviendaSeleccionadaId, ejercicio);
+      Toast.show({ type: 'success', text1: 'Linea fiscal actualizada.' });
+    } catch (error: any) {
+      Toast.show({
+        type: 'error',
+        text1: error.response?.data?.error ?? 'No se pudo actualizar la linea fiscal.',
+      });
+    } finally {
+      setGuardando(false);
+    }
+  };
+
+  if (loading) {
+    return <LoadingScreen />;
+  }
+
+  if (!hayViviendas || viviendas.length === 0) {
+    return (
+      <View style={styles.container}>
+        <View style={styles.emptyContainer}>
+          <View style={styles.emptyIconBox}>
+            <Ionicons name="briefcase-outline" size={34} color={theme.colors.primary} />
+          </View>
+          <Text style={styles.emptyTitle}>Modo fiscal sin viviendas activas</Text>
+          <Text style={styles.emptySubtitle}>
+            Crea una vivienda o activa el modulo de gastos para preparar el resumen fiscal del casero.
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+        <View style={styles.header}>
+          <Text style={styles.headerEyebrow}>Modo fiscal</Text>
+          <Text style={styles.headerTitle}>Preparacion fiscal</Text>
+          <Text style={styles.headerSubtitle}>
+            Revisa ingresos, gastos, prorrateos y documentos antes de llevar el CSV a tu gestor.
+          </Text>
+        </View>
+
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          style={styles.selector}
+          contentContainerStyle={styles.selectorContent}
+        >
+          {viviendas.map((vivienda) => {
+            const activa = vivienda.id === viviendaSeleccionadaId;
+            return (
+              <Pressable
+                key={vivienda.id}
+                style={[styles.chip, activa && styles.chipActive]}
+                onPress={() => cambiarVivienda(vivienda.id)}
+              >
+                <Text style={[styles.chipText, activa && styles.chipTextActive]}>
+                  {vivienda.alias_nombre}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </ScrollView>
+
+        <View style={styles.yearRow}>
+          <Pressable style={styles.yearButton} onPress={() => cambiarEjercicio(-1)}>
+            <Ionicons name="chevron-back" size={20} color={theme.colors.primary} />
+          </Pressable>
+          <View style={styles.yearPill}>
+            <Text style={styles.yearText}>Ejercicio {ejercicio}</Text>
+          </View>
+          <Pressable style={styles.yearButton} onPress={() => cambiarEjercicio(1)}>
+            <Ionicons name="chevron-forward" size={20} color={theme.colors.primary} />
+          </Pressable>
+        </View>
+
+        {errorFiscal && (
+          <StatusNotice
+            text={errorFiscal}
+            icon="alert-circle-outline"
+            tone="danger"
+            styles={styles}
+            theme={theme}
+            statusColors={statusColors}
+          />
+        )}
+
+        {loadingFiscal && (
+          <ActivityIndicator
+            color={theme.colors.primary}
+            style={{ marginVertical: theme.spacing.xl }}
+          />
+        )}
+
+        {resumen && viviendaSeleccionada && (
+          <>
+            <View style={styles.heroCard}>
+              <View style={styles.heroTop}>
+                <Text style={styles.heroLabel}>Resumen anual</Text>
+                <Text style={styles.heroTitle}>{viviendaSeleccionada.alias_nombre}</Text>
+                <Text style={styles.heroAddress}>{viviendaSeleccionada.direccion}</Text>
+              </View>
+
+              <View style={styles.metricGrid}>
+                <MetricCard
+                  label="Ingresos cobrados"
+                  value={formatearImporte(resumen.totales.ingresos.cobrado)}
+                  help={`${formatearImporte(resumen.totales.ingresos.pendiente)} pendiente`}
+                  styles={styles}
+                />
+                <MetricCard
+                  label="Gastos revisables"
+                  value={formatearImporte(resumen.totales.gastos.potencialmente_deducible)}
+                  help={`${formatearImporte(resumen.totales.gastos.deducible_previsto)} preparados`}
+                  styles={styles}
+                />
+                <MetricCard
+                  label="Sin clasificar"
+                  value={formatearImporte(resumen.totales.gastos.pendiente_clasificacion)}
+                  help="Gastos que necesitan categoria o criterio"
+                  styles={styles}
+                />
+                <MetricCard
+                  label="Sin documento"
+                  value={String(documentosAusentes)}
+                  help="Lineas sin factura adjunta"
+                  styles={styles}
+                />
+              </View>
+
+              <View style={styles.actionRow}>
+                <CustomButton
+                  label={exportando ? 'Exportando...' : 'Exportar CSV'}
+                  onPress={exportarDossier}
+                  disabled={!puedeExportar}
+                  style={styles.actionButton}
+                />
+              </View>
+            </View>
+
+            <StatusNotice
+              text={
+                pendientesRevision > 0
+                  ? `${pendientesRevision} avisos necesitan revision antes de cerrar el dossier.`
+                  : 'El resumen esta listo para una revision final. Roomies no sustituye el criterio fiscal profesional.'
+              }
+              icon={pendientesRevision > 0 ? 'warning-outline' : 'checkmark-circle-outline'}
+              tone={pendientesRevision > 0 ? 'review' : 'ready'}
+              styles={styles}
+              theme={theme}
+              statusColors={statusColors}
+            />
+
+            {ocupacion && (
+              <View style={styles.section}>
+                <View style={styles.sectionHeader}>
+                  <Text style={styles.sectionTitle}>Ocupacion y prorrateos</Text>
+                  <Text style={styles.sectionSubtitle}>
+                    Base de calculo para repartir gastos por uso anual de la vivienda.
+                  </Text>
+                </View>
+                <View style={styles.list}>
+                  <View style={styles.card}>
+                    <View style={styles.lineHeader}>
+                      <View style={[styles.lineIcon, { backgroundColor: theme.colors.primaryLight }]}>
+                        <Ionicons name="calendar-outline" size={22} color={theme.colors.primary} />
+                      </View>
+                      <View style={styles.lineBody}>
+                        <Text style={styles.lineTitle}>
+                          {ocupacion.resumen.meses_equivalentes.toLocaleString('es-ES', {
+                            maximumFractionDigits: 1,
+                          })}{' '}
+                          meses equivalentes alquilados
+                        </Text>
+                        <Text style={styles.lineMeta}>
+                          {ocupacion.resumen.dias_alquilados} dias con actividad ·{' '}
+                          {ocupacion.resumen.habitaciones_con_actividad} habitaciones con cargos
+                        </Text>
+                      </View>
+                    </View>
+                    <View style={styles.occupancyRow}>
+                      <View style={styles.occupancyMeter}>
+                        <View
+                          style={[
+                            styles.occupancyFill,
+                            { width: `${Math.min(100, ocupacion.resumen.porcentaje_ocupacion)}%` },
+                          ]}
+                        />
+                      </View>
+                      <Text style={styles.occupancyPercent}>
+                        {formatearPorcentaje(ocupacion.resumen.porcentaje_ocupacion)}
+                      </Text>
+                    </View>
+                  </View>
+
+                  {ocupacion.habitaciones
+                    .filter((habitacion) => habitacion.es_habitable)
+                    .map((habitacion) => (
+                      <View key={habitacion.id} style={styles.card}>
+                        <View style={styles.lineHeader}>
+                          <View style={[styles.lineIcon, { backgroundColor: theme.colors.infoLight }]}>
+                            <Ionicons name="bed-outline" size={22} color={theme.colors.info} />
+                          </View>
+                          <View style={styles.lineBody}>
+                            <Text style={styles.lineTitle}>{habitacion.nombre}</Text>
+                            <Text style={styles.lineMeta}>
+                              {habitacion.dias_alquilados} dias ·{' '}
+                              {formatearPorcentaje(habitacion.porcentaje_ocupacion)}
+                            </Text>
+                          </View>
+                          {habitacion.requiere_revision && (
+                            <View
+                              style={[
+                                styles.badge,
+                                {
+                                  backgroundColor: statusColors.review.bg,
+                                  borderColor: statusColors.review.border,
+                                },
+                              ]}
+                            >
+                              <Text style={[styles.badgeText, { color: statusColors.review.text }]}>
+                                Revisar
+                              </Text>
+                            </View>
+                          )}
+                        </View>
+                        {habitacion.revisiones.map((revision) => (
+                          <Text key={revision.codigo + revision.mensaje} style={styles.warningText}>
+                            {revision.mensaje}
+                          </Text>
+                        ))}
+                      </View>
+                    ))}
+                </View>
+              </View>
+            )}
+
+            <View style={styles.section}>
+              <View style={styles.sectionHeader}>
+                <Text style={styles.sectionTitle}>Gastos a clasificar</Text>
+                <Text style={styles.sectionSubtitle}>
+                  Ajusta categoria, deducibilidad prevista, notas y prorrateo manual cuando proceda.
+                </Text>
+              </View>
+              <View style={styles.list}>
+                {lineasGasto.length === 0 ? (
+                  <EmptyInline text="No hay gastos potencialmente deducibles en este ejercicio." styles={styles} />
+                ) : (
+                  lineasGasto.map((linea) => (
+                    <FiscalLineCard
+                      key={linea.id}
+                      linea={linea}
+                      styles={styles}
+                      theme={theme}
+                      statusColors={statusColors}
+                      onEditar={abrirEditor}
+                    />
+                  ))
+                )}
+              </View>
+            </View>
+
+            <View style={styles.section}>
+              <View style={styles.sectionHeader}>
+                <Text style={styles.sectionTitle}>Ingresos y justificantes</Text>
+                <Text style={styles.sectionSubtitle}>
+                  Seguimiento de cobros del ejercicio sin exponer datos fiscales a inquilinos.
+                </Text>
+              </View>
+              <View style={styles.list}>
+                {lineasIngreso.length === 0 ? (
+                  <EmptyInline text="No hay ingresos registrados para este ejercicio." styles={styles} />
+                ) : (
+                  lineasIngreso.slice(0, 8).map((linea) => (
+                    <FiscalLineCard
+                      key={linea.id}
+                      linea={linea}
+                      styles={styles}
+                      theme={theme}
+                      statusColors={statusColors}
+                    />
+                  ))
+                )}
+              </View>
+            </View>
+          </>
+        )}
+      </ScrollView>
+
+      <Modal visible={!!editor} transparent animationType="slide" onRequestClose={() => setEditor(null)}>
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+          style={styles.modalOverlay}
+        >
+          <Pressable style={{ flex: 1 }} onPress={() => setEditor(null)} />
+          <View style={styles.modalSheet}>
+            <View style={styles.modalHandle} />
+            <ScrollView contentContainerStyle={styles.modalContent} showsVerticalScrollIndicator={false}>
+              <Text style={styles.modalTitle}>Revisar gasto</Text>
+              <Text style={styles.modalSubtitle}>
+                {editor?.linea.concepto}. La marca es de preparacion y puede revisarla tu gestor.
+              </Text>
+
+              <View style={styles.formGroup}>
+                <Text style={styles.inputLabel}>Categoria fiscal</Text>
+                <View style={styles.optionGrid}>
+                  {CATEGORIAS.map((categoria) => {
+                    const activa = editor?.categoria === categoria.value;
+                    return (
+                      <Pressable
+                        key={categoria.value}
+                        style={[styles.optionButton, activa && styles.optionButtonActive]}
+                        onPress={() => editor && setEditor({ ...editor, categoria: categoria.value })}
+                      >
+                        <Text style={[styles.optionText, activa && styles.optionTextActive]}>
+                          {categoria.label}
+                        </Text>
+                        {activa && <Ionicons name="checkmark" size={18} color={theme.colors.primary} />}
+                      </Pressable>
+                    );
+                  })}
+                </View>
+              </View>
+
+              <View style={styles.formGroup}>
+                <Text style={styles.inputLabel}>Deducibilidad prevista</Text>
+                <View style={styles.optionGrid}>
+                  {[
+                    { value: 'pendiente', label: 'Pendiente de revisar' },
+                    { value: 'si', label: 'Preparar como deducible' },
+                    { value: 'no', label: 'Marcar no deducible' },
+                  ].map((opcion) => {
+                    const activa = editor?.deducible === opcion.value;
+                    return (
+                      <Pressable
+                        key={opcion.value}
+                        style={[styles.optionButton, activa && styles.optionButtonActive]}
+                        onPress={() =>
+                          editor &&
+                          setEditor({ ...editor, deducible: opcion.value as EditorFiscal['deducible'] })
+                        }
+                      >
+                        <Text style={[styles.optionText, activa && styles.optionTextActive]}>
+                          {opcion.label}
+                        </Text>
+                        {activa && <Ionicons name="checkmark" size={18} color={theme.colors.primary} />}
+                      </Pressable>
+                    );
+                  })}
+                </View>
+              </View>
+
+              <View style={styles.formGroup}>
+                <Text style={styles.inputLabel}>Prorrateo manual (%)</Text>
+                <TextInput
+                  style={styles.textInput}
+                  placeholder="Vacío: usar ocupación anual"
+                  placeholderTextColor={theme.colors.textMuted}
+                  value={editor?.prorrateo ?? ''}
+                  onChangeText={(valor) => editor && setEditor({ ...editor, prorrateo: valor })}
+                  keyboardType="decimal-pad"
+                />
+              </View>
+
+              <View style={styles.formGroup}>
+                <Text style={styles.inputLabel}>Notas privadas</Text>
+                <TextInput
+                  style={[styles.textInput, styles.notesInput]}
+                  placeholder="Ej. Revisar con gestor si corresponde al periodo alquilado"
+                  placeholderTextColor={theme.colors.textMuted}
+                  value={editor?.notas ?? ''}
+                  onChangeText={(valor) => editor && setEditor({ ...editor, notas: valor })}
+                  multiline
+                  maxLength={1000}
+                />
+              </View>
+
+              <View style={styles.modalActions}>
+                <CustomButton
+                  label="Cancelar"
+                  variant="secondary"
+                  onPress={() => setEditor(null)}
+                  disabled={guardando}
+                  style={styles.modalAction}
+                />
+                <CustomButton
+                  label={guardando ? 'Guardando...' : 'Guardar'}
+                  onPress={guardarMetadataFiscal}
+                  disabled={guardando}
+                  style={styles.modalAction}
+                />
+              </View>
+            </ScrollView>
+          </View>
+        </KeyboardAvoidingView>
+      </Modal>
+    </View>
+  );
+}
+
+function MetricCard({
+  label,
+  value,
+  help,
+  styles,
+}: {
+  label: string;
+  value: string;
+  help: string;
+  styles: FiscalStyles;
+}) {
+  return (
+    <View style={styles.metricCard}>
+      <Text style={styles.metricLabel}>{label}</Text>
+      <Text style={styles.metricValue}>{value}</Text>
+      <Text style={styles.metricHelp}>{help}</Text>
+    </View>
+  );
+}
+
+function StatusNotice({
+  text,
+  icon,
+  tone,
+  styles,
+  theme,
+  statusColors,
+}: {
+  text: string;
+  icon: keyof typeof Ionicons.glyphMap;
+  tone: keyof FiscalStatusColors;
+  styles: FiscalStyles;
+  theme: AppTheme;
+  statusColors: FiscalStatusColors;
+}) {
+  const colors = statusColors[tone];
+  return (
+    <View style={[styles.notice, { backgroundColor: colors.bg, borderColor: colors.border }]}>
+      <Ionicons name={icon} size={19} color={colors.text} />
+      <Text style={[styles.noticeText, { color: theme.isDark ? theme.colors.textMedium : colors.text }]}>
+        {text}
+      </Text>
+    </View>
+  );
+}
+
+function EmptyInline({ text, styles }: { text: string; styles: FiscalStyles }) {
+  return (
+    <View style={styles.card}>
+      <Text style={styles.lineMeta}>{text}</Text>
+    </View>
+  );
+}
+
+function FiscalLineCard({
+  linea,
+  styles,
+  theme,
+  statusColors,
+  onEditar,
+}: {
+  linea: FiscalLinea;
+  styles: FiscalStyles;
+  theme: AppTheme;
+  statusColors: FiscalStatusColors;
+  onEditar?: (linea: FiscalLinea) => void;
+}) {
+  const esGasto = linea.naturaleza === 'GASTO_POTENCIALMENTE_DEDUCIBLE';
+  const tone =
+    linea.advertencias.length > 0
+      ? 'review'
+      : linea.deducibilidad === 'PENDIENTE_CLASIFICACION'
+        ? 'pending'
+        : 'ready';
+  const colors = statusColors[tone];
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.lineHeader}>
+        <View
+          style={[
+            styles.lineIcon,
+            { backgroundColor: esGasto ? theme.colors.warningLight : theme.colors.successLight },
+          ]}
+        >
+          <Ionicons
+            name={esGasto ? 'receipt-outline' : 'cash-outline'}
+            size={22}
+            color={esGasto ? theme.colors.warning : theme.colors.success}
+          />
+        </View>
+        <View style={styles.lineBody}>
+          <Text style={styles.lineTitle} numberOfLines={2}>
+            {linea.concepto}
+          </Text>
+          <Text style={styles.lineMeta}>
+            {formatearFecha(linea.fecha)}
+            {linea.periodo_facturacion ? ` · ${linea.periodo_facturacion}` : ''}
+            {linea.inquilino ? ` · ${nombreCompleto(linea.inquilino.nombre, linea.inquilino.apellidos)}` : ''}
+          </Text>
+        </View>
+        <Text style={styles.lineAmount}>{formatearImporte(linea.importe)}</Text>
+      </View>
+
+      <View style={styles.badgeRow}>
+        <View style={[styles.badge, { backgroundColor: colors.bg, borderColor: colors.border }]}>
+          <Text style={[styles.badgeText, { color: colors.text }]}>
+            {etiquetaDeducibilidad(linea.deducibilidad)}
+          </Text>
+        </View>
+        <View style={[styles.badge, { backgroundColor: theme.colors.surface2, borderColor: theme.colors.border }]}>
+          <Text style={[styles.badgeText, { color: theme.colors.textSecondary }]}>
+            {etiquetaCategoria(linea.categoria)}
+          </Text>
+        </View>
+        {!linea.factura_url && (
+          <View
+            style={[
+              styles.badge,
+              { backgroundColor: statusColors.danger.bg, borderColor: statusColors.danger.border },
+            ]}
+          >
+            <Text style={[styles.badgeText, { color: statusColors.danger.text }]}>Sin factura</Text>
+          </View>
+        )}
+      </View>
+
+      {linea.advertencias.map((advertencia) => (
+        <Text key={`${linea.id}-${advertencia.codigo}-${advertencia.mensaje}`} style={styles.warningText}>
+          {advertencia.mensaje}
+        </Text>
+      ))}
+
+      <View style={styles.lineActions}>
+        {esGasto && onEditar && (
+          <Pressable
+            style={[styles.smallButton, { backgroundColor: theme.colors.primaryLight }]}
+            onPress={() => onEditar(linea)}
+          >
+            <Ionicons name="create-outline" size={15} color={theme.colors.primary} />
+            <Text style={[styles.smallButtonText, { color: theme.colors.primary }]}>Clasificar</Text>
+          </Pressable>
+        )}
+        {linea.factura_url && (
+          <Pressable
+            style={[styles.smallButton, { backgroundColor: theme.colors.infoLight }]}
+            onPress={() => Linking.openURL(linea.factura_url!)}
+          >
+            <Ionicons name="document-text-outline" size={15} color={theme.colors.info} />
+            <Text style={[styles.smallButtonText, { color: theme.colors.info }]}>Factura</Text>
+          </Pressable>
+        )}
+        {linea.justificante_url && (
+          <Pressable
+            style={[styles.smallButton, { backgroundColor: theme.colors.successLight }]}
+            onPress={() => Linking.openURL(linea.justificante_url!)}
+          >
+            <Ionicons name="image-outline" size={15} color={theme.colors.success} />
+            <Text style={[styles.smallButtonText, { color: theme.colors.successText }]}>Justificante</Text>
+          </Pressable>
+        )}
+      </View>
+    </View>
+  );
+}

--- a/frontend/styles/casero/fiscal.styles.ts
+++ b/frontend/styles/casero/fiscal.styles.ts
@@ -1,0 +1,446 @@
+import { StyleSheet } from 'react-native';
+import { AppTheme, DefaultAppTheme } from '@/constants/theme';
+
+export const getFiscalStatusColors = (theme: AppTheme = DefaultAppTheme) => ({
+  ready: {
+    bg: theme.colors.successLight,
+    text: theme.colors.successText,
+    border: `${theme.colors.success}30`,
+  },
+  review: {
+    bg: theme.colors.warningLight,
+    text: theme.colors.warningText,
+    border: `${theme.colors.warning}34`,
+  },
+  pending: {
+    bg: theme.colors.infoLight,
+    text: theme.colors.info,
+    border: `${theme.colors.info}30`,
+  },
+  danger: {
+    bg: theme.colors.dangerLight,
+    text: theme.colors.danger,
+    border: `${theme.colors.danger}28`,
+  },
+} as const);
+
+export const createStyles = (theme: AppTheme = DefaultAppTheme) => StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.background,
+  },
+  content: {
+    paddingHorizontal: theme.spacing.lg,
+    paddingTop: theme.spacing.lg,
+    paddingBottom: 120,
+  },
+  header: {
+    marginBottom: theme.spacing.lg,
+    gap: theme.spacing.sm,
+  },
+  headerEyebrow: {
+    fontSize: theme.typography.caption,
+    fontWeight: '800',
+    color: theme.colors.textTertiary,
+    letterSpacing: 1.1,
+    textTransform: 'uppercase',
+  },
+  headerTitle: {
+    fontSize: theme.typography.hero,
+    fontWeight: '800',
+    color: theme.colors.text,
+  },
+  headerSubtitle: {
+    fontSize: theme.typography.body,
+    color: theme.colors.textSecondary,
+    lineHeight: 22,
+  },
+  selector: {
+    marginBottom: theme.spacing.lg,
+  },
+  selectorContent: {
+    gap: theme.spacing.sm,
+    paddingRight: theme.spacing.sm,
+  },
+  chip: {
+    paddingHorizontal: theme.spacing.base,
+    paddingVertical: theme.spacing.sm,
+    borderRadius: theme.radius.full,
+    backgroundColor: theme.colors.surface,
+    borderWidth: 1.5,
+    borderColor: theme.colors.border,
+  },
+  chipActive: {
+    backgroundColor: theme.colors.primaryLight,
+    borderColor: theme.colors.primary,
+  },
+  chipText: {
+    fontSize: theme.typography.label,
+    fontWeight: '800',
+    color: theme.colors.textSecondary,
+  },
+  chipTextActive: {
+    color: theme.colors.primary,
+  },
+  yearRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: theme.spacing.sm,
+    marginBottom: theme.spacing.lg,
+  },
+  yearButton: {
+    width: 44,
+    height: 44,
+    borderRadius: theme.radius.full,
+    backgroundColor: theme.colors.surface,
+    borderWidth: 1,
+    borderColor: theme.colors.border,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  yearPill: {
+    flex: 1,
+    minHeight: 48,
+    borderRadius: theme.radius.full,
+    backgroundColor: theme.colors.surface,
+    alignItems: 'center',
+    justifyContent: 'center',
+    ...theme.shadows.sm,
+  },
+  yearText: {
+    fontSize: theme.typography.subtitle,
+    fontWeight: '800',
+    color: theme.colors.text,
+  },
+  heroCard: {
+    backgroundColor: theme.colors.surface,
+    borderRadius: theme.radius.xl,
+    padding: theme.spacing.lg,
+    gap: theme.spacing.lg,
+    marginBottom: theme.spacing.xl,
+    ...theme.shadows.sm,
+  },
+  heroTop: {
+    gap: theme.spacing.xs,
+  },
+  heroLabel: {
+    fontSize: theme.typography.caption,
+    fontWeight: '800',
+    color: theme.colors.textTertiary,
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+  },
+  heroTitle: {
+    fontSize: theme.typography.heading,
+    fontWeight: '800',
+    color: theme.colors.text,
+  },
+  heroAddress: {
+    fontSize: theme.typography.label,
+    color: theme.colors.textSecondary,
+    lineHeight: 20,
+  },
+  metricGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: theme.spacing.base,
+  },
+  metricCard: {
+    flexGrow: 1,
+    flexBasis: '45%',
+    borderRadius: theme.radius.lg,
+    backgroundColor: theme.colors.background,
+    padding: theme.spacing.base,
+    gap: theme.spacing.xs,
+  },
+  metricLabel: {
+    fontSize: theme.typography.caption,
+    fontWeight: '800',
+    color: theme.colors.textTertiary,
+    textTransform: 'uppercase',
+  },
+  metricValue: {
+    fontSize: theme.typography.heading,
+    fontWeight: '800',
+    color: theme.colors.text,
+  },
+  metricHelp: {
+    fontSize: theme.typography.caption,
+    color: theme.colors.textSecondary,
+    lineHeight: 18,
+  },
+  actionRow: {
+    flexDirection: 'row',
+    gap: theme.spacing.sm,
+  },
+  actionButton: {
+    flex: 1,
+  },
+  notice: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: theme.spacing.sm,
+    borderRadius: theme.radius.lg,
+    padding: theme.spacing.base,
+    borderWidth: 1,
+    marginBottom: theme.spacing.lg,
+  },
+  noticeText: {
+    flex: 1,
+    fontSize: theme.typography.label,
+    fontWeight: '700',
+    lineHeight: 20,
+  },
+  section: {
+    marginBottom: theme.spacing.xl,
+  },
+  sectionHeader: {
+    marginBottom: theme.spacing.base,
+    gap: theme.spacing.xs,
+  },
+  sectionTitle: {
+    fontSize: theme.typography.subtitle,
+    fontWeight: '800',
+    color: theme.colors.text,
+  },
+  sectionSubtitle: {
+    fontSize: theme.typography.label,
+    color: theme.colors.textSecondary,
+    lineHeight: 20,
+  },
+  list: {
+    gap: theme.spacing.base,
+  },
+  card: {
+    backgroundColor: theme.colors.surface,
+    borderRadius: theme.radius.lg,
+    padding: theme.spacing.base,
+    gap: theme.spacing.base,
+    ...theme.shadows.sm,
+  },
+  lineHeader: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: theme.spacing.base,
+  },
+  lineIcon: {
+    width: 46,
+    height: 46,
+    borderRadius: theme.radius.lg,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+  lineBody: {
+    flex: 1,
+    minWidth: 0,
+    gap: theme.spacing.xs,
+  },
+  lineTitle: {
+    fontSize: theme.typography.body,
+    fontWeight: '800',
+    color: theme.colors.text,
+    lineHeight: 21,
+  },
+  lineMeta: {
+    fontSize: theme.typography.caption,
+    color: theme.colors.textSecondary,
+    lineHeight: 18,
+  },
+  lineAmount: {
+    fontSize: theme.typography.subtitle,
+    fontWeight: '800',
+    color: theme.colors.text,
+    textAlign: 'right',
+  },
+  badgeRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: theme.spacing.sm,
+  },
+  badge: {
+    borderRadius: theme.radius.full,
+    borderWidth: 1,
+    paddingHorizontal: theme.spacing.md,
+    paddingVertical: theme.spacing.xs,
+  },
+  badgeText: {
+    fontSize: theme.typography.caption,
+    fontWeight: '800',
+  },
+  lineActions: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: theme.spacing.sm,
+    paddingTop: theme.spacing.sm,
+    borderTopWidth: 1,
+    borderTopColor: theme.colors.border,
+  },
+  smallButton: {
+    borderRadius: theme.radius.full,
+    paddingHorizontal: theme.spacing.md,
+    paddingVertical: theme.spacing.sm,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: theme.spacing.xs,
+  },
+  smallButtonText: {
+    fontSize: theme.typography.caption,
+    fontWeight: '800',
+  },
+  occupancyRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: theme.spacing.base,
+  },
+  occupancyMeter: {
+    flex: 1,
+    height: 10,
+    borderRadius: theme.radius.full,
+    backgroundColor: theme.colors.surface2,
+    overflow: 'hidden',
+  },
+  occupancyFill: {
+    height: '100%',
+    borderRadius: theme.radius.full,
+    backgroundColor: theme.colors.primary,
+  },
+  occupancyPercent: {
+    width: 64,
+    textAlign: 'right',
+    fontSize: theme.typography.label,
+    fontWeight: '800',
+    color: theme.colors.text,
+  },
+  warningText: {
+    fontSize: theme.typography.caption,
+    color: theme.colors.warningText,
+    lineHeight: 18,
+    fontWeight: '700',
+  },
+  emptyContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: theme.spacing.xxl,
+    paddingHorizontal: theme.spacing.xl,
+  },
+  emptyIconBox: {
+    width: 92,
+    height: 92,
+    borderRadius: theme.radius.xl,
+    backgroundColor: `${theme.colors.primary}12`,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: theme.spacing.lg,
+  },
+  emptyTitle: {
+    fontSize: theme.typography.heading,
+    fontWeight: '800',
+    color: theme.colors.text,
+    textAlign: 'center',
+  },
+  emptySubtitle: {
+    marginTop: theme.spacing.sm,
+    fontSize: theme.typography.body,
+    color: theme.colors.textSecondary,
+    textAlign: 'center',
+    lineHeight: 24,
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: theme.colors.overlay,
+    justifyContent: 'flex-end',
+  },
+  modalSheet: {
+    maxHeight: '92%',
+    backgroundColor: theme.colors.surface,
+    borderTopLeftRadius: theme.radius.xl,
+    borderTopRightRadius: theme.radius.xl,
+    paddingHorizontal: theme.spacing.lg,
+    paddingTop: theme.spacing.md,
+    paddingBottom: theme.spacing.xl,
+  },
+  modalContent: {
+    gap: theme.spacing.base,
+    paddingBottom: theme.spacing.lg,
+  },
+  modalHandle: {
+    width: 44,
+    height: 4,
+    borderRadius: theme.radius.full,
+    backgroundColor: theme.colors.textMuted,
+    alignSelf: 'center',
+    marginBottom: theme.spacing.base,
+  },
+  modalTitle: {
+    fontSize: theme.typography.heading,
+    fontWeight: '800',
+    color: theme.colors.text,
+  },
+  modalSubtitle: {
+    fontSize: theme.typography.label,
+    color: theme.colors.textSecondary,
+    lineHeight: 20,
+  },
+  formGroup: {
+    gap: theme.spacing.xs,
+  },
+  inputLabel: {
+    fontSize: theme.typography.caption,
+    fontWeight: '800',
+    color: theme.colors.textSecondary,
+    textTransform: 'uppercase',
+    letterSpacing: 0.7,
+  },
+  textInput: {
+    minHeight: 52,
+    borderRadius: theme.radius.lg,
+    borderWidth: 1.5,
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.background,
+    paddingHorizontal: theme.spacing.base,
+    paddingVertical: theme.spacing.sm,
+    fontSize: theme.typography.input,
+    color: theme.colors.text,
+  },
+  notesInput: {
+    minHeight: 96,
+    textAlignVertical: 'top',
+  },
+  optionGrid: {
+    gap: theme.spacing.sm,
+  },
+  optionButton: {
+    borderRadius: theme.radius.lg,
+    borderWidth: 1.5,
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.background,
+    padding: theme.spacing.base,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: theme.spacing.base,
+  },
+  optionButtonActive: {
+    borderColor: theme.colors.primary,
+    backgroundColor: theme.colors.primaryLight,
+  },
+  optionText: {
+    flex: 1,
+    fontSize: theme.typography.label,
+    fontWeight: '800',
+    color: theme.colors.textSecondary,
+  },
+  optionTextActive: {
+    color: theme.colors.primary,
+  },
+  modalActions: {
+    flexDirection: 'row',
+    gap: theme.spacing.sm,
+  },
+  modalAction: {
+    flex: 1,
+  },
+});
+
+export const styles = createStyles();


### PR DESCRIPTION
**Descripción:**
## Objetivo
Añade la primera experiencia frontend del modo fiscal para casero, con acceso desde el área de gestión, selector de vivienda y ejercicio, revisión de resumen anual, ocupación y gastos, y exportación del dossier fiscal en CSV.

## Cambios principales
* Se incorpora la pestaña `Fiscal` en el área de casero y se oculta cuando la vivienda no tiene el módulo de gastos activo.
* Se crea la pantalla fiscal con selector de vivienda y ejercicio, métricas de ingresos/gastos, avisos de revisión y detalle de líneas.
* Se permite clasificar gastos desde la UI con `categoria_fiscal`, `deducible_previsto`, `notas_fiscales` y `prorrateo_fiscal`.
* Se añade la exportación del dossier fiscal en formato CSV preparado para descarga o compartición móvil.
* El backend amplía el resumen fiscal con metadatos privados para prellenar la edición sin perder información existente.
* Se añaden pruebas de navegación y de pantalla fiscal, además de cobertura backend para el contrato fiscal ya existente.

## UI / UX (Solo si aplica)
* La pantalla usa `Theme.ts`, `useAppTheme()` y soft tints para estados de revisión, pendiente y listo.
* Se mantiene el lenguaje visual de Roomies con tarjetas suaves, bordes amplios y jerarquía clara para una vista contable menos pesada.

## Changelog
* `docs/changelog/EpicaFiscal/epica-fiscal-issue-328-modo-fiscal-casero.md`