### PR TITLE
[Épica Fiscal] Blindar privacidad y trazabilidad fiscal

### DIFF
--- a/backend/src/routes/fiscal.routes.ts
+++ b/backend/src/routes/fiscal.routes.ts
@@ -5,11 +5,13 @@ import {
   obtenerResumenFiscalVivienda,
 } from '../controllers/fiscal.controller';
 import { verificarToken } from '../middlewares/auth.middleware';
+import { protegerModuloVivienda } from '../middlewares/module.guard';
 
 const router = express.Router();
+const gastosActivos = protegerModuloVivienda('gastos');
 
-router.get('/:viviendaId/fiscal/ocupacion', verificarToken, obtenerOcupacionFiscalVivienda);
-router.get('/:viviendaId/fiscal/:ejercicio/dossier', verificarToken, exportarDossierFiscalVivienda);
-router.get('/:viviendaId/fiscal/:ejercicio', verificarToken, obtenerResumenFiscalVivienda);
+router.get('/:viviendaId/fiscal/ocupacion', verificarToken, gastosActivos, obtenerOcupacionFiscalVivienda);
+router.get('/:viviendaId/fiscal/:ejercicio/dossier', verificarToken, gastosActivos, exportarDossierFiscalVivienda);
+router.get('/:viviendaId/fiscal/:ejercicio', verificarToken, gastosActivos, obtenerResumenFiscalVivienda);
 
 export default router;

--- a/backend/src/services/fiscal.service.ts
+++ b/backend/src/services/fiscal.service.ts
@@ -12,7 +12,6 @@ type InquilinoFiscal = {
   id: number;
   nombre: string;
   apellidos: string | null;
-  documento_identidad?: string | null;
 };
 
 type HabitacionFiscal = {
@@ -276,7 +275,6 @@ const COLUMNAS_DOSSIER_DETALLE = [
   'Habitacion',
   'Inquilino ID',
   'Inquilino',
-  'Documento inquilino',
   'Advertencias',
 ] as const;
 
@@ -407,7 +405,6 @@ const generarCsvDossierFiscal = (resumen: FiscalResumenAnualVivienda) => {
     linea.habitacion?.nombre ?? '',
     linea.inquilino?.id ?? '',
     nombreCompleto(linea.inquilino),
-    linea.inquilino?.documento_identidad ?? '',
     serializarAdvertencias(linea.advertencias),
   ]);
 
@@ -819,7 +816,6 @@ export const obtenerFotoOcupacionFiscalVivienda = async (
               id: true,
               nombre: true,
               apellidos: true,
-              documento_identidad: true,
             },
           },
         },
@@ -867,7 +863,6 @@ export const obtenerFotoOcupacionFiscalVivienda = async (
           id: true,
           nombre: true,
           apellidos: true,
-          documento_identidad: true,
         },
       },
     },
@@ -895,7 +890,6 @@ export const obtenerResumenFiscalAnualVivienda = async (
           id: true,
           nombre: true,
           apellidos: true,
-          documento_identidad: true,
         },
       },
     },
@@ -939,7 +933,6 @@ export const obtenerResumenFiscalAnualVivienda = async (
             id: true,
             nombre: true,
             apellidos: true,
-            documento_identidad: true,
           },
         },
         gasto: {
@@ -968,7 +961,6 @@ export const obtenerResumenFiscalAnualVivienda = async (
                 id: true,
                 nombre: true,
                 apellidos: true,
-                documento_identidad: true,
               },
             },
           },

--- a/backend/tests/fiscal.controller.test.ts
+++ b/backend/tests/fiscal.controller.test.ts
@@ -14,7 +14,11 @@ const fiscalService = vi.hoisted(() => ({
 
 vi.mock('../src/services/fiscal.service', () => fiscalService);
 
-const { exportarDossierFiscalVivienda, obtenerResumenFiscalVivienda } = await import('../src/controllers/fiscal.controller');
+const {
+  exportarDossierFiscalVivienda,
+  obtenerOcupacionFiscalVivienda,
+  obtenerResumenFiscalVivienda,
+} = await import('../src/controllers/fiscal.controller');
 
 function request({
   usuario,
@@ -67,6 +71,7 @@ async function invoke(handler: Handler, req: express.Request) {
 
 beforeEach(() => {
   fiscalService.obtenerResumenFiscalAnualVivienda.mockReset();
+  fiscalService.obtenerFotoOcupacionFiscalVivienda.mockReset();
   fiscalService.obtenerDossierFiscalVivienda.mockReset();
   fiscalService.generarBufferCsvExcel.mockClear();
 });
@@ -84,6 +89,35 @@ describe('fiscal.controller', () => {
     assert.equal(res.statusCode, 403);
     assert.deepEqual(res.body, { error: 'Solo el casero propietario puede consultar el resumen fiscal.' });
     assert.equal(fiscalService.obtenerResumenFiscalAnualVivienda.mock.calls.length, 0);
+  });
+
+  test('rechaza ocupacion fiscal para inquilinos', async () => {
+    const res = await invoke(
+      obtenerOcupacionFiscalVivienda,
+      request({
+        usuario: { id: 12, rol: 'INQUILINO' },
+        params: { viviendaId: '1' },
+        query: { ejercicio: '2026' },
+      }),
+    );
+
+    assert.equal(res.statusCode, 403);
+    assert.deepEqual(res.body, { error: 'Solo el casero puede consultar la ocupacion fiscal.' });
+    assert.equal(fiscalService.obtenerFotoOcupacionFiscalVivienda.mock.calls.length, 0);
+  });
+
+  test('rechaza exportar dossier fiscal para inquilinos', async () => {
+    const res = await invoke(
+      exportarDossierFiscalVivienda,
+      request({
+        usuario: { id: 12, rol: 'INQUILINO' },
+        params: { viviendaId: '1', ejercicio: '2026' },
+      }),
+    );
+
+    assert.equal(res.statusCode, 403);
+    assert.deepEqual(res.body, { error: 'Solo el casero propietario puede exportar el dossier fiscal.' });
+    assert.equal(fiscalService.obtenerDossierFiscalVivienda.mock.calls.length, 0);
   });
 
   test('devuelve 404 cuando la vivienda no pertenece al casero', async () => {

--- a/backend/tests/fiscal.service.test.ts
+++ b/backend/tests/fiscal.service.test.ts
@@ -340,12 +340,14 @@ describe('fiscal.service', () => {
     assert.equal(dossier.mimeType, 'text/csv');
     assert.deepEqual(dossier.columnas.resumen, ['Clave', 'Valor', 'Moneda', 'Notas']);
     assert.ok(dossier.columnas.detalle.includes('Advertencias'));
+    assert.ok(!dossier.columnas.detalle.includes('Documento inquilino'));
     assert.match(dossier.contenido, /# RESUMEN/);
     assert.match(dossier.contenido, /# DETALLE/);
     assert.match(dossier.contenido, /"revision\.lineas_problematicas";"2";"";""/);
     assert.match(dossier.contenido, /"deuda-7";"INGRESO";"Deuda";"101";"7"/);
     assert.match(dossier.contenido, /IMPORTE_PENDIENTE/);
     assert.match(dossier.contenido, /"'=Formula peligrosa"/);
+    assert.doesNotMatch(dossier.contenido, /11111111A|22222222B|99999999Z/);
     assert.equal(generarBufferCsvExcel(dossier.contenido).subarray(0, 2).toString('hex'), 'fffe');
   });
 });

--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -1539,7 +1539,8 @@ Descarga un dossier fiscal anual en CSV compatible con Excel para revisar o envi
 
 **Contenido del CSV:**
 - Seccion `RESUMEN`, con columnas estables: `Clave`, `Valor`, `Moneda`, `Notas`.
-- Seccion `DETALLE`, con columnas estables: `Linea ID`, `Naturaleza`, `Modelo origen`, `Gasto ID`, `Deuda ID`, `Concepto`, `Categoria`, `Deducibilidad`, `Importe`, `Moneda`, `Fecha`, `Periodo facturacion`, `Estado pago`, `Factura URL`, `Justificante URL`, `Habitacion ID`, `Habitacion`, `Inquilino ID`, `Inquilino`, `Documento inquilino`, `Advertencias`.
+- Seccion `DETALLE`, con columnas estables: `Linea ID`, `Naturaleza`, `Modelo origen`, `Gasto ID`, `Deuda ID`, `Concepto`, `Categoria`, `Deducibilidad`, `Importe`, `Moneda`, `Fecha`, `Periodo facturacion`, `Estado pago`, `Factura URL`, `Justificante URL`, `Habitacion ID`, `Habitacion`, `Inquilino ID`, `Inquilino`, `Advertencias`.
+- El CSV minimiza datos personales de inquilinos: conserva referencia interna y nombre para trazabilidad de cobros, pero no exporta `documento_identidad`, email ni telefono.
 - Las lineas con importes pendientes, facturas ausentes, categorias fiscales pendientes, periodos incompletos o prorrateos manuales quedan marcadas en la columna `Advertencias`.
 - Las referencias documentales se incluyen como URL (`factura_url` y `justificante_url`) sin duplicar archivos pesados.
 

--- a/docs/changelog/EpicaFiscal/epica-fiscal-issue-329-privacidad-trazabilidad.md
+++ b/docs/changelog/EpicaFiscal/epica-fiscal-issue-329-privacidad-trazabilidad.md
@@ -1,0 +1,27 @@
+# Epica Fiscal - Issue 329 - Privacidad y trazabilidad fiscal
+
+Se refuerza el modo fiscal como cierre transversal de permisos, minimizacion de datos y trazabilidad.
+
+## Cambios principales
+
+- Las rutas fiscales (`resumen anual`, `ocupacion` y `dossier`) pasan por el guard del modulo de gastos antes del controller, por lo que la vivienda debe pertenecer al usuario y tener el modulo activo.
+- Los controllers mantienen el rechazo explicito a `INQUILINO`; el servicio fiscal sigue acotando cada consulta por `vivienda_id` y `casero_id`.
+- El dossier CSV deja de exportar `Documento inquilino` y las consultas fiscales dejan de seleccionar `documento_identidad` de casero o inquilinos. El export conserva solo `Inquilino ID` y nombre como referencia minima para cobros.
+- Se mantienen las referencias `factura_url` y `justificante_url` solo en endpoints de casero propietario; los listados compartidos de inquilino siguen ocultando `categoria_fiscal`, `deducible_previsto`, `notas_fiscales` y `prorrateo_fiscal`.
+- No existen modelos ni endpoints de contratos firmados ni historico explicito de ocupacion en esta rama; el riesgo queda acotado al contrato documental ya existente.
+
+## Matriz de privacidad
+
+| Endpoint / superficie | Rol permitido | Datos expuestos | Tests |
+|---|---|---|---|
+| `GET /api/viviendas/:viviendaId/fiscal/:ejercicio` | `CASERO` propietario con `mod_gastos` activo | Resumen anual, totales, lineas fiscales, metadatos fiscales privados, URLs de factura/justificante | `backend/tests/fiscal.controller.test.ts`, `backend/tests/fiscal.service.test.ts` |
+| `GET /api/viviendas/:viviendaId/fiscal/ocupacion?ejercicio=YYYY` | `CASERO` propietario con `mod_gastos` activo | Ocupacion por vivienda/habitacion, periodos de cargo e inquilino asociado al cargo | `backend/tests/fiscal.controller.test.ts`, `backend/tests/fiscal.service.test.ts` |
+| `GET /api/viviendas/:viviendaId/fiscal/:ejercicio/dossier` | `CASERO` propietario con `mod_gastos` activo | CSV con resumen, detalle, referencias internas, nombre de inquilino, factura y justificante; sin documento/email/telefono de inquilino | `backend/tests/fiscal.controller.test.ts`, `backend/tests/fiscal.service.test.ts` |
+| `GET /api/viviendas/:viviendaId/gastos` como inquilino | Inquilino perteneciente a la vivienda | Gastos/deudas donde participa, sin metadatos fiscales privados | `backend/tests/economico.test.ts` |
+| `GET /api/viviendas/:viviendaId/cobros` | `CASERO` propietario | Cobros de facturacion propia, justificantes y metadatos fiscales para revision del propietario | `backend/tests/economico.test.ts` |
+| Navegacion frontend `casero/(tabs)/fiscal` | Casero con alguna vivienda con `mod_gastos` | UI fiscal de propietario; no existe tab fiscal en layout de inquilino | `frontend/app/__tests__/fiscal.test.tsx`, `frontend/app/__tests__/navigation-smoke.test.tsx` |
+
+## Riesgos conocidos
+
+- Las URLs de Cloudinary siguen siendo referencias directas guardadas en base de datos. La proteccion actual esta en el endpoint que las entrega; si Cloudinary sirve recursos publicos, haria falta una mejora futura de URLs firmadas o acceso proxy para confidencialidad fuerte.
+- Roomies aun no conserva un historico contractual completo de altas/bajas ni contratos firmados versionados. La ocupacion fiscal se reconstruye desde cargos mensuales y marca revision manual cuando faltan datos.


### PR DESCRIPTION
## Objetivo
Blindar el modo fiscal para que solo el casero propietario con el módulo activo pueda acceder a resúmenes, ocupación y exportaciones, y reducir al mínimo los datos personales expuestos en el dossier fiscal.

## Cambios principales
* Añadido el guard del módulo `gastos` a las rutas fiscales para bloquear accesos fuera de la vivienda o con el módulo desactivado.
* Mantenido el rechazo explícito a inquilinos en los endpoints fiscales del backend.
* Eliminado `documento_identidad` del dossier CSV y de las consultas fiscales que no lo necesitaban.
* Conservadas solo referencias mínimas de trazabilidad en el export: `Inquilino ID`, nombre y URLs documentales necesarias.
* Actualizada la documentación de API y añadida una matriz de privacidad con roles permitidos, datos expuestos y tests asociados.

## UI / UX (Solo si aplica)
* No aplica.

## Testing
* Se añadieron tests de controller para rechazar ocupación y dossier fiscal a inquilinos.
* Se añadió cobertura de service para verificar que el CSV no incluye `Documento inquilino` ni documentos personales.
* Verificación completa del backend con la suite de Vitest: `121` tests superados.

## Changelog
* `docs/changelog/EpicaFiscal/epica-fiscal-issue-329-privacidad-trazabilidad.md`