### PR TITLE
[Épica 18] Añade contratos de alquiler con firma interna y trazabilidad

### DIFF
--- a/backend/prisma/migrations/20260506112000_add_contratos_alquiler/migration.sql
+++ b/backend/prisma/migrations/20260506112000_add_contratos_alquiler/migration.sql
@@ -1,0 +1,92 @@
+CREATE TYPE "EstadoContratoAlquiler" AS ENUM (
+  'BORRADOR',
+  'PENDIENTE_FIRMA',
+  'FIRMADO',
+  'RECHAZADO',
+  'ANULADO'
+);
+
+CREATE TYPE "TipoEventoContratoAlquiler" AS ENUM (
+  'CREADO',
+  'ENVIADO_FIRMA',
+  'FIRMADO',
+  'RECHAZADO',
+  'ANULADO'
+);
+
+CREATE TABLE "ContratoAlquiler" (
+  "id" SERIAL NOT NULL,
+  "vivienda_id" INTEGER NOT NULL,
+  "habitacion_id" INTEGER,
+  "casero_id" INTEGER NOT NULL,
+  "inquilino_id" INTEGER NOT NULL,
+  "version" INTEGER NOT NULL,
+  "estado" "EstadoContratoAlquiler" NOT NULL DEFAULT 'BORRADOR',
+  "documento_url" TEXT NOT NULL,
+  "documento_nombre" TEXT,
+  "documento_mime" TEXT,
+  "documento_hash" TEXT NOT NULL,
+  "renta_mensual" DOUBLE PRECISION NOT NULL,
+  "fecha_inicio" TIMESTAMP(3) NOT NULL,
+  "fecha_fin" TIMESTAMP(3),
+  "notas" TEXT,
+  "enviado_en" TIMESTAMP(3),
+  "firmado_en" TIMESTAMP(3),
+  "rechazado_en" TIMESTAMP(3),
+  "anulado_en" TIMESTAMP(3),
+  "firma_usuario_id" INTEGER,
+  "firma_documento_identidad" TEXT,
+  "firma_origen_tecnico" TEXT,
+  "fecha_creacion" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "fecha_actualizacion" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "ContratoAlquiler_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "EventoContratoAlquiler" (
+  "id" SERIAL NOT NULL,
+  "contrato_id" INTEGER NOT NULL,
+  "usuario_id" INTEGER NOT NULL,
+  "tipo" "TipoEventoContratoAlquiler" NOT NULL,
+  "estado_desde" "EstadoContratoAlquiler",
+  "estado_hasta" "EstadoContratoAlquiler",
+  "origen_tecnico" TEXT,
+  "metadata" JSONB,
+  "fecha" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "EventoContratoAlquiler_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "ContratoAlquiler_vivienda_id_estado_idx" ON "ContratoAlquiler"("vivienda_id", "estado");
+CREATE INDEX "ContratoAlquiler_inquilino_id_estado_idx" ON "ContratoAlquiler"("inquilino_id", "estado");
+CREATE UNIQUE INDEX "ContratoAlquiler_vivienda_id_habitacion_id_inquilino_id_version_key"
+  ON "ContratoAlquiler"("vivienda_id", "habitacion_id", "inquilino_id", "version");
+CREATE INDEX "EventoContratoAlquiler_contrato_id_fecha_idx" ON "EventoContratoAlquiler"("contrato_id", "fecha");
+
+ALTER TABLE "ContratoAlquiler"
+  ADD CONSTRAINT "ContratoAlquiler_vivienda_id_fkey"
+  FOREIGN KEY ("vivienda_id") REFERENCES "Vivienda"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "ContratoAlquiler"
+  ADD CONSTRAINT "ContratoAlquiler_habitacion_id_fkey"
+  FOREIGN KEY ("habitacion_id") REFERENCES "Habitacion"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "ContratoAlquiler"
+  ADD CONSTRAINT "ContratoAlquiler_casero_id_fkey"
+  FOREIGN KEY ("casero_id") REFERENCES "Usuario"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "ContratoAlquiler"
+  ADD CONSTRAINT "ContratoAlquiler_inquilino_id_fkey"
+  FOREIGN KEY ("inquilino_id") REFERENCES "Usuario"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "ContratoAlquiler"
+  ADD CONSTRAINT "ContratoAlquiler_firma_usuario_id_fkey"
+  FOREIGN KEY ("firma_usuario_id") REFERENCES "Usuario"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "EventoContratoAlquiler"
+  ADD CONSTRAINT "EventoContratoAlquiler_contrato_id_fkey"
+  FOREIGN KEY ("contrato_id") REFERENCES "ContratoAlquiler"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "EventoContratoAlquiler"
+  ADD CONSTRAINT "EventoContratoAlquiler_usuario_id_fkey"
+  FOREIGN KEY ("usuario_id") REFERENCES "Usuario"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -78,6 +78,22 @@ enum EstadoItem {
   ROTO
 }
 
+enum EstadoContratoAlquiler {
+  BORRADOR
+  PENDIENTE_FIRMA
+  FIRMADO
+  RECHAZADO
+  ANULADO
+}
+
+enum TipoEventoContratoAlquiler {
+  CREADO
+  ENVIADO_FIRMA
+  FIRMADO
+  RECHAZADO
+  ANULADO
+}
+
 model Usuario {
   id                 Int                      @id @default(autoincrement())
   nombre             String
@@ -105,6 +121,10 @@ model Usuario {
   deudas_a_pagar     Deuda[]                  @relation("DeudorDeuda")
   deudas_a_cobrar    Deuda[]                  @relation("AcreedorDeuda")
   items_inventario_validados ItemInventario[] @relation("ValidadorInventario")
+  contratos_casero   ContratoAlquiler[]       @relation("CaseroContrato")
+  contratos_inquilino ContratoAlquiler[]      @relation("InquilinoContrato")
+  contratos_firmados ContratoAlquiler[]       @relation("FirmanteContrato")
+  eventos_contrato   EventoContratoAlquiler[]
 }
 
 model Vivienda {
@@ -126,6 +146,7 @@ model Vivienda {
   gastos           Gasto[]
   gastos_recurrentes GastoRecurrente[]
   items_inventario ItemInventario[]
+  contratos_alquiler ContratoAlquiler[]
 }
 
 model Habitacion {
@@ -143,6 +164,7 @@ model Habitacion {
   incidencias       Incidencia[]
   items_inventario  ItemInventario[]
   cargos_alquiler   Gasto[]          @relation("CargoHabitacion")
+  contratos_alquiler ContratoAlquiler[]
   zonas_limpieza_objetivo ZonaLimpieza[] @relation("ZonaLimpiezaObjetivoHabitacion")
   asignaciones_limpieza_fijas AsignacionLimpiezaFija[] @relation("AsignacionLimpiezaFijaHabitacion")
   turnos_limpieza_responsable TurnoLimpieza[] @relation("TurnoLimpiezaHabitacionResponsable")
@@ -255,6 +277,59 @@ model FotoAsset {
   item_id      Int
   item         ItemInventario @relation(fields: [item_id], references: [id], onDelete: Cascade)
   fecha_subida DateTime       @default(now())
+}
+
+model ContratoAlquiler {
+  id                        Int                    @id @default(autoincrement())
+  vivienda_id               Int
+  vivienda                  Vivienda               @relation(fields: [vivienda_id], references: [id], onDelete: Cascade)
+  habitacion_id             Int?
+  habitacion                Habitacion?            @relation(fields: [habitacion_id], references: [id], onDelete: SetNull)
+  casero_id                 Int
+  casero                    Usuario                @relation("CaseroContrato", fields: [casero_id], references: [id])
+  inquilino_id              Int
+  inquilino                 Usuario                @relation("InquilinoContrato", fields: [inquilino_id], references: [id])
+  version                   Int
+  estado                    EstadoContratoAlquiler @default(BORRADOR)
+  documento_url             String
+  documento_nombre          String?
+  documento_mime            String?
+  documento_hash            String
+  renta_mensual             Float
+  fecha_inicio              DateTime
+  fecha_fin                 DateTime?
+  notas                     String?
+  enviado_en                DateTime?
+  firmado_en                DateTime?
+  rechazado_en              DateTime?
+  anulado_en                DateTime?
+  firma_usuario_id          Int?
+  firma_usuario             Usuario?               @relation("FirmanteContrato", fields: [firma_usuario_id], references: [id], onDelete: SetNull)
+  firma_documento_identidad String?
+  firma_origen_tecnico      String?
+  fecha_creacion            DateTime               @default(now())
+  fecha_actualizacion       DateTime               @updatedAt
+  eventos                   EventoContratoAlquiler[]
+
+  @@index([vivienda_id, estado])
+  @@index([inquilino_id, estado])
+  @@unique([vivienda_id, habitacion_id, inquilino_id, version])
+}
+
+model EventoContratoAlquiler {
+  id             Int                         @id @default(autoincrement())
+  contrato_id    Int
+  contrato       ContratoAlquiler            @relation(fields: [contrato_id], references: [id], onDelete: Cascade)
+  usuario_id     Int
+  usuario        Usuario                     @relation(fields: [usuario_id], references: [id])
+  tipo           TipoEventoContratoAlquiler
+  estado_desde   EstadoContratoAlquiler?
+  estado_hasta   EstadoContratoAlquiler?
+  origen_tecnico String?
+  metadata       Json?
+  fecha          DateTime                    @default(now())
+
+  @@index([contrato_id, fecha])
 }
 
 // ── Módulo de limpieza ────────────────────────────────────────────────────────

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -13,6 +13,7 @@ import deudaRoutes from './routes/deuda.routes';
 import userRoutes from './routes/user.routes';
 import inventarioRoutes from './routes/inventario.routes';
 import fiscalRoutes from './routes/fiscal.routes';
+import contratoRoutes from './routes/contrato.routes';
 
 const app = express();
 
@@ -32,6 +33,7 @@ app.use('/api/viviendas', limpiezaRoutes);
 app.use('/api/viviendas', gastoRoutes);
 app.use('/api/viviendas', gastoRecurrenteRoutes);
 app.use('/api/viviendas', fiscalRoutes);
+app.use('/api/viviendas', contratoRoutes);
 app.use('/api', deudaRoutes);
 app.use('/api', inventarioRoutes);
 app.use('/api/usuarios', userRoutes);

--- a/backend/src/config/cloudinary.config.ts
+++ b/backend/src/config/cloudinary.config.ts
@@ -74,5 +74,6 @@ export const uploadInventarioFoto = crearUploaderImagen('roomies-inventario');
 export const uploadJustificanteFoto = crearUploaderImagen('roomies-justificantes');
 export const uploadFacturaGasto = crearUploaderDocumento('roomies-facturas');
 export const uploadFacturaFoto = crearUploaderImagen('roomies-facturas');
+export const uploadContratoAlquiler = crearUploaderDocumento('roomies-contratos');
 
 export { cloudinary };

--- a/backend/src/controllers/contrato.controller.ts
+++ b/backend/src/controllers/contrato.controller.ts
@@ -1,0 +1,487 @@
+import crypto from 'node:crypto';
+import express from 'express';
+import { RolUsuario } from '../generated/prisma/client';
+import { prisma } from '../lib/prisma';
+
+const ESTADOS_CONTRATO = {
+  BORRADOR: 'BORRADOR',
+  PENDIENTE_FIRMA: 'PENDIENTE_FIRMA',
+  FIRMADO: 'FIRMADO',
+  RECHAZADO: 'RECHAZADO',
+  ANULADO: 'ANULADO',
+} as const;
+
+const EVENTOS_CONTRATO = {
+  CREADO: 'CREADO',
+  ENVIADO_FIRMA: 'ENVIADO_FIRMA',
+  FIRMADO: 'FIRMADO',
+  RECHAZADO: 'RECHAZADO',
+  ANULADO: 'ANULADO',
+} as const;
+
+const db = prisma as typeof prisma & {
+  contratoAlquiler: any;
+  eventoContratoAlquiler: any;
+};
+
+const obtenerParamNumerico = (valor: string | string[] | undefined) => {
+  const normalizado = Array.isArray(valor) ? valor[0] : valor;
+  if (!normalizado) return NaN;
+  return parseInt(normalizado, 10);
+};
+
+const normalizarNumero = (valor: unknown) => {
+  if (typeof valor === 'number') return valor;
+  if (typeof valor === 'string') return parseFloat(valor.replace(',', '.'));
+  return NaN;
+};
+
+const normalizarFecha = (valor: unknown) => {
+  if (typeof valor !== 'string' || !valor.trim()) return null;
+  const fecha = new Date(valor);
+  return Number.isNaN(fecha.getTime()) ? null : fecha;
+};
+
+const normalizarBooleano = (valor: unknown, defecto: boolean) => {
+  if (valor === undefined || valor === null || valor === '') return defecto;
+  if (typeof valor === 'boolean') return valor;
+  if (typeof valor === 'string') {
+    const normalizado = valor.trim().toLowerCase();
+    if (['true', '1', 'si', 's'].includes(normalizado)) return true;
+    if (['false', '0', 'no', 'n'].includes(normalizado)) return false;
+  }
+  return defecto;
+};
+
+const obtenerUrlArchivo = (file: Express.Multer.File | undefined) => {
+  if (!file) return null;
+  const posibleCloudinary = file as Express.Multer.File & { path?: string; secure_url?: string };
+  return posibleCloudinary.path ?? posibleCloudinary.secure_url ?? null;
+};
+
+const calcularHashDocumento = (file: Express.Multer.File) => {
+  const fuente =
+    file.buffer && file.buffer.length > 0
+      ? file.buffer
+      : Buffer.from(
+          [
+            (file as Express.Multer.File & { path?: string }).path ?? '',
+            file.originalname,
+            file.mimetype,
+            file.size,
+          ].join('|'),
+        );
+
+  return crypto.createHash('sha256').update(fuente).digest('hex');
+};
+
+const origenTecnico = (req: express.Request) =>
+  [
+    req.ip ? `ip=${req.ip}` : null,
+    typeof req.headers['user-agent'] === 'string' ? `ua=${req.headers['user-agent'].slice(0, 180)}` : null,
+  ]
+    .filter(Boolean)
+    .join('; ');
+
+const includeContrato = {
+  vivienda: {
+    select: {
+      id: true,
+      alias_nombre: true,
+      direccion: true,
+      ciudad: true,
+      provincia: true,
+    },
+  },
+  habitacion: {
+    select: {
+      id: true,
+      nombre: true,
+      tipo: true,
+    },
+  },
+  casero: {
+    select: {
+      id: true,
+      nombre: true,
+      apellidos: true,
+    },
+  },
+  inquilino: {
+    select: {
+      id: true,
+      nombre: true,
+      apellidos: true,
+      documento_identidad: true,
+    },
+  },
+  eventos: {
+    orderBy: { fecha: 'asc' },
+    select: {
+      id: true,
+      tipo: true,
+      estado_desde: true,
+      estado_hasta: true,
+      fecha: true,
+      usuario: {
+        select: {
+          id: true,
+          nombre: true,
+          apellidos: true,
+        },
+      },
+    },
+  },
+};
+
+const obtenerContratoAccesible = async (contratoId: number, usuarioId: number, rol: RolUsuario) =>
+  db.contratoAlquiler.findFirst({
+    where: {
+      id: contratoId,
+      ...(rol === RolUsuario.CASERO ? { casero_id: usuarioId } : { inquilino_id: usuarioId }),
+    },
+    include: includeContrato,
+  });
+
+const validarViviendaCasero = async (viviendaId: number, caseroId: number) =>
+  prisma.vivienda.findFirst({
+    where: { id: viviendaId, casero_id: caseroId },
+    select: {
+      id: true,
+      habitaciones: {
+        select: {
+          id: true,
+          inquilino_id: true,
+          precio: true,
+          es_habitable: true,
+        },
+      },
+    },
+  });
+
+export const listarContratosVivienda: express.RequestHandler = async (req, res) => {
+  const viviendaId = obtenerParamNumerico(req.params.viviendaId);
+  const usuario = req.usuario!;
+
+  if (!Number.isInteger(viviendaId) || viviendaId <= 0) {
+    res.status(400).json({ error: 'viviendaId invalido.' });
+    return;
+  }
+
+  const vivienda =
+    usuario.rol === RolUsuario.CASERO
+      ? await prisma.vivienda.findFirst({ where: { id: viviendaId, casero_id: usuario.id }, select: { id: true } })
+      : await prisma.habitacion.findFirst({
+          where: { vivienda_id: viviendaId, inquilino_id: usuario.id },
+          select: { id: true },
+        });
+
+  if (!vivienda) {
+    res.status(403).json({ error: 'No tienes acceso a los contratos de esta vivienda.' });
+    return;
+  }
+
+  const contratos = await db.contratoAlquiler.findMany({
+    where: {
+      vivienda_id: viviendaId,
+      ...(usuario.rol === RolUsuario.INQUILINO ? { inquilino_id: usuario.id } : {}),
+    },
+    orderBy: [{ fecha_creacion: 'desc' }, { id: 'desc' }],
+    include: includeContrato,
+  });
+
+  res.status(200).json(contratos);
+};
+
+export const crearContratoAlquiler: express.RequestHandler = async (req, res) => {
+  const viviendaId = obtenerParamNumerico(req.params.viviendaId);
+  const usuario = req.usuario!;
+
+  if (usuario.rol !== RolUsuario.CASERO) {
+    res.status(403).json({ error: 'Solo el casero puede subir contratos de alquiler.' });
+    return;
+  }
+
+  if (!Number.isInteger(viviendaId) || viviendaId <= 0) {
+    res.status(400).json({ error: 'viviendaId invalido.' });
+    return;
+  }
+
+  if (!req.file) {
+    res.status(400).json({ error: 'Debes adjuntar el contrato en PDF o imagen.' });
+    return;
+  }
+
+  const vivienda = await validarViviendaCasero(viviendaId, usuario.id);
+  if (!vivienda) {
+    res.status(403).json({ error: 'No tienes permiso para gestionar contratos de esta vivienda.' });
+    return;
+  }
+
+  const inquilinoId = normalizarNumero(req.body.inquilino_id ?? req.body.inquilinoId);
+  const habitacionIdRaw = req.body.habitacion_id ?? req.body.habitacionId;
+  const habitacionId = habitacionIdRaw == null || habitacionIdRaw === '' ? null : normalizarNumero(habitacionIdRaw);
+  const rentaMensual = normalizarNumero(req.body.renta_mensual ?? req.body.rentaMensual);
+  const fechaInicio = normalizarFecha(req.body.fecha_inicio ?? req.body.fechaInicio);
+  const fechaFinRaw = req.body.fecha_fin ?? req.body.fechaFin;
+  const fechaFin = fechaFinRaw == null || fechaFinRaw === '' ? null : normalizarFecha(fechaFinRaw);
+  const notas = typeof req.body.notas === 'string' && req.body.notas.trim() ? req.body.notas.trim() : null;
+  const enviarAFirma = normalizarBooleano(req.body.enviarAFirma ?? req.body.enviar_a_firma, true);
+
+  if (!Number.isInteger(inquilinoId) || inquilinoId <= 0) {
+    res.status(400).json({ error: 'inquilino_id es obligatorio.' });
+    return;
+  }
+
+  if (habitacionId !== null && (!Number.isInteger(habitacionId) || habitacionId <= 0)) {
+    res.status(400).json({ error: 'habitacion_id invalido.' });
+    return;
+  }
+
+  if (!Number.isFinite(rentaMensual) || rentaMensual <= 0) {
+    res.status(400).json({ error: 'renta_mensual debe ser mayor que 0.' });
+    return;
+  }
+
+  if (!fechaInicio) {
+    res.status(400).json({ error: 'fecha_inicio debe ser una fecha valida.' });
+    return;
+  }
+
+  if (fechaFinRaw && !fechaFin) {
+    res.status(400).json({ error: 'fecha_fin debe ser una fecha valida.' });
+    return;
+  }
+
+  const habitacionContrato =
+    habitacionId === null
+      ? vivienda.habitaciones.find((habitacion) => habitacion.inquilino_id === inquilinoId)
+      : vivienda.habitaciones.find((habitacion) => habitacion.id === habitacionId);
+
+  if (!habitacionContrato || habitacionContrato.inquilino_id !== inquilinoId) {
+    res.status(400).json({ error: 'El inquilino debe estar asignado a la vivienda o habitacion indicada.' });
+    return;
+  }
+
+  const documentoUrl = obtenerUrlArchivo(req.file);
+  if (!documentoUrl) {
+    res.status(500).json({ error: 'No se pudo obtener la URL del contrato subido.' });
+    return;
+  }
+
+  const estadoInicial = enviarAFirma ? ESTADOS_CONTRATO.PENDIENTE_FIRMA : ESTADOS_CONTRATO.BORRADOR;
+  const ahora = new Date();
+  const versionAnterior = await db.contratoAlquiler.aggregate({
+    where: {
+      vivienda_id: viviendaId,
+      habitacion_id: habitacionContrato.id,
+      inquilino_id: inquilinoId,
+    },
+    _max: { version: true },
+  });
+
+  const contrato = await db.$transaction(async (tx: any) => {
+    const creado = await tx.contratoAlquiler.create({
+      data: {
+        vivienda_id: viviendaId,
+        habitacion_id: habitacionContrato.id,
+        casero_id: usuario.id,
+        inquilino_id: inquilinoId,
+        version: (versionAnterior._max.version ?? 0) + 1,
+        estado: estadoInicial,
+        documento_url: documentoUrl,
+        documento_nombre: req.file?.originalname ?? null,
+        documento_mime: req.file?.mimetype ?? null,
+        documento_hash: calcularHashDocumento(req.file!),
+        renta_mensual: rentaMensual,
+        fecha_inicio: fechaInicio,
+        fecha_fin: fechaFin,
+        notas,
+        enviado_en: enviarAFirma ? ahora : null,
+      },
+    });
+
+    await tx.eventoContratoAlquiler.create({
+      data: {
+        contrato_id: creado.id,
+        usuario_id: usuario.id,
+        tipo: enviarAFirma ? EVENTOS_CONTRATO.ENVIADO_FIRMA : EVENTOS_CONTRATO.CREADO,
+        estado_hasta: estadoInicial,
+        origen_tecnico: origenTecnico(req),
+        metadata: {
+          documento_nombre: req.file?.originalname ?? null,
+          documento_mime: req.file?.mimetype ?? null,
+          documento_hash: creado.documento_hash,
+        },
+      },
+    });
+
+    return tx.contratoAlquiler.findUnique({
+      where: { id: creado.id },
+      include: includeContrato,
+    });
+  });
+
+  res.status(201).json(contrato);
+};
+
+export const firmarContratoAlquiler: express.RequestHandler = async (req, res) => {
+  const contratoId = obtenerParamNumerico(req.params.contratoId);
+  const usuario = req.usuario!;
+
+  if (usuario.rol !== RolUsuario.INQUILINO) {
+    res.status(403).json({ error: 'Solo el inquilino implicado puede firmar el contrato.' });
+    return;
+  }
+
+  if (!Number.isInteger(contratoId) || contratoId <= 0) {
+    res.status(400).json({ error: 'contratoId invalido.' });
+    return;
+  }
+
+  const contrato = await obtenerContratoAccesible(contratoId, usuario.id, usuario.rol);
+  if (!contrato) {
+    res.status(404).json({ error: 'Contrato no encontrado.' });
+    return;
+  }
+
+  if (contrato.estado !== ESTADOS_CONTRATO.PENDIENTE_FIRMA) {
+    res.status(409).json({ error: 'Solo se pueden firmar contratos pendientes de firma.' });
+    return;
+  }
+
+  const ahora = new Date();
+  const origen = origenTecnico(req);
+  const contratoActualizado = await db.$transaction(async (tx: any) => {
+    await tx.eventoContratoAlquiler.create({
+      data: {
+        contrato_id: contrato.id,
+        usuario_id: usuario.id,
+        tipo: EVENTOS_CONTRATO.FIRMADO,
+        estado_desde: contrato.estado,
+        estado_hasta: ESTADOS_CONTRATO.FIRMADO,
+        origen_tecnico: origen,
+        metadata: {
+          documento_hash: contrato.documento_hash,
+          version: contrato.version,
+        },
+      },
+    });
+
+    return tx.contratoAlquiler.update({
+      where: { id: contrato.id },
+      data: {
+        estado: ESTADOS_CONTRATO.FIRMADO,
+        firmado_en: ahora,
+        firma_usuario_id: usuario.id,
+        firma_documento_identidad: contrato.inquilino.documento_identidad ?? null,
+        firma_origen_tecnico: origen,
+      },
+      include: includeContrato,
+    });
+  });
+
+  res.status(200).json(contratoActualizado);
+};
+
+export const rechazarContratoAlquiler: express.RequestHandler = async (req, res) => {
+  const contratoId = obtenerParamNumerico(req.params.contratoId);
+  const usuario = req.usuario!;
+
+  if (usuario.rol !== RolUsuario.INQUILINO) {
+    res.status(403).json({ error: 'Solo el inquilino implicado puede rechazar el contrato.' });
+    return;
+  }
+
+  if (!Number.isInteger(contratoId) || contratoId <= 0) {
+    res.status(400).json({ error: 'contratoId invalido.' });
+    return;
+  }
+
+  const contrato = await obtenerContratoAccesible(contratoId, usuario.id, usuario.rol);
+  if (!contrato) {
+    res.status(404).json({ error: 'Contrato no encontrado.' });
+    return;
+  }
+
+  if (contrato.estado !== ESTADOS_CONTRATO.PENDIENTE_FIRMA) {
+    res.status(409).json({ error: 'Solo se pueden rechazar contratos pendientes de firma.' });
+    return;
+  }
+
+  const motivo = typeof req.body.motivo === 'string' && req.body.motivo.trim() ? req.body.motivo.trim() : null;
+  const contratoActualizado = await db.$transaction(async (tx: any) => {
+    await tx.eventoContratoAlquiler.create({
+      data: {
+        contrato_id: contrato.id,
+        usuario_id: usuario.id,
+        tipo: EVENTOS_CONTRATO.RECHAZADO,
+        estado_desde: contrato.estado,
+        estado_hasta: ESTADOS_CONTRATO.RECHAZADO,
+        origen_tecnico: origenTecnico(req),
+        metadata: { motivo },
+      },
+    });
+
+    return tx.contratoAlquiler.update({
+      where: { id: contrato.id },
+      data: {
+        estado: ESTADOS_CONTRATO.RECHAZADO,
+        rechazado_en: new Date(),
+      },
+      include: includeContrato,
+    });
+  });
+
+  res.status(200).json(contratoActualizado);
+};
+
+export const anularContratoAlquiler: express.RequestHandler = async (req, res) => {
+  const contratoId = obtenerParamNumerico(req.params.contratoId);
+  const usuario = req.usuario!;
+
+  if (usuario.rol !== RolUsuario.CASERO) {
+    res.status(403).json({ error: 'Solo el casero puede anular contratos.' });
+    return;
+  }
+
+  if (!Number.isInteger(contratoId) || contratoId <= 0) {
+    res.status(400).json({ error: 'contratoId invalido.' });
+    return;
+  }
+
+  const contrato = await obtenerContratoAccesible(contratoId, usuario.id, usuario.rol);
+  if (!contrato) {
+    res.status(404).json({ error: 'Contrato no encontrado.' });
+    return;
+  }
+
+  if ([ESTADOS_CONTRATO.FIRMADO, ESTADOS_CONTRATO.ANULADO].includes(contrato.estado)) {
+    res.status(409).json({ error: 'No se puede anular un contrato firmado o ya anulado.' });
+    return;
+  }
+
+  const contratoActualizado = await db.$transaction(async (tx: any) => {
+    await tx.eventoContratoAlquiler.create({
+      data: {
+        contrato_id: contrato.id,
+        usuario_id: usuario.id,
+        tipo: EVENTOS_CONTRATO.ANULADO,
+        estado_desde: contrato.estado,
+        estado_hasta: ESTADOS_CONTRATO.ANULADO,
+        origen_tecnico: origenTecnico(req),
+      },
+    });
+
+    return tx.contratoAlquiler.update({
+      where: { id: contrato.id },
+      data: {
+        estado: ESTADOS_CONTRATO.ANULADO,
+        anulado_en: new Date(),
+      },
+      include: includeContrato,
+    });
+  });
+
+  res.status(200).json(contratoActualizado);
+};

--- a/backend/src/routes/contrato.routes.ts
+++ b/backend/src/routes/contrato.routes.ts
@@ -1,0 +1,28 @@
+import express from 'express';
+import { uploadContratoAlquiler } from '../config/cloudinary.config';
+import {
+  anularContratoAlquiler,
+  crearContratoAlquiler,
+  firmarContratoAlquiler,
+  listarContratosVivienda,
+  rechazarContratoAlquiler,
+} from '../controllers/contrato.controller';
+import { verificarToken } from '../middlewares/auth.middleware';
+import { protegerModuloVivienda } from '../middlewares/module.guard';
+
+const router = express.Router();
+const gastosActivos = protegerModuloVivienda('gastos');
+
+router.get('/:viviendaId/contratos', verificarToken, gastosActivos, listarContratosVivienda);
+router.post(
+  '/:viviendaId/contratos',
+  verificarToken,
+  gastosActivos,
+  uploadContratoAlquiler.single('contrato'),
+  crearContratoAlquiler,
+);
+router.patch('/:viviendaId/contratos/:contratoId/firmar', verificarToken, gastosActivos, firmarContratoAlquiler);
+router.patch('/:viviendaId/contratos/:contratoId/rechazar', verificarToken, gastosActivos, rechazarContratoAlquiler);
+router.patch('/:viviendaId/contratos/:contratoId/anular', verificarToken, gastosActivos, anularContratoAlquiler);
+
+export default router;

--- a/backend/src/services/fiscal.service.ts
+++ b/backend/src/services/fiscal.service.ts
@@ -41,6 +41,19 @@ type GastoFiscal = {
   inquilino_cargo?: InquilinoFiscal | null;
 };
 
+type ContratoFiscal = {
+  id: number;
+  version: number;
+  estado: string;
+  documento_hash: string;
+  renta_mensual: number;
+  fecha_inicio: Date;
+  fecha_fin: Date | null;
+  habitacion_id: number | null;
+  inquilino_id: number;
+  inquilino?: InquilinoFiscal | null;
+};
+
 export type FiscalEstadoOcupacion = 'SIN_ACTIVIDAD' | 'PARCIAL' | 'TODO_EL_ANO';
 
 export type FiscalRevision = {
@@ -53,7 +66,11 @@ export type FiscalPeriodoOcupacion = {
   fin: string;
   dias: number;
   periodo_facturacion: string;
-  gasto_id: number;
+  gasto_id?: number;
+  contrato_id?: number;
+  fuente: 'CARGO_ALQUILER' | 'CONTRATO_FIRMADO';
+  contrato_version?: number;
+  documento_hash?: string;
   inquilino: InquilinoFiscal | null;
   importe: number;
 };
@@ -126,6 +143,7 @@ type ConstruirFotoInput = {
     habitaciones: HabitacionFiscal[];
   };
   gastos: GastoFiscal[];
+  contratos?: ContratoFiscal[];
 };
 
 type CaseroFiscal = {
@@ -505,6 +523,7 @@ export const construirFotoOcupacionFiscal = ({
   ejercicio,
   vivienda,
   gastos,
+  contratos = [],
 }: ConstruirFotoInput): FiscalFotoOcupacionVivienda => {
   const inicioEjercicio = new Date(Date.UTC(ejercicio, 0, 1));
   const finEjercicio = new Date(Date.UTC(ejercicio + 1, 0, 1));
@@ -515,9 +534,13 @@ export const construirFotoOcupacionFiscal = ({
   const habitaciones = vivienda.habitaciones.map((habitacion) => {
     const revisiones: FiscalRevision[] = [];
     const cargosHabitacion = cargosAlquiler.filter((gasto) => gasto.habitacion_cargo_id === habitacion.id);
+    const contratosHabitacion = contratos.filter(
+      (contrato) => contrato.estado === 'FIRMADO' && contrato.habitacion_id === habitacion.id,
+    );
+    const usarContratosFirmados = contratosHabitacion.length > 0;
     const periodos: FiscalPeriodoOcupacion[] = [];
 
-    for (const cargo of cargosHabitacion) {
+    for (const cargo of usarContratosFirmados ? [] : cargosHabitacion) {
       if (!cargo.periodo_facturacion) {
         const revision = {
           codigo: 'SIN_PERIODO_FACTURACION' as const,
@@ -548,8 +571,28 @@ export const construirFotoOcupacionFiscal = ({
         dias: diasEntre(recortado.inicio, recortado.fin),
         periodo_facturacion: cargo.periodo_facturacion,
         gasto_id: cargo.id,
+        fuente: 'CARGO_ALQUILER',
         inquilino: cargo.inquilino_cargo ?? null,
         importe: normalizarImporteMonetario(cargo.importe),
+      });
+    }
+
+    for (const contrato of contratosHabitacion) {
+      const finContrato = contrato.fecha_fin ?? finEjercicio;
+      const recortado = recortarPeriodo(contrato.fecha_inicio, finContrato, inicioEjercicio, finEjercicio);
+      if (!recortado) continue;
+
+      periodos.push({
+        inicio: isoFecha(recortado.inicio),
+        fin: isoFecha(recortado.fin),
+        dias: diasEntre(recortado.inicio, recortado.fin),
+        periodo_facturacion: `${isoFecha(recortado.inicio)}..${isoFecha(recortado.fin)}`,
+        contrato_id: contrato.id,
+        contrato_version: contrato.version,
+        documento_hash: contrato.documento_hash,
+        fuente: 'CONTRATO_FIRMADO',
+        inquilino: contrato.inquilino ?? null,
+        importe: normalizarImporteMonetario(contrato.renta_mensual),
       });
     }
 
@@ -827,48 +870,77 @@ export const obtenerFotoOcupacionFiscalVivienda = async (
 
   const inicioEjercicio = new Date(Date.UTC(ejercicio, 0, 1));
   const finEjercicio = new Date(Date.UTC(ejercicio + 1, 0, 1));
-  const gastos = await prisma.gasto.findMany({
-    where: {
-      vivienda_id: viviendaId,
-      OR: [
-        {
-          tipo: 'ALQUILER_HABITACION',
-          periodo_facturacion: {
-            gte: `${ejercicio}-01`,
-            lte: `${ejercicio}-12`,
+  const [gastos, contratos] = await Promise.all([
+    prisma.gasto.findMany({
+      where: {
+        vivienda_id: viviendaId,
+        OR: [
+          {
+            tipo: 'ALQUILER_HABITACION',
+            periodo_facturacion: {
+              gte: `${ejercicio}-01`,
+              lte: `${ejercicio}-12`,
+            },
           },
-        },
-        {
-          tipo: { not: 'ENTRE_COMPANEROS' },
-          fecha_creacion: {
-            gte: inicioEjercicio,
-            lt: finEjercicio,
+          {
+            tipo: { not: 'ENTRE_COMPANEROS' },
+            fecha_creacion: {
+              gte: inicioEjercicio,
+              lt: finEjercicio,
+            },
           },
-        },
-      ],
-    },
-    orderBy: [{ fecha_creacion: 'asc' }, { id: 'asc' }],
-    select: {
-      id: true,
-      concepto: true,
-      importe: true,
-      tipo: true,
-      fecha_creacion: true,
-      periodo_facturacion: true,
-      habitacion_cargo_id: true,
-      inquilino_cargo_id: true,
-      prorrateo_fiscal: true,
-      inquilino_cargo: {
-        select: {
-          id: true,
-          nombre: true,
-          apellidos: true,
+        ],
+      },
+      orderBy: [{ fecha_creacion: 'asc' }, { id: 'asc' }],
+      select: {
+        id: true,
+        concepto: true,
+        importe: true,
+        tipo: true,
+        fecha_creacion: true,
+        periodo_facturacion: true,
+        habitacion_cargo_id: true,
+        inquilino_cargo_id: true,
+        prorrateo_fiscal: true,
+        inquilino_cargo: {
+          select: {
+            id: true,
+            nombre: true,
+            apellidos: true,
+          },
         },
       },
-    },
-  });
+    }),
+    (prisma as typeof prisma & { contratoAlquiler: any }).contratoAlquiler.findMany({
+      where: {
+        vivienda_id: viviendaId,
+        estado: 'FIRMADO',
+        fecha_inicio: { lt: finEjercicio },
+        OR: [{ fecha_fin: null }, { fecha_fin: { gt: inicioEjercicio } }],
+      },
+      orderBy: [{ fecha_inicio: 'asc' }, { id: 'asc' }],
+      select: {
+        id: true,
+        version: true,
+        estado: true,
+        documento_hash: true,
+        renta_mensual: true,
+        fecha_inicio: true,
+        fecha_fin: true,
+        habitacion_id: true,
+        inquilino_id: true,
+        inquilino: {
+          select: {
+            id: true,
+            nombre: true,
+            apellidos: true,
+          },
+        },
+      },
+    }),
+  ]);
 
-  return construirFotoOcupacionFiscal({ ejercicio, vivienda, gastos });
+  return construirFotoOcupacionFiscal({ ejercicio, vivienda, gastos, contratos });
 };
 
 export const obtenerResumenFiscalAnualVivienda = async (

--- a/backend/tests/contrato-issue-337.test.ts
+++ b/backend/tests/contrato-issue-337.test.ts
@@ -1,0 +1,190 @@
+import assert from 'node:assert/strict';
+import type express from 'express';
+import { beforeEach, describe, test, vi } from 'vitest';
+
+type UsuarioTest = { id: number; rol: 'CASERO' | 'INQUILINO' };
+
+const prisma = vi.hoisted(() => ({
+  vivienda: {
+    findFirst: async (_args: unknown): Promise<unknown> => null,
+  },
+  habitacion: {
+    findFirst: async (_args: unknown): Promise<unknown> => null,
+  },
+  contratoAlquiler: {
+    aggregate: async (_args: unknown): Promise<unknown> => ({ _max: { version: null } }),
+    create: async (_args: unknown): Promise<unknown> => ({}),
+    findFirst: async (_args: unknown): Promise<unknown> => null,
+    findMany: async (_args: unknown): Promise<unknown> => [],
+    findUnique: async (_args: unknown): Promise<unknown> => null,
+    update: async (_args: unknown): Promise<unknown> => ({}),
+  },
+  eventoContratoAlquiler: {
+    create: async (_args: unknown): Promise<unknown> => ({}),
+  },
+  $transaction: async (callback: (tx: unknown) => Promise<unknown>) => callback(prisma),
+}));
+
+vi.mock('../src/lib/prisma', () => ({ prisma }));
+
+const {
+  crearContratoAlquiler,
+  firmarContratoAlquiler,
+  listarContratosVivienda,
+} = await import('../src/controllers/contrato.controller');
+
+function resetPrisma() {
+  prisma.vivienda.findFirst = async () => null;
+  prisma.habitacion.findFirst = async () => null;
+  prisma.contratoAlquiler.aggregate = async () => ({ _max: { version: null } });
+  prisma.contratoAlquiler.create = async (args: any) => ({ id: 1, ...args.data });
+  prisma.contratoAlquiler.findFirst = async () => null;
+  prisma.contratoAlquiler.findMany = async () => [];
+  prisma.contratoAlquiler.findUnique = async () => null;
+  prisma.contratoAlquiler.update = async (args: any) => ({ id: args.where.id, ...args.data });
+  prisma.eventoContratoAlquiler.create = async () => ({});
+}
+
+beforeEach(() => {
+  resetPrisma();
+});
+
+function req({
+  usuario,
+  params = {},
+  body = {},
+  file,
+}: {
+  usuario: UsuarioTest;
+  params?: Record<string, string>;
+  body?: Record<string, unknown>;
+  file?: Partial<Express.Multer.File>;
+}) {
+  return {
+    usuario,
+    params,
+    body,
+    file,
+    headers: { 'user-agent': 'vitest' },
+    ip: '127.0.0.1',
+  } as unknown as express.Request;
+}
+
+function res() {
+  const response = {
+    statusCode: 200,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  };
+
+  return response as unknown as express.Response & typeof response;
+}
+
+async function invoke(handler: express.RequestHandler, requestData: express.Request) {
+  const response = res();
+  await handler(requestData, response, () => undefined);
+  return response;
+}
+
+const contratoFile = {
+  originalname: 'contrato.pdf',
+  mimetype: 'application/pdf',
+  size: 18,
+  path: 'https://cdn.test/contrato.pdf',
+  buffer: Buffer.from('contrato version uno'),
+};
+
+describe('issue 337 - contratos de alquiler', () => {
+  test('el casero crea una version pendiente con hash y evento trazable', async () => {
+    let contratoCreate: any;
+    let eventoCreate: any;
+
+    prisma.vivienda.findFirst = async () => ({
+      id: 7,
+      habitaciones: [{ id: 3, inquilino_id: 20, precio: 450, es_habitable: true }],
+    });
+    prisma.contratoAlquiler.aggregate = async () => ({ _max: { version: 2 } });
+    prisma.contratoAlquiler.create = async (args: any) => {
+      contratoCreate = args;
+      return { id: 99, ...args.data };
+    };
+    prisma.eventoContratoAlquiler.create = async (args: any) => {
+      eventoCreate = args;
+      return {};
+    };
+    prisma.contratoAlquiler.findUnique = async (_args: unknown) => ({ id: 99, estado: 'PENDIENTE_FIRMA' });
+
+    const response = await invoke(
+      crearContratoAlquiler,
+      req({
+        usuario: { id: 10, rol: 'CASERO' },
+        params: { viviendaId: '7' },
+        body: {
+          inquilino_id: '20',
+          habitacion_id: '3',
+          renta_mensual: '450',
+          fecha_inicio: '2026-06-01',
+        },
+        file: contratoFile,
+      }),
+    );
+
+    assert.equal(response.statusCode, 201);
+    assert.equal(contratoCreate.data.version, 3);
+    assert.equal(contratoCreate.data.estado, 'PENDIENTE_FIRMA');
+    assert.equal(contratoCreate.data.documento_hash.length, 64);
+    assert.equal(eventoCreate.data.tipo, 'ENVIADO_FIRMA');
+    assert.equal(eventoCreate.data.metadata.documento_hash, contratoCreate.data.documento_hash);
+  });
+
+  test('el inquilino solo firma contratos propios pendientes', async () => {
+    let updateData: any;
+
+    prisma.contratoAlquiler.findFirst = async () => ({
+      id: 99,
+      version: 1,
+      estado: 'PENDIENTE_FIRMA',
+      documento_hash: 'a'.repeat(64),
+      inquilino: { id: 20, documento_identidad: '12345678Z' },
+    });
+    prisma.contratoAlquiler.update = async (args: any) => {
+      updateData = args.data;
+      return { id: args.where.id, ...args.data };
+    };
+
+    const response = await invoke(
+      firmarContratoAlquiler,
+      req({ usuario: { id: 20, rol: 'INQUILINO' }, params: { contratoId: '99' } }),
+    );
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(updateData.estado, 'FIRMADO');
+    assert.equal(updateData.firma_usuario_id, 20);
+    assert.equal(updateData.firma_documento_identidad, '12345678Z');
+    assert.match(updateData.firma_origen_tecnico, /ua=vitest/);
+  });
+
+  test('el inquilino no lista contratos de otros ocupantes de la vivienda', async () => {
+    let filtros: any;
+    prisma.habitacion.findFirst = async () => ({ id: 3 });
+    prisma.contratoAlquiler.findMany = async (args: any) => {
+      filtros = args.where;
+      return [];
+    };
+
+    const response = await invoke(
+      listarContratosVivienda,
+      req({ usuario: { id: 20, rol: 'INQUILINO' }, params: { viviendaId: '7' } }),
+    );
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(filtros, { vivienda_id: 7, inquilino_id: 20 });
+  });
+});

--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -1445,6 +1445,55 @@ Devuelve el dashboard financiero mensual del casero para una vivienda.
 
 ---
 
+## Contratos de alquiler (`/viviendas/:viviendaId/contratos`)
+
+Todos los endpoints de esta seccion estan protegidos por `mod_gastos`, porque alimentan el modo fiscal y la trazabilidad de ocupacion.
+
+### GET `/viviendas/:viviendaId/contratos`
+
+Lista contratos visibles para el usuario autenticado. El casero propietario ve los contratos de la vivienda; el inquilino solo ve los contratos donde aparece como parte.
+
+**Auth requerida:** Si - `Authorization: Bearer <token>`
+
+**Respuestas:**
+
+| Codigo | Descripcion |
+|---|---|
+| `200` | Array de contratos con vivienda, habitacion, inquilino y eventos. |
+| `403` | Sin acceso a la vivienda o modulo desactivado. |
+
+### POST `/viviendas/:viviendaId/contratos`
+
+Sube un PDF o imagen del contrato y crea una nueva version para la habitacion e inquilino indicados. Por defecto queda en `PENDIENTE_FIRMA`.
+
+**Auth requerida:** Si - rol `CASERO`
+
+**Body multipart:**
+
+| Campo | Tipo | Obligatorio | Notas |
+|---|---|---|---|
+| `contrato` | file | Si | PDF o imagen. |
+| `habitacion_id` | number | Si | Debe pertenecer a la vivienda y tener el inquilino asignado. |
+| `inquilino_id` | number | Si | Parte que firmara el contrato. |
+| `renta_mensual` | number | Si | Importe pactado para uso fiscal. |
+| `fecha_inicio` | string | Si | Fecha ISO del inicio del contrato. |
+| `fecha_fin` | string | No | Fecha ISO de fin si existe. |
+| `notas` | string | No | Notas internas del casero. |
+
+### PATCH `/viviendas/:viviendaId/contratos/:contratoId/firmar`
+
+Firma internamente un contrato pendiente. Solo puede hacerlo el inquilino implicado y registra usuario, fecha, version, hash, documento de identidad si existe y origen tecnico disponible.
+
+### PATCH `/viviendas/:viviendaId/contratos/:contratoId/rechazar`
+
+Rechaza un contrato pendiente. Solo puede hacerlo el inquilino implicado.
+
+### PATCH `/viviendas/:viviendaId/contratos/:contratoId/anular`
+
+Anula un contrato pendiente o rechazado. Solo puede hacerlo el casero propietario; no se anulan contratos ya firmados.
+
+---
+
 ## Fiscal (`/viviendas/:viviendaId`)
 
 ### GET `/viviendas/:viviendaId/fiscal/:ejercicio`

--- a/docs/changelog/issue-337-contratos-firma.md
+++ b/docs/changelog/issue-337-contratos-firma.md
@@ -1,0 +1,20 @@
+# Issue 337 - Contratos de alquiler y firma interna
+
+## Objetivo
+
+Se anade un flujo operativo para que el casero suba contratos de alquiler por vivienda/habitacion y el inquilino pueda revisarlos, firmarlos o rechazarlos desde la app.
+
+## Cambios principales
+
+- Nuevo modelo `ContratoAlquiler` con estados `BORRADOR`, `PENDIENTE_FIRMA`, `FIRMADO`, `RECHAZADO` y `ANULADO`.
+- Nuevo modelo `EventoContratoAlquiler` para conservar trazabilidad de version, hash, usuario, estado y origen tecnico.
+- Endpoints protegidos para listar contratos por vivienda, crear nuevas versiones, firmar, rechazar y anular.
+- Subida de PDF o imagen mediante Cloudinary en la carpeta `roomies-contratos`.
+- La foto fiscal de ocupacion puede consumir contratos firmados como fuente de periodos, renta e inquilino.
+- Nuevas pantallas de contratos para casero e inquilino, con aviso de alcance legal de la firma interna.
+
+## Verificacion
+
+- `npm test -- contrato-issue-337.test.ts fiscal.service.test.ts`
+- `npm run build` en backend
+- `npx tsc --noEmit` en frontend queda bloqueado por errores preexistentes en `app/casero/vivienda/[id]/(tabs)/limpieza.tsx`.

--- a/frontend/app/casero/(tabs)/_layout.tsx
+++ b/frontend/app/casero/(tabs)/_layout.tsx
@@ -117,6 +117,16 @@ export default function CaseroTabsLayout() {
         }}
       />
       <Tabs.Screen
+        name="contratos"
+        options={{
+          title: 'Contratos',
+          href: modulos.gastos ? undefined : null,
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="document-text-outline" size={size} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
         name="inventario"
         options={{
           title: 'Invent.',

--- a/frontend/app/casero/(tabs)/contratos.tsx
+++ b/frontend/app/casero/(tabs)/contratos.tsx
@@ -1,0 +1,5 @@
+import { ContratosAlquilerScreen } from '@/components/contratos/ContratosAlquilerScreen';
+
+export default function CaseroContratosScreen() {
+  return <ContratosAlquilerScreen rol="CASERO" />;
+}

--- a/frontend/app/inquilino/(tabs)/_layout.tsx
+++ b/frontend/app/inquilino/(tabs)/_layout.tsx
@@ -125,6 +125,16 @@ export default function InquilinoTabsLayout() {
         }}
       />
       <Tabs.Screen
+        name="contratos"
+        options={{
+          title: "Contrato",
+          href: modulos.gastos ? undefined : null,
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="document-text-outline" size={size} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
         name="inventario"
         options={{
           title: "Invent.",

--- a/frontend/app/inquilino/(tabs)/contratos.tsx
+++ b/frontend/app/inquilino/(tabs)/contratos.tsx
@@ -1,0 +1,5 @@
+import { ContratosAlquilerScreen } from '@/components/contratos/ContratosAlquilerScreen';
+
+export default function InquilinoContratosScreen() {
+  return <ContratosAlquilerScreen rol="INQUILINO" />;
+}

--- a/frontend/components/contratos/ContratosAlquilerScreen.tsx
+++ b/frontend/components/contratos/ContratosAlquilerScreen.tsx
@@ -1,0 +1,445 @@
+import { useCallback, useMemo, useState } from 'react';
+import { ActivityIndicator, Linking, Pressable, ScrollView, Text, TextInput, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import * as DocumentPicker from 'expo-document-picker';
+import { useFocusEffect } from 'expo-router';
+import Toast from 'react-native-toast-message';
+import { CustomButton } from '@/components/common/CustomButton';
+import { LoadingScreen } from '@/components/common/LoadingScreen';
+import { AppTheme } from '@/constants/theme';
+import { useAppTheme } from '@/contexts/ThemeContext';
+import api from '@/services/api';
+import { createStyles, getContratoStatusColors } from '@/styles/contratos/contratos.styles';
+
+type Rol = 'CASERO' | 'INQUILINO';
+type EstadoContrato = 'BORRADOR' | 'PENDIENTE_FIRMA' | 'FIRMADO' | 'RECHAZADO' | 'ANULADO';
+type Styles = ReturnType<typeof createStyles>;
+type StatusColors = ReturnType<typeof getContratoStatusColors>;
+
+type UsuarioResumen = { id: number; nombre: string; apellidos: string | null; documento_identidad?: string | null };
+type HabitacionResumen = {
+  id: number;
+  nombre: string;
+  tipo: string;
+  precio: number | null;
+  inquilino_id?: number | null;
+  inquilino?: UsuarioResumen | null;
+};
+type Vivienda = {
+  id: number;
+  alias_nombre: string;
+  direccion: string;
+  mod_gastos?: boolean;
+  habitaciones?: HabitacionResumen[];
+};
+type Contrato = {
+  id: number;
+  version: number;
+  estado: EstadoContrato;
+  documento_url: string;
+  documento_nombre: string | null;
+  documento_hash: string;
+  renta_mensual: number;
+  fecha_inicio: string;
+  fecha_fin: string | null;
+  enviado_en: string | null;
+  firmado_en: string | null;
+  rechazado_en: string | null;
+  habitacion: { id: number; nombre: string; tipo: string } | null;
+  inquilino: UsuarioResumen;
+  vivienda: { id: number; alias_nombre: string; direccion: string };
+};
+
+const estadoLabel: Record<EstadoContrato, string> = {
+  BORRADOR: 'Borrador',
+  PENDIENTE_FIRMA: 'Pendiente de firma',
+  FIRMADO: 'Firmado',
+  RECHAZADO: 'Rechazado',
+  ANULADO: 'Anulado',
+};
+
+const nombreCompleto = (usuario: UsuarioResumen) =>
+  usuario.apellidos ? `${usuario.nombre} ${usuario.apellidos}` : usuario.nombre;
+
+const formatearImporte = (importe: number) =>
+  importe.toLocaleString('es-ES', { style: 'currency', currency: 'EUR' });
+
+const formatearFecha = (fecha: string | null) =>
+  fecha
+    ? new Date(fecha).toLocaleDateString('es-ES', { day: '2-digit', month: 'short', year: 'numeric' })
+    : 'Sin fin';
+
+const obtenerHabitacionesConInquilino = (vivienda: Vivienda | null) =>
+  (vivienda?.habitaciones ?? []).filter((habitacion) => habitacion.tipo === 'DORMITORIO' && habitacion.inquilino);
+
+export function ContratosAlquilerScreen({ rol }: { rol: Rol }) {
+  const { theme } = useAppTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const statusColors = useMemo(() => getContratoStatusColors(theme), [theme]);
+  const [loading, setLoading] = useState(true);
+  const [loadingContratos, setLoadingContratos] = useState(false);
+  const [viviendas, setViviendas] = useState<Vivienda[]>([]);
+  const [viviendaId, setViviendaId] = useState<number | null>(null);
+  const [contratos, setContratos] = useState<Contrato[]>([]);
+  const [asset, setAsset] = useState<DocumentPicker.DocumentPickerAsset | null>(null);
+  const [habitacionId, setHabitacionId] = useState<number | null>(null);
+  const [renta, setRenta] = useState('');
+  const [fechaInicio, setFechaInicio] = useState(new Date().toISOString().slice(0, 10));
+  const [fechaFin, setFechaFin] = useState('');
+  const [subiendo, setSubiendo] = useState(false);
+  const [firmandoId, setFirmandoId] = useState<number | null>(null);
+
+  const viviendaSeleccionada = useMemo(
+    () => viviendas.find((vivienda) => vivienda.id === viviendaId) ?? null,
+    [viviendaId, viviendas],
+  );
+  const habitacionesConInquilino = useMemo(
+    () => obtenerHabitacionesConInquilino(viviendaSeleccionada),
+    [viviendaSeleccionada],
+  );
+  const habitacionSeleccionada = useMemo(
+    () => habitacionesConInquilino.find((habitacion) => habitacion.id === habitacionId) ?? null,
+    [habitacionId, habitacionesConInquilino],
+  );
+
+  const cargarContratos = useCallback(async (id: number) => {
+    setLoadingContratos(true);
+    try {
+      const { data } = await api.get<Contrato[]>(`/viviendas/${id}/contratos`);
+      setContratos(data);
+    } catch (error: any) {
+      setContratos([]);
+      Toast.show({ type: 'error', text1: error.response?.data?.error ?? 'No se pudieron cargar los contratos.' });
+    } finally {
+      setLoadingContratos(false);
+    }
+  }, []);
+
+  const cargarContexto = useCallback(async () => {
+    setLoading(true);
+    try {
+      if (rol === 'CASERO') {
+        const { data } = await api.get<Vivienda[]>('/viviendas');
+        const activas = data.filter((vivienda) => vivienda.mod_gastos !== false);
+        setViviendas(activas);
+        const inicial = activas.find((vivienda) => vivienda.id === viviendaId) ?? activas[0] ?? null;
+        setViviendaId(inicial?.id ?? null);
+        const primeraHab = obtenerHabitacionesConInquilino(inicial)[0] ?? null;
+        setHabitacionId((actual) => actual ?? primeraHab?.id ?? null);
+        if (inicial) await cargarContratos(inicial.id);
+      } else {
+        const { data } = await api.get<{ miHabitacionId: number; vivienda: Vivienda }>('/inquilino/vivienda');
+        setViviendas([data.vivienda]);
+        setViviendaId(data.vivienda.id);
+        setHabitacionId(data.miHabitacionId);
+        await cargarContratos(data.vivienda.id);
+      }
+    } catch {
+      setViviendas([]);
+      setViviendaId(null);
+      setContratos([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [cargarContratos, rol, viviendaId]);
+
+  useFocusEffect(
+    useCallback(() => {
+      cargarContexto();
+    }, [cargarContexto]),
+  );
+
+  const seleccionarDocumento = async () => {
+    const resultado = await DocumentPicker.getDocumentAsync({
+      type: ['application/pdf', 'image/*'],
+      copyToCacheDirectory: true,
+      multiple: false,
+    });
+
+    if (!resultado.canceled) {
+      setAsset(resultado.assets[0]);
+    }
+  };
+
+  const cambiarVivienda = async (id: number) => {
+    setViviendaId(id);
+    const vivienda = viviendas.find((item) => item.id === id) ?? null;
+    const primeraHab = obtenerHabitacionesConInquilino(vivienda)[0] ?? null;
+    setHabitacionId(primeraHab?.id ?? null);
+    setRenta(primeraHab?.precio ? String(primeraHab.precio).replace('.', ',') : '');
+    await cargarContratos(id);
+  };
+
+  const subirContrato = async () => {
+    if (!viviendaSeleccionada || !asset || !habitacionSeleccionada?.inquilino) return;
+
+    const rentaNumerica = Number(renta.trim().replace(',', '.'));
+    if (!Number.isFinite(rentaNumerica) || rentaNumerica <= 0) {
+      Toast.show({ type: 'error', text1: 'Indica una renta mensual valida.' });
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append('contrato', {
+      uri: asset.uri,
+      name: asset.name ?? 'contrato.pdf',
+      type: asset.mimeType ?? 'application/pdf',
+    } as any);
+    formData.append('habitacion_id', String(habitacionSeleccionada.id));
+    formData.append('inquilino_id', String(habitacionSeleccionada.inquilino.id));
+    formData.append('renta_mensual', String(rentaNumerica));
+    formData.append('fecha_inicio', fechaInicio);
+    if (fechaFin.trim()) formData.append('fecha_fin', fechaFin.trim());
+
+    setSubiendo(true);
+    try {
+      await api.post(`/viviendas/${viviendaSeleccionada.id}/contratos`, formData, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+      setAsset(null);
+      Toast.show({ type: 'success', text1: 'Contrato enviado a firma.' });
+      await cargarContratos(viviendaSeleccionada.id);
+    } catch (error: any) {
+      Toast.show({ type: 'error', text1: error.response?.data?.error ?? 'No se pudo subir el contrato.' });
+    } finally {
+      setSubiendo(false);
+    }
+  };
+
+  const cambiarEstadoInquilino = async (contrato: Contrato, accion: 'firmar' | 'rechazar') => {
+    setFirmandoId(contrato.id);
+    try {
+      await api.patch(`/viviendas/${contrato.vivienda.id}/contratos/${contrato.id}/${accion}`);
+      Toast.show({ type: 'success', text1: accion === 'firmar' ? 'Contrato firmado.' : 'Contrato rechazado.' });
+      await cargarContratos(contrato.vivienda.id);
+    } catch (error: any) {
+      Toast.show({ type: 'error', text1: error.response?.data?.error ?? 'No se pudo actualizar el contrato.' });
+    } finally {
+      setFirmandoId(null);
+    }
+  };
+
+  if (loading) return <LoadingScreen />;
+
+  return (
+    <View style={styles.container}>
+      <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+        <View style={styles.header}>
+          <Text style={styles.eyebrow}>{rol === 'CASERO' ? 'Contratos' : 'Mi contrato'}</Text>
+          <Text style={styles.title}>{rol === 'CASERO' ? 'Contratos de alquiler' : 'Firma del alquiler'}</Text>
+          <Text style={styles.subtitle}>
+            {rol === 'CASERO'
+              ? 'Sube el documento asociado a una habitacion y conserva versiones, hash y estado de firma.'
+              : 'Abre el documento completo antes de firmarlo o rechazarlo desde la app.'}
+          </Text>
+        </View>
+
+        <View style={styles.warning}>
+          <Ionicons name="shield-checkmark-outline" size={19} color={theme.colors.warningText} />
+          <Text style={styles.warningText}>
+            La aceptacion interna deja trazabilidad operativa. Si necesitas firma electronica avanzada o cualificada,
+            revisa el caso con soporte legal y un proveedor especializado.
+          </Text>
+        </View>
+
+        {viviendas.length > 1 && (
+          <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.selectorContent}>
+            {viviendas.map((vivienda) => {
+              const activa = vivienda.id === viviendaId;
+              return (
+                <Pressable
+                  key={vivienda.id}
+                  style={[styles.chip, activa && styles.chipActive]}
+                  onPress={() => cambiarVivienda(vivienda.id)}
+                >
+                  <Text style={[styles.chipText, activa && styles.chipTextActive]}>{vivienda.alias_nombre}</Text>
+                </Pressable>
+              );
+            })}
+          </ScrollView>
+        )}
+
+        {rol === 'CASERO' && viviendaSeleccionada && (
+          <View style={styles.card}>
+            <Text style={styles.sectionTitle}>Enviar nuevo contrato</Text>
+            <View style={styles.field}>
+              <Text style={styles.label}>Habitacion e inquilino</Text>
+              <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.selectorContent}>
+                {habitacionesConInquilino.map((habitacion) => {
+                  const activa = habitacion.id === habitacionId;
+                  return (
+                    <Pressable
+                      key={habitacion.id}
+                      style={[styles.chip, activa && styles.chipActive]}
+                      onPress={() => {
+                        setHabitacionId(habitacion.id);
+                        setRenta(habitacion.precio ? String(habitacion.precio).replace('.', ',') : '');
+                      }}
+                    >
+                      <Text style={[styles.chipText, activa && styles.chipTextActive]}>
+                        {habitacion.nombre} - {habitacion.inquilino ? nombreCompleto(habitacion.inquilino) : ''}
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </ScrollView>
+            </View>
+            <View style={styles.row}>
+              <View style={[styles.field, { flex: 1 }]}>
+                <Text style={styles.label}>Renta mensual</Text>
+                <TextInput
+                  style={styles.input}
+                  value={renta}
+                  onChangeText={setRenta}
+                  placeholder="450"
+                  placeholderTextColor={theme.colors.textMuted}
+                  keyboardType="decimal-pad"
+                />
+              </View>
+              <View style={[styles.field, { flex: 1 }]}>
+                <Text style={styles.label}>Inicio</Text>
+                <TextInput
+                  style={styles.input}
+                  value={fechaInicio}
+                  onChangeText={setFechaInicio}
+                  placeholder="2026-06-01"
+                  placeholderTextColor={theme.colors.textMuted}
+                />
+              </View>
+            </View>
+            <View style={styles.field}>
+              <Text style={styles.label}>Fin opcional</Text>
+              <TextInput
+                style={styles.input}
+                value={fechaFin}
+                onChangeText={setFechaFin}
+                placeholder="2027-05-31"
+                placeholderTextColor={theme.colors.textMuted}
+              />
+            </View>
+            <Pressable
+              style={[styles.smallButton, { backgroundColor: theme.colors.infoLight, alignSelf: 'flex-start' }]}
+              onPress={seleccionarDocumento}
+            >
+              <Ionicons name="document-attach-outline" size={16} color={theme.colors.info} />
+              <Text style={[styles.smallButtonText, { color: theme.colors.info }]}>
+                {asset?.name ?? 'Elegir PDF o imagen'}
+              </Text>
+            </Pressable>
+            <CustomButton
+              label={subiendo ? 'Subiendo...' : 'Subir y enviar a firma'}
+              onPress={subirContrato}
+              disabled={subiendo || !asset || !habitacionSeleccionada}
+            />
+          </View>
+        )}
+
+        {loadingContratos ? (
+          <ActivityIndicator color={theme.colors.primary} />
+        ) : contratos.length === 0 ? (
+          <View style={styles.empty}>
+            <Ionicons name="document-text-outline" size={42} color={theme.colors.primary} />
+            <Text style={styles.emptyTitle}>Sin contratos todavia</Text>
+            <Text style={styles.emptyText}>
+              {rol === 'CASERO'
+                ? 'Cuando subas un documento aparecera aqui con su version y estado.'
+                : 'Tu casero todavia no ha enviado un contrato para revisar.'}
+            </Text>
+          </View>
+        ) : (
+          contratos.map((contrato) => (
+            <ContratoCard
+              key={contrato.id}
+              contrato={contrato}
+              rol={rol}
+              styles={styles}
+              theme={theme}
+              statusColors={statusColors}
+              busy={firmandoId === contrato.id}
+              onFirmar={() => cambiarEstadoInquilino(contrato, 'firmar')}
+              onRechazar={() => cambiarEstadoInquilino(contrato, 'rechazar')}
+            />
+          ))
+        )}
+      </ScrollView>
+    </View>
+  );
+}
+
+function ContratoCard({
+  contrato,
+  rol,
+  styles,
+  theme,
+  statusColors,
+  busy,
+  onFirmar,
+  onRechazar,
+}: {
+  contrato: Contrato;
+  rol: Rol;
+  styles: Styles;
+  theme: AppTheme;
+  statusColors: StatusColors;
+  busy: boolean;
+  onFirmar: () => void;
+  onRechazar: () => void;
+}) {
+  const colors = statusColors[contrato.estado];
+  const puedeFirmar = rol === 'INQUILINO' && contrato.estado === 'PENDIENTE_FIRMA';
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.cardHeader}>
+        <View style={styles.iconBox}>
+          <Ionicons name="document-text-outline" size={22} color={theme.colors.primary} />
+        </View>
+        <View style={styles.body}>
+          <Text style={styles.cardTitle}>
+            {contrato.habitacion?.nombre ?? contrato.vivienda.alias_nombre} - v{contrato.version}
+          </Text>
+          <Text style={styles.meta}>
+            {nombreCompleto(contrato.inquilino)} - {formatearImporte(contrato.renta_mensual)} -{' '}
+            {formatearFecha(contrato.fecha_inicio)} - {formatearFecha(contrato.fecha_fin)}
+          </Text>
+          <Text style={styles.meta} numberOfLines={1}>
+            Hash {contrato.documento_hash}
+          </Text>
+        </View>
+        <View style={[styles.badge, { backgroundColor: colors.bg, borderColor: colors.border }]}>
+          <Text style={[styles.badgeText, { color: colors.text }]}>{estadoLabel[contrato.estado]}</Text>
+        </View>
+      </View>
+
+      <View style={styles.row}>
+        <Pressable
+          style={[styles.smallButton, { backgroundColor: theme.colors.infoLight }]}
+          onPress={() => Linking.openURL(contrato.documento_url)}
+        >
+          <Ionicons name="open-outline" size={15} color={theme.colors.info} />
+          <Text style={[styles.smallButtonText, { color: theme.colors.info }]}>Abrir documento</Text>
+        </Pressable>
+        {puedeFirmar && (
+          <>
+            <Pressable
+              style={[styles.smallButton, { backgroundColor: theme.colors.successLight }]}
+              onPress={onFirmar}
+              disabled={busy}
+            >
+              <Ionicons name="checkmark-circle-outline" size={15} color={theme.colors.success} />
+              <Text style={[styles.smallButtonText, { color: theme.colors.successText }]}>Firmar</Text>
+            </Pressable>
+            <Pressable
+              style={[styles.smallButton, { backgroundColor: theme.colors.dangerLight }]}
+              onPress={onRechazar}
+              disabled={busy}
+            >
+              <Ionicons name="close-circle-outline" size={15} color={theme.colors.danger} />
+              <Text style={[styles.smallButtonText, { color: theme.colors.dangerText }]}>Rechazar</Text>
+            </Pressable>
+          </>
+        )}
+      </View>
+    </View>
+  );
+}

--- a/frontend/styles/contratos/contratos.styles.ts
+++ b/frontend/styles/contratos/contratos.styles.ts
@@ -1,0 +1,189 @@
+import { StyleSheet } from 'react-native';
+import { AppTheme, DefaultAppTheme } from '@/constants/theme';
+
+export const getContratoStatusColors = (theme: AppTheme = DefaultAppTheme) => ({
+  BORRADOR: { bg: theme.colors.surface2, text: theme.colors.textSecondary, border: theme.colors.border },
+  PENDIENTE_FIRMA: { bg: theme.colors.warningLight, text: theme.colors.warningText, border: `${theme.colors.warning}34` },
+  FIRMADO: { bg: theme.colors.successLight, text: theme.colors.successText, border: `${theme.colors.success}30` },
+  RECHAZADO: { bg: theme.colors.dangerLight, text: theme.colors.dangerText, border: `${theme.colors.danger}28` },
+  ANULADO: { bg: theme.colors.surface2, text: theme.colors.textTertiary, border: theme.colors.border },
+});
+
+export const createStyles = (theme: AppTheme = DefaultAppTheme) => StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.background,
+  },
+  content: {
+    paddingHorizontal: theme.spacing.lg,
+    paddingTop: theme.spacing.lg,
+    paddingBottom: 120,
+    gap: theme.spacing.lg,
+  },
+  header: {
+    gap: theme.spacing.sm,
+  },
+  eyebrow: {
+    fontSize: theme.typography.caption,
+    fontWeight: '800',
+    color: theme.colors.textTertiary,
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+  },
+  title: {
+    fontSize: theme.typography.hero,
+    fontWeight: '800',
+    color: theme.colors.text,
+  },
+  subtitle: {
+    fontSize: theme.typography.body,
+    color: theme.colors.textSecondary,
+    lineHeight: 22,
+  },
+  selectorContent: {
+    gap: theme.spacing.sm,
+    paddingRight: theme.spacing.sm,
+  },
+  chip: {
+    paddingHorizontal: theme.spacing.base,
+    paddingVertical: theme.spacing.sm,
+    borderRadius: theme.radius.full,
+    backgroundColor: theme.colors.surface,
+    borderWidth: 1.5,
+    borderColor: theme.colors.border,
+  },
+  chipActive: {
+    backgroundColor: theme.colors.primaryLight,
+    borderColor: theme.colors.primary,
+  },
+  chipText: {
+    fontSize: theme.typography.label,
+    fontWeight: '800',
+    color: theme.colors.textSecondary,
+  },
+  chipTextActive: {
+    color: theme.colors.primary,
+  },
+  card: {
+    backgroundColor: theme.colors.surface,
+    borderRadius: theme.radius.lg,
+    padding: theme.spacing.base,
+    gap: theme.spacing.base,
+    ...theme.shadows.sm,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: theme.spacing.base,
+  },
+  iconBox: {
+    width: 46,
+    height: 46,
+    borderRadius: theme.radius.lg,
+    backgroundColor: theme.colors.primaryLight,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  body: {
+    flex: 1,
+    minWidth: 0,
+    gap: theme.spacing.xs,
+  },
+  cardTitle: {
+    fontSize: theme.typography.subtitle,
+    fontWeight: '800',
+    color: theme.colors.text,
+  },
+  meta: {
+    fontSize: theme.typography.label,
+    color: theme.colors.textSecondary,
+    lineHeight: 20,
+  },
+  badge: {
+    alignSelf: 'flex-start',
+    borderRadius: theme.radius.full,
+    borderWidth: 1,
+    paddingHorizontal: theme.spacing.md,
+    paddingVertical: theme.spacing.xs,
+  },
+  badgeText: {
+    fontSize: theme.typography.caption,
+    fontWeight: '800',
+  },
+  warning: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: theme.spacing.sm,
+    borderRadius: theme.radius.lg,
+    borderWidth: 1,
+    padding: theme.spacing.base,
+    backgroundColor: theme.colors.warningLight,
+    borderColor: `${theme.colors.warning}34`,
+  },
+  warningText: {
+    flex: 1,
+    fontSize: theme.typography.label,
+    color: theme.colors.warningText,
+    lineHeight: 20,
+    fontWeight: '700',
+  },
+  row: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: theme.spacing.sm,
+  },
+  smallButton: {
+    borderRadius: theme.radius.full,
+    paddingHorizontal: theme.spacing.md,
+    paddingVertical: theme.spacing.sm,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: theme.spacing.xs,
+  },
+  smallButtonText: {
+    fontSize: theme.typography.caption,
+    fontWeight: '800',
+  },
+  sectionTitle: {
+    fontSize: theme.typography.subtitle,
+    fontWeight: '800',
+    color: theme.colors.text,
+  },
+  field: {
+    gap: theme.spacing.xs,
+  },
+  label: {
+    fontSize: theme.typography.caption,
+    fontWeight: '800',
+    color: theme.colors.textSecondary,
+    textTransform: 'uppercase',
+    letterSpacing: 0.7,
+  },
+  input: {
+    minHeight: 52,
+    borderRadius: theme.radius.lg,
+    borderWidth: 1.5,
+    borderColor: theme.colors.border,
+    backgroundColor: theme.colors.background,
+    paddingHorizontal: theme.spacing.base,
+    fontSize: theme.typography.input,
+    color: theme.colors.text,
+  },
+  empty: {
+    alignItems: 'center',
+    paddingVertical: theme.spacing.xxl,
+    gap: theme.spacing.sm,
+  },
+  emptyTitle: {
+    fontSize: theme.typography.heading,
+    fontWeight: '800',
+    color: theme.colors.text,
+    textAlign: 'center',
+  },
+  emptyText: {
+    fontSize: theme.typography.body,
+    color: theme.colors.textSecondary,
+    textAlign: 'center',
+    lineHeight: 22,
+  },
+});


### PR DESCRIPTION
**Descripción:**
## Objetivo
Esta PR añade un flujo operativo para que el casero suba contratos de alquiler por vivienda o habitación, y para que el inquilino pueda revisarlos, firmarlos o rechazarlos desde la app con trazabilidad suficiente para uso fiscal y operativo.

## Cambios principales
* Nuevo modelo de contratos con versionado, hash del documento, estados y evento histórico de firma/aceptación.
* Endpoints backend para listar, crear nuevas versiones, firmar, rechazar y anular contratos.
* Subida de PDF o imagen del contrato mediante Cloudinary con validación de permisos por vivienda y parte implicada.
* Integración con el modo fiscal para que los contratos firmados puedan servir como fuente de periodo, renta e inquilino.
* Tests backend para permisos, versionado, hash, firma, rechazo y acceso cruzado.

## UI / UX
* Se añaden pantallas de contratos para casero e inquilino con avisos claros sobre el alcance de la firma interna y uso de tokens de `Theme.ts`.
* La presentación sigue el patrón de soft tints y tarjetas suaves ya usado en la app.

## Changelog
* `docs/changelog/issue-337-contratos-firma.md`

## Testing
* `npm test -- contrato-issue-337.test.ts fiscal.service.test.ts`
* `npm run build` en backend
* Validación frontend con `npx tsc --noEmit` no queda limpia por errores preexistentes en `frontend/app/casero/vivienda/[id]/(tabs)/limpieza.tsx`.