### PR TITLE
[Épica Fiscal] Guarda el histórico explícito de ocupación

### DIFF
--- a/backend/prisma/migrations/20260506143000_add_periodos_ocupacion/migration.sql
+++ b/backend/prisma/migrations/20260506143000_add_periodos_ocupacion/migration.sql
@@ -1,0 +1,51 @@
+CREATE TYPE "EstadoPeriodoOcupacion" AS ENUM (
+  'ACTIVO',
+  'FINALIZADO',
+  'PENDIENTE_REVISION'
+);
+
+CREATE TYPE "OrigenPeriodoOcupacion" AS ENUM (
+  'CONTRATO_FIRMADO',
+  'ALTA_MANUAL',
+  'INFERIDO_CARGO_ALQUILER',
+  'MIGRADO'
+);
+
+CREATE TABLE "PeriodoOcupacion" (
+  "id" SERIAL NOT NULL,
+  "vivienda_id" INTEGER NOT NULL,
+  "habitacion_id" INTEGER,
+  "inquilino_id" INTEGER NOT NULL,
+  "contrato_id" INTEGER,
+  "fecha_inicio" TIMESTAMP(3) NOT NULL,
+  "fecha_fin" TIMESTAMP(3),
+  "estado" "EstadoPeriodoOcupacion" NOT NULL DEFAULT 'ACTIVO',
+  "origen" "OrigenPeriodoOcupacion" NOT NULL,
+  "renta_mensual" DOUBLE PRECISION,
+  "requiere_revision" BOOLEAN NOT NULL DEFAULT false,
+  "notas" TEXT,
+  "fecha_creacion" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "fecha_actualizacion" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "PeriodoOcupacion_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "PeriodoOcupacion_vivienda_id_fecha_inicio_idx" ON "PeriodoOcupacion"("vivienda_id", "fecha_inicio");
+CREATE INDEX "PeriodoOcupacion_habitacion_id_fecha_inicio_idx" ON "PeriodoOcupacion"("habitacion_id", "fecha_inicio");
+CREATE INDEX "PeriodoOcupacion_inquilino_id_fecha_inicio_idx" ON "PeriodoOcupacion"("inquilino_id", "fecha_inicio");
+CREATE INDEX "PeriodoOcupacion_contrato_id_idx" ON "PeriodoOcupacion"("contrato_id");
+
+ALTER TABLE "PeriodoOcupacion"
+  ADD CONSTRAINT "PeriodoOcupacion_vivienda_id_fkey"
+  FOREIGN KEY ("vivienda_id") REFERENCES "Vivienda"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "PeriodoOcupacion"
+  ADD CONSTRAINT "PeriodoOcupacion_habitacion_id_fkey"
+  FOREIGN KEY ("habitacion_id") REFERENCES "Habitacion"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "PeriodoOcupacion"
+  ADD CONSTRAINT "PeriodoOcupacion_inquilino_id_fkey"
+  FOREIGN KEY ("inquilino_id") REFERENCES "Usuario"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "PeriodoOcupacion"
+  ADD CONSTRAINT "PeriodoOcupacion_contrato_id_fkey"
+  FOREIGN KEY ("contrato_id") REFERENCES "ContratoAlquiler"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -94,6 +94,19 @@ enum TipoEventoContratoAlquiler {
   ANULADO
 }
 
+enum EstadoPeriodoOcupacion {
+  ACTIVO
+  FINALIZADO
+  PENDIENTE_REVISION
+}
+
+enum OrigenPeriodoOcupacion {
+  CONTRATO_FIRMADO
+  ALTA_MANUAL
+  INFERIDO_CARGO_ALQUILER
+  MIGRADO
+}
+
 model Usuario {
   id                 Int                      @id @default(autoincrement())
   nombre             String
@@ -125,6 +138,7 @@ model Usuario {
   contratos_inquilino ContratoAlquiler[]      @relation("InquilinoContrato")
   contratos_firmados ContratoAlquiler[]       @relation("FirmanteContrato")
   eventos_contrato   EventoContratoAlquiler[]
+  periodos_ocupacion PeriodoOcupacion[]       @relation("InquilinoPeriodoOcupacion")
 }
 
 model Vivienda {
@@ -147,6 +161,7 @@ model Vivienda {
   gastos_recurrentes GastoRecurrente[]
   items_inventario ItemInventario[]
   contratos_alquiler ContratoAlquiler[]
+  periodos_ocupacion PeriodoOcupacion[]
 }
 
 model Habitacion {
@@ -168,6 +183,7 @@ model Habitacion {
   zonas_limpieza_objetivo ZonaLimpieza[] @relation("ZonaLimpiezaObjetivoHabitacion")
   asignaciones_limpieza_fijas AsignacionLimpiezaFija[] @relation("AsignacionLimpiezaFijaHabitacion")
   turnos_limpieza_responsable TurnoLimpieza[] @relation("TurnoLimpiezaHabitacionResponsable")
+  periodos_ocupacion PeriodoOcupacion[]
 }
 
 model Incidencia {
@@ -310,6 +326,7 @@ model ContratoAlquiler {
   fecha_creacion            DateTime               @default(now())
   fecha_actualizacion       DateTime               @updatedAt
   eventos                   EventoContratoAlquiler[]
+  periodos_ocupacion        PeriodoOcupacion[]
 
   @@index([vivienda_id, estado])
   @@index([inquilino_id, estado])
@@ -330,6 +347,32 @@ model EventoContratoAlquiler {
   fecha          DateTime                    @default(now())
 
   @@index([contrato_id, fecha])
+}
+
+model PeriodoOcupacion {
+  id                Int                     @id @default(autoincrement())
+  vivienda_id       Int
+  vivienda          Vivienda                @relation(fields: [vivienda_id], references: [id], onDelete: Cascade)
+  habitacion_id     Int?
+  habitacion        Habitacion?             @relation(fields: [habitacion_id], references: [id], onDelete: SetNull)
+  inquilino_id      Int
+  inquilino         Usuario                 @relation("InquilinoPeriodoOcupacion", fields: [inquilino_id], references: [id])
+  contrato_id       Int?
+  contrato          ContratoAlquiler?       @relation(fields: [contrato_id], references: [id], onDelete: SetNull)
+  fecha_inicio      DateTime
+  fecha_fin         DateTime?
+  estado            EstadoPeriodoOcupacion  @default(ACTIVO)
+  origen            OrigenPeriodoOcupacion
+  renta_mensual     Float?
+  requiere_revision Boolean                 @default(false)
+  notas             String?
+  fecha_creacion    DateTime                @default(now())
+  fecha_actualizacion DateTime              @updatedAt
+
+  @@index([vivienda_id, fecha_inicio])
+  @@index([habitacion_id, fecha_inicio])
+  @@index([inquilino_id, fecha_inicio])
+  @@index([contrato_id])
 }
 
 // ── Módulo de limpieza ────────────────────────────────────────────────────────

--- a/backend/src/controllers/contrato.controller.ts
+++ b/backend/src/controllers/contrato.controller.ts
@@ -2,6 +2,7 @@ import crypto from 'node:crypto';
 import express from 'express';
 import { RolUsuario } from '../generated/prisma/client';
 import { prisma } from '../lib/prisma';
+import { registrarPeriodoContratoFirmado } from '../services/ocupacion.service';
 
 const ESTADOS_CONTRATO = {
   BORRADOR: 'BORRADOR',
@@ -368,7 +369,7 @@ export const firmarContratoAlquiler: express.RequestHandler = async (req, res) =
       },
     });
 
-    return tx.contratoAlquiler.update({
+    const actualizado = await tx.contratoAlquiler.update({
       where: { id: contrato.id },
       data: {
         estado: ESTADOS_CONTRATO.FIRMADO,
@@ -379,6 +380,18 @@ export const firmarContratoAlquiler: express.RequestHandler = async (req, res) =
       },
       include: includeContrato,
     });
+
+    await registrarPeriodoContratoFirmado(tx, {
+      id: contrato.id,
+      vivienda_id: contrato.vivienda.id,
+      habitacion_id: contrato.habitacion?.id ?? null,
+      inquilino_id: usuario.id,
+      fecha_inicio: contrato.fecha_inicio,
+      fecha_fin: contrato.fecha_fin,
+      renta_mensual: contrato.renta_mensual,
+    });
+
+    return actualizado;
   });
 
   res.status(200).json(contratoActualizado);

--- a/backend/src/controllers/inquilino.controller.ts
+++ b/backend/src/controllers/inquilino.controller.ts
@@ -3,6 +3,7 @@ import { prisma } from '../lib/prisma';
 import { RolUsuario } from '../generated/prisma/client';
 import { generarCodigoInvitacion } from '../utils/generarCodigo';
 import { enviarNotificacionPush } from '../services/notification.service';
+import { registrarAltaOcupacion, registrarBajaOcupacion } from '../services/ocupacion.service';
 
 const serializarHabitacionParaInquilino = <
   T extends { precio: number | null; codigo_invitacion: string | null; inquilino_id?: number | null },
@@ -113,16 +114,27 @@ export const unirseHabitacion: express.RequestHandler = async (req, res) => {
 
   const nuevoCodigo = await generarCodigoInvitacion();
 
-  const habitacionActualizada = await prisma.habitacion.update({
-    where: { codigo_invitacion },
-    data: {
-      inquilino_id: req.usuario!.id,
-      codigo_invitacion: nuevoCodigo, // burn after reading: el código antiguo queda invalidado al instante
-    },
-    include: {
-      vivienda: true,
-      inquilino: { select: { nombre: true, apellidos: true } },
-    },
+  const habitacionActualizada = await prisma.$transaction(async (tx) => {
+    const actualizada = await tx.habitacion.update({
+      where: { codigo_invitacion },
+      data: {
+        inquilino_id: req.usuario!.id,
+        codigo_invitacion: nuevoCodigo, // burn after reading: el código antiguo queda invalidado al instante
+      },
+      include: {
+        vivienda: true,
+        inquilino: { select: { nombre: true, apellidos: true } },
+      },
+    });
+
+    await registrarAltaOcupacion(tx as any, {
+      viviendaId: actualizada.vivienda_id,
+      habitacionId: actualizada.id,
+      inquilinoId: req.usuario!.id,
+      rentaMensual: actualizada.precio,
+    });
+
+    return actualizada;
   });
 
   res.status(200).json({
@@ -157,9 +169,18 @@ export const abandonarHabitacion: express.RequestHandler = async (req, res) => {
     return;
   }
 
-  await prisma.habitacion.update({
-    where: { id: habitacion.id },
-    data: { inquilino_id: null },
+  await prisma.$transaction(async (tx) => {
+    await registrarBajaOcupacion(tx as any, {
+      viviendaId: habitacion.vivienda_id,
+      habitacionId: habitacion.id,
+      inquilinoId: req.usuario!.id,
+      notas: 'Baja registrada al abandonar la habitacion.',
+    });
+
+    await tx.habitacion.update({
+      where: { id: habitacion.id },
+      data: { inquilino_id: null },
+    });
   });
 
   res.status(200).json({ mensaje: 'Has abandonado la habitación correctamente.' });

--- a/backend/src/controllers/vivienda.controller.ts
+++ b/backend/src/controllers/vivienda.controller.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import { prisma } from '../lib/prisma';
 import { RolUsuario, TipoHabitacion, EstadoIncidencia } from '../generated/prisma/client';
 import { generarCodigoInvitacion } from '../utils/generarCodigo';
+import { registrarBajaOcupacion } from '../services/ocupacion.service';
 
 const parsePrecioHabitacion = (precio: unknown): number | null => {
   if (precio === undefined || precio === null || precio === '') return null;
@@ -315,9 +316,18 @@ export const expulsarInquilino: express.RequestHandler = async (req, res) => {
     return;
   }
 
-  await prisma.habitacion.update({
-    where: { id: habId },
-    data: { inquilino_id: null },
+  await prisma.$transaction(async (tx) => {
+    await registrarBajaOcupacion(tx as any, {
+      viviendaId,
+      habitacionId: habId,
+      inquilinoId: habitacion.inquilino_id!,
+      notas: 'Baja registrada al expulsar al inquilino.',
+    });
+
+    await tx.habitacion.update({
+      where: { id: habId },
+      data: { inquilino_id: null },
+    });
   });
 
   res.status(200).json({ mensaje: 'Inquilino desvinculado correctamente.' });

--- a/backend/src/services/fiscal.service.ts
+++ b/backend/src/services/fiscal.service.ts
@@ -54,10 +54,28 @@ type ContratoFiscal = {
   inquilino?: InquilinoFiscal | null;
 };
 
+type PeriodoOcupacionFiscal = {
+  id: number;
+  estado: string;
+  origen: string;
+  fecha_inicio: Date;
+  fecha_fin: Date | null;
+  habitacion_id: number | null;
+  inquilino_id: number;
+  contrato_id: number | null;
+  renta_mensual: number | null;
+  requiere_revision: boolean;
+  inquilino?: InquilinoFiscal | null;
+};
+
 export type FiscalEstadoOcupacion = 'SIN_ACTIVIDAD' | 'PARCIAL' | 'TODO_EL_ANO';
 
 export type FiscalRevision = {
-  codigo: 'SIN_PERIODO_FACTURACION' | 'OCUPACION_ACTUAL_SIN_CARGOS' | 'SIN_PRECIO_HABITACION';
+  codigo:
+    | 'SIN_PERIODO_FACTURACION'
+    | 'OCUPACION_ACTUAL_SIN_CARGOS'
+    | 'SIN_PRECIO_HABITACION'
+    | 'PERIODO_OCUPACION_REVISABLE';
   mensaje: string;
 };
 
@@ -68,9 +86,12 @@ export type FiscalPeriodoOcupacion = {
   periodo_facturacion: string;
   gasto_id?: number;
   contrato_id?: number;
-  fuente: 'CARGO_ALQUILER' | 'CONTRATO_FIRMADO';
+  fuente: 'CARGO_ALQUILER' | 'CONTRATO_FIRMADO' | 'PERIODO_OCUPACION';
   contrato_version?: number;
   documento_hash?: string;
+  periodo_ocupacion_id?: number;
+  origen_periodo?: string;
+  requiere_revision?: boolean;
   inquilino: InquilinoFiscal | null;
   importe: number;
 };
@@ -144,6 +165,7 @@ type ConstruirFotoInput = {
   };
   gastos: GastoFiscal[];
   contratos?: ContratoFiscal[];
+  periodosOcupacion?: PeriodoOcupacionFiscal[];
 };
 
 type CaseroFiscal = {
@@ -524,6 +546,7 @@ export const construirFotoOcupacionFiscal = ({
   vivienda,
   gastos,
   contratos = [],
+  periodosOcupacion = [],
 }: ConstruirFotoInput): FiscalFotoOcupacionVivienda => {
   const inicioEjercicio = new Date(Date.UTC(ejercicio, 0, 1));
   const finEjercicio = new Date(Date.UTC(ejercicio + 1, 0, 1));
@@ -537,10 +560,12 @@ export const construirFotoOcupacionFiscal = ({
     const contratosHabitacion = contratos.filter(
       (contrato) => contrato.estado === 'FIRMADO' && contrato.habitacion_id === habitacion.id,
     );
-    const usarContratosFirmados = contratosHabitacion.length > 0;
+    const periodosHabitacion = periodosOcupacion.filter((periodo) => periodo.habitacion_id === habitacion.id);
+    const usarPeriodosOcupacion = periodosHabitacion.length > 0;
+    const usarContratosFirmados = !usarPeriodosOcupacion && contratosHabitacion.length > 0;
     const periodos: FiscalPeriodoOcupacion[] = [];
 
-    for (const cargo of usarContratosFirmados ? [] : cargosHabitacion) {
+    for (const cargo of usarPeriodosOcupacion || usarContratosFirmados ? [] : cargosHabitacion) {
       if (!cargo.periodo_facturacion) {
         const revision = {
           codigo: 'SIN_PERIODO_FACTURACION' as const,
@@ -577,7 +602,36 @@ export const construirFotoOcupacionFiscal = ({
       });
     }
 
-    for (const contrato of contratosHabitacion) {
+    for (const periodo of periodosHabitacion) {
+      const finPeriodo = periodo.fecha_fin ?? finEjercicio;
+      const recortado = recortarPeriodo(periodo.fecha_inicio, finPeriodo, inicioEjercicio, finEjercicio);
+      if (!recortado) continue;
+
+      if (periodo.requiere_revision || periodo.estado === 'PENDIENTE_REVISION') {
+        const revision = {
+          codigo: 'PERIODO_OCUPACION_REVISABLE' as const,
+          mensaje: `El periodo de ocupacion ${periodo.id} procede de ${periodo.origen} y requiere revision.`,
+        };
+        revisiones.push(revision);
+        revisionesVivienda.push(revision);
+      }
+
+      periodos.push({
+        inicio: isoFecha(recortado.inicio),
+        fin: isoFecha(recortado.fin),
+        dias: diasEntre(recortado.inicio, recortado.fin),
+        periodo_facturacion: `${isoFecha(recortado.inicio)}..${isoFecha(recortado.fin)}`,
+        contrato_id: periodo.contrato_id ?? undefined,
+        periodo_ocupacion_id: periodo.id,
+        fuente: 'PERIODO_OCUPACION',
+        origen_periodo: periodo.origen,
+        requiere_revision: periodo.requiere_revision,
+        inquilino: periodo.inquilino ?? null,
+        importe: normalizarImporteMonetario(periodo.renta_mensual ?? habitacion.precio ?? 0),
+      });
+    }
+
+    for (const contrato of usarContratosFirmados ? contratosHabitacion : []) {
       const finContrato = contrato.fecha_fin ?? finEjercicio;
       const recortado = recortarPeriodo(contrato.fecha_inicio, finContrato, inicioEjercicio, finEjercicio);
       if (!recortado) continue;
@@ -870,7 +924,7 @@ export const obtenerFotoOcupacionFiscalVivienda = async (
 
   const inicioEjercicio = new Date(Date.UTC(ejercicio, 0, 1));
   const finEjercicio = new Date(Date.UTC(ejercicio + 1, 0, 1));
-  const [gastos, contratos] = await Promise.all([
+  const [gastos, periodosOcupacion, contratos] = await Promise.all([
     prisma.gasto.findMany({
       where: {
         vivienda_id: viviendaId,
@@ -911,6 +965,33 @@ export const obtenerFotoOcupacionFiscalVivienda = async (
         },
       },
     }),
+    (prisma as typeof prisma & { periodoOcupacion: any }).periodoOcupacion.findMany({
+      where: {
+        vivienda_id: viviendaId,
+        fecha_inicio: { lt: finEjercicio },
+        OR: [{ fecha_fin: null }, { fecha_fin: { gt: inicioEjercicio } }],
+      },
+      orderBy: [{ fecha_inicio: 'asc' }, { id: 'asc' }],
+      select: {
+        id: true,
+        estado: true,
+        origen: true,
+        fecha_inicio: true,
+        fecha_fin: true,
+        habitacion_id: true,
+        inquilino_id: true,
+        contrato_id: true,
+        renta_mensual: true,
+        requiere_revision: true,
+        inquilino: {
+          select: {
+            id: true,
+            nombre: true,
+            apellidos: true,
+          },
+        },
+      },
+    }),
     (prisma as typeof prisma & { contratoAlquiler: any }).contratoAlquiler.findMany({
       where: {
         vivienda_id: viviendaId,
@@ -940,7 +1021,7 @@ export const obtenerFotoOcupacionFiscalVivienda = async (
     }),
   ]);
 
-  return construirFotoOcupacionFiscal({ ejercicio, vivienda, gastos, contratos });
+  return construirFotoOcupacionFiscal({ ejercicio, vivienda, gastos, contratos, periodosOcupacion });
 };
 
 export const obtenerResumenFiscalAnualVivienda = async (

--- a/backend/src/services/ocupacion.service.ts
+++ b/backend/src/services/ocupacion.service.ts
@@ -1,0 +1,287 @@
+import { prisma } from '../lib/prisma';
+
+export const ESTADOS_PERIODO_OCUPACION = {
+  ACTIVO: 'ACTIVO',
+  FINALIZADO: 'FINALIZADO',
+  PENDIENTE_REVISION: 'PENDIENTE_REVISION',
+} as const;
+
+export const ORIGENES_PERIODO_OCUPACION = {
+  CONTRATO_FIRMADO: 'CONTRATO_FIRMADO',
+  ALTA_MANUAL: 'ALTA_MANUAL',
+  INFERIDO_CARGO_ALQUILER: 'INFERIDO_CARGO_ALQUILER',
+  MIGRADO: 'MIGRADO',
+} as const;
+
+type DbPeriodo = typeof prisma & {
+  periodoOcupacion: any;
+};
+
+type OrigenPeriodoOcupacion = (typeof ORIGENES_PERIODO_OCUPACION)[keyof typeof ORIGENES_PERIODO_OCUPACION];
+
+type RegistrarAltaInput = {
+  viviendaId: number;
+  habitacionId: number | null;
+  inquilinoId: number;
+  fechaInicio?: Date;
+  fechaFin?: Date | null;
+  origen?: OrigenPeriodoOcupacion;
+  contratoId?: number | null;
+  rentaMensual?: number | null;
+  requiereRevision?: boolean;
+  notas?: string | null;
+};
+
+type RegistrarBajaInput = {
+  viviendaId: number;
+  habitacionId?: number | null;
+  inquilinoId: number;
+  fechaFin?: Date;
+  notas?: string | null;
+};
+
+type CargoAlquilerInferible = {
+  id: number;
+  vivienda_id: number;
+  habitacion_cargo_id: number | null;
+  inquilino_cargo_id: number | null;
+  importe: number;
+  periodo_facturacion: string | null;
+};
+
+const db = prisma as DbPeriodo;
+
+const inicioMes = (periodo: string) => {
+  const match = /^(\d{4})-(\d{2})$/.exec(periodo);
+  if (!match) return null;
+  const ano = Number(match[1]);
+  const mes = Number(match[2]);
+  if (!Number.isInteger(ano) || !Number.isInteger(mes) || mes < 1 || mes > 12) return null;
+  return new Date(Date.UTC(ano, mes - 1, 1));
+};
+
+const mesSiguiente = (fecha: Date) => new Date(Date.UTC(fecha.getUTCFullYear(), fecha.getUTCMonth() + 1, 1));
+
+const esMismoMes = (a: Date, b: Date) =>
+  a.getUTCFullYear() === b.getUTCFullYear() && a.getUTCMonth() === b.getUTCMonth();
+
+const estadoDesdeFechas = (fechaInicio: Date, fechaFin: Date | null | undefined, requiereRevision: boolean) => {
+  if (requiereRevision) return ESTADOS_PERIODO_OCUPACION.PENDIENTE_REVISION;
+  return fechaFin && fechaFin > fechaInicio ? ESTADOS_PERIODO_OCUPACION.FINALIZADO : ESTADOS_PERIODO_OCUPACION.ACTIVO;
+};
+
+export const registrarAltaOcupacion = async (
+  tx: DbPeriodo,
+  {
+    viviendaId,
+    habitacionId,
+    inquilinoId,
+    fechaInicio = new Date(),
+    fechaFin = null,
+    origen = ORIGENES_PERIODO_OCUPACION.ALTA_MANUAL,
+    contratoId = null,
+    rentaMensual = null,
+    requiereRevision = false,
+    notas = null,
+  }: RegistrarAltaInput,
+) => {
+  const existente = await tx.periodoOcupacion.findFirst({
+    where: {
+      vivienda_id: viviendaId,
+      habitacion_id: habitacionId,
+      inquilino_id: inquilinoId,
+      fecha_fin: null,
+      estado: ESTADOS_PERIODO_OCUPACION.ACTIVO,
+    },
+  });
+
+  if (existente) {
+    if (contratoId || origen === ORIGENES_PERIODO_OCUPACION.CONTRATO_FIRMADO) {
+      return tx.periodoOcupacion.update({
+        where: { id: existente.id },
+        data: {
+          contrato_id: contratoId,
+          origen,
+          fecha_inicio: fechaInicio < existente.fecha_inicio ? fechaInicio : existente.fecha_inicio,
+          fecha_fin: fechaFin,
+          estado: estadoDesdeFechas(fechaInicio, fechaFin, requiereRevision),
+          renta_mensual: rentaMensual ?? existente.renta_mensual,
+          requiere_revision: requiereRevision,
+          notas,
+        },
+      });
+    }
+
+    return existente;
+  }
+
+  await tx.periodoOcupacion.updateMany({
+    where: {
+      vivienda_id: viviendaId,
+      inquilino_id: inquilinoId,
+      fecha_fin: null,
+      estado: ESTADOS_PERIODO_OCUPACION.ACTIVO,
+    },
+    data: {
+      fecha_fin: fechaInicio,
+      estado: ESTADOS_PERIODO_OCUPACION.FINALIZADO,
+      notas: 'Cerrado automaticamente al abrir un nuevo periodo de ocupacion.',
+    },
+  });
+
+  await tx.periodoOcupacion.updateMany({
+    where: {
+      vivienda_id: viviendaId,
+      habitacion_id: habitacionId,
+      fecha_fin: null,
+      estado: ESTADOS_PERIODO_OCUPACION.ACTIVO,
+    },
+    data: {
+      fecha_fin: fechaInicio,
+      estado: ESTADOS_PERIODO_OCUPACION.FINALIZADO,
+      notas: 'Cerrado automaticamente al reocupar la habitacion.',
+    },
+  });
+
+  return tx.periodoOcupacion.create({
+    data: {
+      vivienda_id: viviendaId,
+      habitacion_id: habitacionId,
+      inquilino_id: inquilinoId,
+      contrato_id: contratoId,
+      fecha_inicio: fechaInicio,
+      fecha_fin: fechaFin,
+      estado: estadoDesdeFechas(fechaInicio, fechaFin, requiereRevision),
+      origen,
+      renta_mensual: rentaMensual,
+      requiere_revision: requiereRevision,
+      notas,
+    },
+  });
+};
+
+export const registrarBajaOcupacion = async (
+  tx: DbPeriodo,
+  { viviendaId, habitacionId, inquilinoId, fechaFin = new Date(), notas = null }: RegistrarBajaInput,
+) =>
+  tx.periodoOcupacion.updateMany({
+    where: {
+      vivienda_id: viviendaId,
+      inquilino_id: inquilinoId,
+      ...(habitacionId !== undefined ? { habitacion_id: habitacionId } : {}),
+      fecha_fin: null,
+      estado: ESTADOS_PERIODO_OCUPACION.ACTIVO,
+    },
+    data: {
+      fecha_fin: fechaFin,
+      estado: ESTADOS_PERIODO_OCUPACION.FINALIZADO,
+      ...(notas ? { notas } : {}),
+    },
+  });
+
+export const registrarPeriodoContratoFirmado = async (
+  tx: DbPeriodo,
+  contrato: {
+    id: number;
+    vivienda_id: number;
+    habitacion_id: number | null;
+    inquilino_id: number;
+    fecha_inicio: Date;
+    fecha_fin: Date | null;
+    renta_mensual: number;
+  },
+) =>
+  registrarAltaOcupacion(tx, {
+    viviendaId: contrato.vivienda_id,
+    habitacionId: contrato.habitacion_id,
+    inquilinoId: contrato.inquilino_id,
+    fechaInicio: contrato.fecha_inicio,
+    fechaFin: contrato.fecha_fin,
+    origen: ORIGENES_PERIODO_OCUPACION.CONTRATO_FIRMADO,
+    contratoId: contrato.id,
+    rentaMensual: contrato.renta_mensual,
+  });
+
+export const inferirPeriodosOcupacionDesdeCargos = (cargos: CargoAlquilerInferible[]) => {
+  const validos = cargos
+    .map((cargo) => ({ cargo, inicio: cargo.periodo_facturacion ? inicioMes(cargo.periodo_facturacion) : null }))
+    .filter(
+      (item): item is { cargo: CargoAlquilerInferible; inicio: Date } =>
+        !!item.inicio && item.cargo.habitacion_cargo_id !== null && item.cargo.inquilino_cargo_id !== null,
+    )
+    .sort((a, b) => a.inicio.getTime() - b.inicio.getTime() || a.cargo.id - b.cargo.id);
+
+  const periodos: Array<{
+    vivienda_id: number;
+    habitacion_id: number;
+    inquilino_id: number;
+    fecha_inicio: Date;
+    fecha_fin: Date;
+    estado: typeof ESTADOS_PERIODO_OCUPACION.PENDIENTE_REVISION;
+    origen: typeof ORIGENES_PERIODO_OCUPACION.INFERIDO_CARGO_ALQUILER;
+    renta_mensual: number;
+    requiere_revision: true;
+    notas: string;
+    gasto_ids: number[];
+  }> = [];
+
+  for (const { cargo, inicio } of validos) {
+    const habitacionId = cargo.habitacion_cargo_id!;
+    const inquilinoId = cargo.inquilino_cargo_id!;
+    const ultimo = periodos.length > 0 ? periodos[periodos.length - 1] : undefined;
+    const fin = mesSiguiente(inicio);
+
+    if (
+      ultimo &&
+      ultimo.vivienda_id === cargo.vivienda_id &&
+      ultimo.habitacion_id === habitacionId &&
+      ultimo.inquilino_id === inquilinoId &&
+      esMismoMes(ultimo.fecha_fin, inicio)
+    ) {
+      ultimo.fecha_fin = fin;
+      ultimo.gasto_ids.push(cargo.id);
+      ultimo.renta_mensual = cargo.importe;
+      continue;
+    }
+
+    periodos.push({
+      vivienda_id: cargo.vivienda_id,
+      habitacion_id: habitacionId,
+      inquilino_id: inquilinoId,
+      fecha_inicio: inicio,
+      fecha_fin: fin,
+      estado: ESTADOS_PERIODO_OCUPACION.PENDIENTE_REVISION,
+      origen: ORIGENES_PERIODO_OCUPACION.INFERIDO_CARGO_ALQUILER,
+      renta_mensual: cargo.importe,
+      requiere_revision: true,
+      notas: 'Periodo inferido desde cargos ALQUILER_HABITACION; revisar fechas reales de alta y baja.',
+      gasto_ids: [cargo.id],
+    });
+  }
+
+  return periodos;
+};
+
+export const crearPeriodosMigradosDesdeEstadoActual = async (fechaInicio = new Date()) => {
+  const habitaciones = await prisma.habitacion.findMany({
+    where: { inquilino_id: { not: null }, tipo: 'DORMITORIO', es_habitable: true },
+    select: { id: true, vivienda_id: true, inquilino_id: true, precio: true },
+  });
+
+  return db.$transaction((tx) =>
+    Promise.all(
+      habitaciones.map((habitacion) =>
+        registrarAltaOcupacion(tx as any, {
+          viviendaId: habitacion.vivienda_id,
+          habitacionId: habitacion.id,
+          inquilinoId: habitacion.inquilino_id!,
+          fechaInicio,
+          origen: ORIGENES_PERIODO_OCUPACION.MIGRADO,
+          rentaMensual: habitacion.precio,
+          requiereRevision: true,
+          notas: 'Periodo migrado desde la ocupacion actual; revisar fecha real de entrada.',
+        }),
+      ),
+    ),
+  );
+};

--- a/backend/tests/contrato-issue-337.test.ts
+++ b/backend/tests/contrato-issue-337.test.ts
@@ -22,6 +22,12 @@ const prisma = vi.hoisted(() => ({
   eventoContratoAlquiler: {
     create: async (_args: unknown): Promise<unknown> => ({}),
   },
+  periodoOcupacion: {
+    create: async (_args: unknown): Promise<unknown> => ({}),
+    findFirst: async (_args: unknown): Promise<unknown> => null,
+    update: async (_args: unknown): Promise<unknown> => ({}),
+    updateMany: async (_args: unknown): Promise<unknown> => ({ count: 0 }),
+  },
   $transaction: async (callback: (tx: unknown) => Promise<unknown>) => callback(prisma),
 }));
 
@@ -43,6 +49,10 @@ function resetPrisma() {
   prisma.contratoAlquiler.findUnique = async () => null;
   prisma.contratoAlquiler.update = async (args: any) => ({ id: args.where.id, ...args.data });
   prisma.eventoContratoAlquiler.create = async () => ({});
+  prisma.periodoOcupacion.create = async () => ({});
+  prisma.periodoOcupacion.findFirst = async () => null;
+  prisma.periodoOcupacion.update = async () => ({});
+  prisma.periodoOcupacion.updateMany = async () => ({ count: 0 });
 }
 
 beforeEach(() => {
@@ -146,17 +156,28 @@ describe('issue 337 - contratos de alquiler', () => {
 
   test('el inquilino solo firma contratos propios pendientes', async () => {
     let updateData: any;
+    let periodoCreate: any;
 
     prisma.contratoAlquiler.findFirst = async () => ({
       id: 99,
       version: 1,
       estado: 'PENDIENTE_FIRMA',
       documento_hash: 'a'.repeat(64),
+      vivienda: { id: 7 },
+      habitacion: { id: 3 },
+      inquilino_id: 20,
+      fecha_inicio: new Date('2026-06-01T00:00:00.000Z'),
+      fecha_fin: null,
+      renta_mensual: 450,
       inquilino: { id: 20, documento_identidad: '12345678Z' },
     });
     prisma.contratoAlquiler.update = async (args: any) => {
       updateData = args.data;
       return { id: args.where.id, ...args.data };
+    };
+    prisma.periodoOcupacion.create = async (args: any) => {
+      periodoCreate = args;
+      return { id: 1, ...args.data };
     };
 
     const response = await invoke(
@@ -169,6 +190,8 @@ describe('issue 337 - contratos de alquiler', () => {
     assert.equal(updateData.firma_usuario_id, 20);
     assert.equal(updateData.firma_documento_identidad, '12345678Z');
     assert.match(updateData.firma_origen_tecnico, /ua=vitest/);
+    assert.equal(periodoCreate.data.contrato_id, 99);
+    assert.equal(periodoCreate.data.origen, 'CONTRATO_FIRMADO');
   });
 
   test('el inquilino no lista contratos de otros ocupantes de la vivienda', async () => {

--- a/backend/tests/multitenant-security.test.ts
+++ b/backend/tests/multitenant-security.test.ts
@@ -25,6 +25,12 @@ const prisma = vi.hoisted(() => ({
       throw new Error('Unexpected prisma call: habitacion.update');
     },
   },
+  periodoOcupacion: {
+    findFirst: async (_args: unknown): Promise<unknown> => null,
+    updateMany: async (_args: unknown): Promise<unknown> => ({ count: 0 }),
+    create: async (_args: unknown): Promise<unknown> => ({}),
+    update: async (_args: unknown): Promise<unknown> => ({}),
+  },
   incidencia: {
     findUnique: async (_args: unknown): Promise<unknown> => {
       throw new Error('Unexpected prisma call: incidencia.findUnique');
@@ -41,6 +47,7 @@ const prisma = vi.hoisted(() => ({
       throw new Error('Unexpected prisma call: anuncio.delete');
     },
   },
+  $transaction: async (callback: (tx: unknown) => Promise<unknown>) => callback(prisma),
 }));
 
 function unexpectedPrismaCall(method: string): never {
@@ -64,6 +71,10 @@ function resetPrisma() {
   prisma.habitacion.findUnique = async (_args: unknown): Promise<unknown> => unexpectedPrismaCall('habitacion.findUnique');
   prisma.habitacion.findFirst = async (_args: unknown): Promise<unknown> => unexpectedPrismaCall('habitacion.findFirst');
   prisma.habitacion.update = async (_args: unknown): Promise<unknown> => unexpectedPrismaCall('habitacion.update');
+  prisma.periodoOcupacion.findFirst = async () => null;
+  prisma.periodoOcupacion.updateMany = async () => ({ count: 0 });
+  prisma.periodoOcupacion.create = async () => ({});
+  prisma.periodoOcupacion.update = async () => ({});
   prisma.incidencia.findUnique = async (_args: unknown): Promise<unknown> => unexpectedPrismaCall('incidencia.findUnique');
   prisma.incidencia.create = async (_args: unknown): Promise<unknown> => unexpectedPrismaCall('incidencia.create');
   prisma.anuncio.findUnique = async (_args: unknown): Promise<unknown> => unexpectedPrismaCall('anuncio.findUnique');

--- a/backend/tests/ocupacion-issue-338.test.ts
+++ b/backend/tests/ocupacion-issue-338.test.ts
@@ -1,0 +1,268 @@
+import assert from 'node:assert/strict';
+import { describe, test, vi } from 'vitest';
+import {
+  inferirPeriodosOcupacionDesdeCargos,
+  ORIGENES_PERIODO_OCUPACION,
+  registrarAltaOcupacion,
+  registrarBajaOcupacion,
+  registrarPeriodoContratoFirmado,
+} from '../src/services/ocupacion.service';
+import { construirFotoOcupacionFiscal } from '../src/services/fiscal.service';
+
+vi.mock('../src/lib/prisma', () => ({ prisma: {} }));
+
+const inquilinoAna = { id: 10, nombre: 'Ana', apellidos: 'Lopez' };
+const inquilinoLuis = { id: 11, nombre: 'Luis', apellidos: 'Garcia' };
+
+const viviendaBase = {
+  id: 1,
+  alias_nombre: 'Piso Centro',
+  direccion: 'Calle Luna 1',
+  codigo_postal: '28001',
+  ciudad: 'Madrid',
+  provincia: 'Madrid',
+};
+
+const habitacionAzul = {
+  id: 7,
+  nombre: 'Habitacion azul',
+  tipo: 'DORMITORIO',
+  es_habitable: true,
+  precio: 450,
+  inquilino_id: null,
+  inquilino: null,
+};
+
+const crearTxPeriodos = () => {
+  const periodos: any[] = [];
+  const coincide = (periodo: any, where: Record<string, any>) =>
+    Object.entries(where).every(([clave, valor]) => {
+      if (valor && typeof valor === 'object' && 'not' in valor) return periodo[clave] !== valor.not;
+      return periodo[clave] === valor;
+    });
+
+  return {
+    periodos,
+    periodoOcupacion: {
+      findFirst: async ({ where }: any) => periodos.find((periodo) => coincide(periodo, where)) ?? null,
+      updateMany: async ({ where, data }: any) => {
+        let count = 0;
+        for (const periodo of periodos) {
+          if (coincide(periodo, where)) {
+            Object.assign(periodo, data);
+            count += 1;
+          }
+        }
+        return { count };
+      },
+      create: async ({ data }: any) => {
+        const creado = { id: periodos.length + 1, ...data };
+        periodos.push(creado);
+        return creado;
+      },
+      update: async ({ where, data }: any) => {
+        const periodo = periodos.find((item) => item.id === where.id);
+        Object.assign(periodo, data);
+        return periodo;
+      },
+    },
+  };
+};
+
+describe('issue 338 - historico explicito de ocupacion', () => {
+  test('registra alta, baja y cambio de habitacion cerrando el periodo anterior', async () => {
+    const tx = crearTxPeriodos();
+
+    await registrarAltaOcupacion(tx as any, {
+      viviendaId: 1,
+      habitacionId: 7,
+      inquilinoId: 10,
+      fechaInicio: new Date('2026-01-01T00:00:00.000Z'),
+      rentaMensual: 450,
+    });
+    await registrarAltaOcupacion(tx as any, {
+      viviendaId: 1,
+      habitacionId: 8,
+      inquilinoId: 10,
+      fechaInicio: new Date('2026-03-01T00:00:00.000Z'),
+      rentaMensual: 500,
+    });
+    await registrarBajaOcupacion(tx as any, {
+      viviendaId: 1,
+      habitacionId: 8,
+      inquilinoId: 10,
+      fechaFin: new Date('2026-05-01T00:00:00.000Z'),
+    });
+
+    assert.equal(tx.periodos.length, 2);
+    assert.equal(tx.periodos[0].habitacion_id, 7);
+    assert.equal(tx.periodos[0].estado, 'FINALIZADO');
+    assert.equal(tx.periodos[0].fecha_fin.toISOString(), '2026-03-01T00:00:00.000Z');
+    assert.equal(tx.periodos[1].habitacion_id, 8);
+    assert.equal(tx.periodos[1].estado, 'FINALIZADO');
+    assert.equal(tx.periodos[1].fecha_fin.toISOString(), '2026-05-01T00:00:00.000Z');
+  });
+
+  test('conserva trazabilidad al reocupar una habitacion con otro inquilino', async () => {
+    const tx = crearTxPeriodos();
+
+    await registrarAltaOcupacion(tx as any, {
+      viviendaId: 1,
+      habitacionId: 7,
+      inquilinoId: 10,
+      fechaInicio: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    await registrarAltaOcupacion(tx as any, {
+      viviendaId: 1,
+      habitacionId: 7,
+      inquilinoId: 11,
+      fechaInicio: new Date('2026-02-01T00:00:00.000Z'),
+    });
+
+    assert.equal(tx.periodos.length, 2);
+    assert.deepEqual(
+      tx.periodos.map((periodo) => [periodo.inquilino_id, periodo.estado]),
+      [
+        [10, 'FINALIZADO'],
+        [11, 'ACTIVO'],
+      ],
+    );
+  });
+
+  test('el contrato firmado alimenta el historico reutilizable por fiscalidad', async () => {
+    const tx = crearTxPeriodos();
+
+    await registrarPeriodoContratoFirmado(tx as any, {
+      id: 99,
+      vivienda_id: 1,
+      habitacion_id: 7,
+      inquilino_id: 10,
+      fecha_inicio: new Date('2026-01-15T00:00:00.000Z'),
+      fecha_fin: new Date('2026-04-01T00:00:00.000Z'),
+      renta_mensual: 450,
+    });
+
+    assert.equal(tx.periodos[0].contrato_id, 99);
+    assert.equal(tx.periodos[0].origen, ORIGENES_PERIODO_OCUPACION.CONTRATO_FIRMADO);
+    assert.equal(tx.periodos[0].estado, 'FINALIZADO');
+  });
+
+  test('la firma de contrato actualiza una alta manual abierta sin duplicar periodos', async () => {
+    const tx = crearTxPeriodos();
+
+    await registrarAltaOcupacion(tx as any, {
+      viviendaId: 1,
+      habitacionId: 7,
+      inquilinoId: 10,
+      fechaInicio: new Date('2026-01-20T00:00:00.000Z'),
+      rentaMensual: 430,
+    });
+    await registrarPeriodoContratoFirmado(tx as any, {
+      id: 99,
+      vivienda_id: 1,
+      habitacion_id: 7,
+      inquilino_id: 10,
+      fecha_inicio: new Date('2026-01-01T00:00:00.000Z'),
+      fecha_fin: null,
+      renta_mensual: 450,
+    });
+
+    assert.equal(tx.periodos.length, 1);
+    assert.equal(tx.periodos[0].contrato_id, 99);
+    assert.equal(tx.periodos[0].origen, ORIGENES_PERIODO_OCUPACION.CONTRATO_FIRMADO);
+    assert.equal(tx.periodos[0].fecha_inicio.toISOString(), '2026-01-01T00:00:00.000Z');
+    assert.equal(tx.periodos[0].renta_mensual, 450);
+  });
+
+  test('infiere tramos heredados desde cargos de alquiler y los marca revisables', () => {
+    const periodos = inferirPeriodosOcupacionDesdeCargos([
+      {
+        id: 1,
+        vivienda_id: 1,
+        habitacion_cargo_id: 7,
+        inquilino_cargo_id: 10,
+        importe: 450,
+        periodo_facturacion: '2026-01',
+      },
+      {
+        id: 2,
+        vivienda_id: 1,
+        habitacion_cargo_id: 7,
+        inquilino_cargo_id: 10,
+        importe: 450,
+        periodo_facturacion: '2026-02',
+      },
+      {
+        id: 3,
+        vivienda_id: 1,
+        habitacion_cargo_id: 7,
+        inquilino_cargo_id: 11,
+        importe: 470,
+        periodo_facturacion: '2026-04',
+      },
+    ]);
+
+    assert.equal(periodos.length, 2);
+    assert.equal(periodos[0].fecha_inicio.toISOString(), '2026-01-01T00:00:00.000Z');
+    assert.equal(periodos[0].fecha_fin.toISOString(), '2026-03-01T00:00:00.000Z');
+    assert.deepEqual(periodos[0].gasto_ids, [1, 2]);
+    assert.equal(periodos[0].requiere_revision, true);
+    assert.equal(periodos[1].inquilino_id, 11);
+  });
+
+  test('fiscalidad usa periodos explicitos antes que cargos y contratos auxiliares', () => {
+    const foto = construirFotoOcupacionFiscal({
+      ejercicio: 2026,
+      vivienda: { ...viviendaBase, habitaciones: [habitacionAzul] },
+      gastos: [
+        {
+          id: 1,
+          concepto: 'Alquiler enero',
+          importe: 450,
+          tipo: 'ALQUILER_HABITACION',
+          fecha_creacion: new Date('2026-01-01T00:00:00.000Z'),
+          periodo_facturacion: '2026-01',
+          habitacion_cargo_id: 7,
+          inquilino_cargo_id: 10,
+          prorrateo_fiscal: null,
+          inquilino_cargo: inquilinoAna,
+        },
+      ],
+      contratos: [
+        {
+          id: 50,
+          version: 1,
+          estado: 'FIRMADO',
+          documento_hash: 'a'.repeat(64),
+          renta_mensual: 450,
+          fecha_inicio: new Date('2026-02-01T00:00:00.000Z'),
+          fecha_fin: new Date('2026-03-01T00:00:00.000Z'),
+          habitacion_id: 7,
+          inquilino_id: 10,
+          inquilino: inquilinoAna,
+        },
+      ],
+      periodosOcupacion: [
+        {
+          id: 70,
+          estado: 'ACTIVO',
+          origen: 'ALTA_MANUAL',
+          fecha_inicio: new Date('2026-01-15T00:00:00.000Z'),
+          fecha_fin: new Date('2026-04-01T00:00:00.000Z'),
+          habitacion_id: 7,
+          inquilino_id: 10,
+          contrato_id: null,
+          renta_mensual: 450,
+          requiere_revision: false,
+          inquilino: inquilinoAna,
+        },
+      ],
+    });
+
+    assert.equal(foto.habitaciones[0].periodos.length, 1);
+    assert.equal(foto.habitaciones[0].periodos[0].fuente, 'PERIODO_OCUPACION');
+    assert.equal(foto.habitaciones[0].periodos[0].periodo_ocupacion_id, 70);
+    assert.equal(foto.habitaciones[0].periodos[0].dias, 76);
+    assert.equal(foto.habitaciones[0].periodos[0].inquilino?.id, inquilinoAna.id);
+  });
+});

--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -1614,9 +1614,10 @@ Devuelve la foto anual de ocupacion fiscal de una vivienda, con detalle por habi
 - `ejercicio` es obligatorio y representa un ano natural.
 
 **Comportamiento:**
-- Usa cargos `ALQUILER_HABITACION` con `periodo_facturacion` mensual (`YYYY-MM`) para calcular dias alquilados, meses equivalentes y porcentaje de ocupacion.
+- Usa `PeriodoOcupacion` como fuente preferente para calcular dias alquilados, meses equivalentes y porcentaje de ocupacion.
+- Si una habitacion no tiene periodos explicitos, cae a contratos firmados y despues a cargos `ALQUILER_HABITACION` con `periodo_facturacion` mensual (`YYYY-MM`) como compatibilidad heredada.
 - Distingue viviendas y habitaciones `SIN_ACTIVIDAD`, `PARCIAL` y `TODO_EL_ANO`.
-- Marca `requiere_revision` cuando faltan periodos de facturacion, hay ocupacion actual sin cargos del ejercicio o una habitacion con actividad no conserva precio valido.
+- Marca `requiere_revision` cuando faltan periodos de facturacion, hay ocupacion actual sin periodos/cargos del ejercicio, una habitacion con actividad no conserva precio valido o el periodo explicito procede de una migracion/inferencia revisable.
 - Prorratea gastos del flujo del casero por porcentaje manual (`prorrateo_fiscal`) cuando existe; si no, usa el porcentaje anual de ocupacion de la vivienda.
 
 **Respuestas:**

--- a/docs/backend/contrato-fiscal-propietario.md
+++ b/docs/backend/contrato-fiscal-propietario.md
@@ -14,6 +14,7 @@ Este contrato define los datos internos que Roomies debe preparar para convertir
 | `Gasto` | Documento economico emitido o registrado. | `id`, `concepto`, `importe`, `tipo`, `factura_url`, `categoria_fiscal`, `deducible_previsto`, `notas_fiscales`, `prorrateo_fiscal`, `fecha_creacion`, `periodo_facturacion`, `habitacion_cargo_id`, `inquilino_cargo_id`, `vivienda_id`, `pagador_id` |
 | `GastoRecurrente` | Plantilla de cargos mensuales futuros. | `id`, `concepto`, `importe`, `tipo`, `dia_del_mes`, `vivienda_id`, `pagador_id`, `activo` |
 | `Deuda` | Linea exigible/cobrada asociada a un gasto. | `id`, `gasto_id`, `deudor_id`, `acreedor_id`, `importe`, `estado`, `justificante_url` |
+| `PeriodoOcupacion` | Historico explicito de alta, baja, contrato o inferencia por habitacion/inquilino. | `vivienda_id`, `habitacion_id`, `inquilino_id`, `contrato_id`, `fecha_inicio`, `fecha_fin`, `estado`, `origen`, `renta_mensual`, `requiere_revision` |
 | Facturas | Soporte documental del gasto o cargo emitido. | `Gasto.factura_url` |
 | Justificantes | Evidencia de pago aportada por el deudor. | `Deuda.justificante_url` |
 
@@ -164,6 +165,8 @@ type FiscalResumenPropietarioDTO = {
 - Para ingresos, la linea fiscal principal debe partir de `Deuda`, no solo de `Gasto`, porque el estado cobrado/pendiente vive en `Deuda.estado` y el importe puede estar repartido por inquilino.
 - `Gasto.importe` se usa como importe emitido agregado del documento; `Deuda.importe` se usa para imputacion por inquilino y estado de cobro.
 - `Habitacion` e `inquilino` son opcionales excepto en `ALQUILER_HABITACION`, donde deben recuperarse desde `habitacion_cargo_id` e `inquilino_cargo_id` si siguen disponibles.
+- Para ocupacion y prorrateo, `PeriodoOcupacion` es la fuente preferente. Los contratos firmados y cargos `ALQUILER_HABITACION` quedan como respaldo cuando una habitacion aun no tiene historico explicito.
+- Los periodos con origen `INFERIDO_CARGO_ALQUILER` o `MIGRADO` deben conservar `requiere_revision` hasta que el casero o un flujo contractual confirme las fechas reales.
 - `factura_url` documenta el soporte del cargo o gasto; `justificante_url` documenta el pago de una deuda concreta.
 - Los importes deben sumarse en centimos y exponerse normalizados a euros para evitar descuadres por `Float`.
 - Las lineas sin factura o sin categoria fiscal futura deben aparecer como pendientes de revision, no como deducibles confirmados.

--- a/docs/changelog/issue-338-historico-ocupacion.md
+++ b/docs/changelog/issue-338-historico-ocupacion.md
@@ -1,0 +1,23 @@
+# Issue 338 - Historico explicito de ocupacion
+
+## Objetivo
+
+Persistir periodos historicos de ocupacion por vivienda, habitacion e inquilino para que el modo fiscal no dependa solo de cargos mensuales de alquiler.
+
+## Cambios principales
+
+- Nuevo modelo `PeriodoOcupacion` con fechas de inicio/fin, estado, origen, renta mensual, contrato asociado opcional y marca `requiere_revision`.
+- Nuevos enums `EstadoPeriodoOcupacion` y `OrigenPeriodoOcupacion` (`CONTRATO_FIRMADO`, `ALTA_MANUAL`, `INFERIDO_CARGO_ALQUILER`, `MIGRADO`).
+- El flujo de unirse a una habitacion abre un periodo de ocupacion; abandonar o expulsar cierra el periodo activo.
+- La firma de un contrato alimenta el historico con origen `CONTRATO_FIRMADO`, dejando una API interna reutilizable por el flujo de contratos.
+- La foto fiscal de ocupacion usa `PeriodoOcupacion` como fuente preferente, con contratos firmados y cargos de alquiler como respaldo heredado.
+- Se anade utilidad para inferir tramos desde cargos `ALQUILER_HABITACION` y marcarlos como revisables.
+
+## Documentacion
+
+- `docs/backend/api.md`
+- `docs/backend/contrato-fiscal-propietario.md`
+
+## Verificacion
+
+- `npm test -- ocupacion-issue-338.test.ts contrato-issue-337.test.ts fiscal.service.test.ts multitenant-security.test.ts`


### PR DESCRIPTION
## Objetivo
Persistir un histórico explícito de altas, bajas, cambios de habitación y contratos para que el cálculo fiscal deje de depender solo de cargos mensuales y pueda distinguir periodos reales, inferidos y revisables.

## Cambios principales
* Se añade el modelo `PeriodoOcupacion` en Prisma con estado, origen, fechas, renta mensual, contrato asociado y marca de revisión.
* Los flujos de `unirse`, `abandonar`, `expulsar` y `firmar contrato` crean, cierran o actualizan periodos de ocupación sin romper el comportamiento actual.
* El servicio fiscal prioriza `PeriodoOcupacion` como fuente de ocupación, dejando contratos firmados y cargos `ALQUILER_HABITACION` como respaldo heredado.
* Se incorpora inferencia de periodos a partir de cargos existentes y se marca como revisable cuando faltan certezas suficientes.
* Se añaden tests para alta, baja, cambio de habitación, reocupación, migración/inferencia y protección multitenant del histórico.

## UI / UX (Solo si aplica)
* No aplica.

## Changelog
* `docs/changelog/issue-338-historico-ocupacion.md`