### PR TITLE
[Épica Fiscal] Cierre documental de la preparación fiscal

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,6 +34,14 @@ Aplicación móvil de gestión de pisos compartidos. Hay dos roles:
 
 ## Actualizaciones recientes
 
+### Cierre fiscal del propietario (Epica Fiscal)
+
+- El modo fiscal del casero esta cerrado documentalmente en `docs/backend/fiscal-cierre-epica.md`, con flujo extremo a extremo, contrato de exportacion, checklist manual, matriz issue -> archivos -> tests y riesgos residuales.
+- El backend expone `GET /api/viviendas/:viviendaId/fiscal/:ejercicio`, `GET /api/viviendas/:viviendaId/fiscal/ocupacion?ejercicio=YYYY` y `GET /api/viviendas/:viviendaId/fiscal/:ejercicio/dossier`; todos son de casero propietario con `mod_gastos` activo.
+- El dossier fiscal exporta CSV con secciones `RESUMEN` y `DETALLE`, minimiza datos personales de inquilinos y marca `FALTA_FACTURA`, `FALTA_CATEGORIA`, `IMPORTE_PENDIENTE`, `PERIODO_INCOMPLETO` y `PRORRATEO_MANUAL`.
+- La pantalla `frontend/app/casero/(tabs)/fiscal.tsx` permite seleccionar vivienda/ejercicio, revisar ocupacion, editar metadatos fiscales y exportar CSV movil con `formato=base64`.
+- `ContratoAlquiler`, `EventoContratoAlquiler` y `PeriodoOcupacion` alimentan trazabilidad contractual y ocupacion fiscal; la firma interna no equivale a firma electronica avanzada/cualificada y debe validarse con proveedor si se requiere.
+
 ### Limpieza, inventario legal y cierre funcional (Epica 17)
 
 - El modulo de limpieza se reparte por habitaciones responsables: `ZonaLimpieza` puede vincularse a una habitacion objetivo, `AsignacionLimpiezaFija` guarda `habitacion_id` y `TurnoLimpieza` conserva `habitacion_id` como responsable estable con `usuario_id` solo como snapshot del ocupante al generar.
@@ -722,6 +730,16 @@ El seed demo crea gastos puntuales, deudas del casero, deudas entre inquilinos y
   - El inquilino ve tareas asociadas a su habitacion responsable y contexto de zonas comunes.
   - Login, registro, rol y perfil muestran documentos legales versionados; registro y selector de rol exigen aceptacion explicita cuando aplica.
   - Inventario del casero muestra estados de validacion y respeta modo claro/oscuro.
+
+## Update 2026-05-06 - Cierre epica fiscal
+
+- Backend:
+  - El resumen anual, la foto de ocupacion y el dossier fiscal quedan documentados como contrato de propietario en `docs/backend/api.md`.
+  - `docs/backend/fiscal-cierre-epica.md` centraliza checklist manual, matriz de issues #323-#330/#337/#338, pruebas relevantes y riesgos fiscales/legales.
+  - `docs/backend/contrato-fiscal-propietario.md` aclara limites de firma interna, dossier CSV y revision profesional.
+- Frontend:
+  - `docs/frontend/setup.md` documenta la tab `Fiscal`, estados principales, endpoints consumidos y exportacion base64.
+  - El cierre explicita que los inquilinos no tienen tab fiscal ni acceso a metadatos fiscales privados.
 
 ## Update 2026-04-10 - Cobros, mensualidades y push (Epica 12)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Roomies
 
-Aplicacion movil para gestionar pisos compartidos. Conecta a caseros e inquilinos para centralizar viviendas, incidencias, tablones, limpieza, inventario y ahora tambien cobros recurrentes con recordatorios push.
+Aplicacion movil para gestionar pisos compartidos. Conecta a caseros e inquilinos para centralizar viviendas, incidencias, tablones, limpieza, inventario, contratos, cobros recurrentes y preparacion fiscal del propietario.
 
 ## Que incluye hoy
 
@@ -9,14 +9,15 @@ Aplicacion movil para gestionar pisos compartidos. Conecta a caseros e inquilino
 - Gestion multipropiedad con alta de viviendas y habitaciones.
 - Centro de mando por vivienda con resumen, incidencias, tablon y limpieza.
 - Limpieza por habitaciones responsables, asignaciones fijas y exportacion CSV compatible con Excel.
-- Pestanas globales de `Mis viviendas`, `Cobros`, `Inventario`, `Tablon` y `Perfil`.
+- Pestanas globales de `Mis viviendas`, `Cobros`, `Fiscal`, `Contratos`, `Inventario`, `Tablon` y `Perfil`.
 - Dashboard de cobros mensuales con detalle de deudas pagadas, pendientes y justificantes.
 - Inventario por vivienda con subida de imagenes a Cloudinary y estado de validacion del inquilino.
+- Modo fiscal con resumen anual, ocupacion, revision de metadatos, contratos/historico como soporte y exportacion CSV para gestoria.
 
 ### Inquilino
 
 - Onboarding por codigo de invitacion y dashboard de vivienda.
-- Tablon, limpieza, gastos, inventario y perfil en navegacion principal.
+- Tablon, limpieza, gastos, inventario, contratos y perfil en navegacion principal.
 - Gestion de gastos puntuales y mensualidades.
 - Subida de justificantes de pago y saldado de deudas desde la app.
 - Check-in visual del inventario con conformidad por item visible: vivienda, zonas comunes y habitacion propia.
@@ -54,6 +55,8 @@ Aplicacion movil para gestionar pisos compartidos. Conecta a caseros e inquilino
 - [x] Cobros mensuales del casero
 - [x] Mensualidades recurrentes
 - [x] Recordatorios de pago por push
+- [x] Modo fiscal para casero y dossier CSV revisable
+- [x] Contratos de alquiler con firma interna e historico de ocupacion
 - [ ] Chat integrado Inquilino <-> Casero
 - [ ] Notificaciones push avanzadas para incidencias y cambios de estado
 
@@ -184,6 +187,8 @@ Los tests cargan valores de entorno de prueba y no necesitan `.env` privados. El
 | Contexto de proyecto | `CONTEXT.md` |
 | Setup backend | `docs/backend/setup.md` |
 | API REST | `docs/backend/api.md` |
+| Contrato fiscal propietario | `docs/backend/contrato-fiscal-propietario.md` |
+| Cierre epica fiscal | `docs/backend/fiscal-cierre-epica.md` |
 | Setup frontend | `docs/frontend/setup.md` |
 | Infraestructura y despliegue | `docs/infra/setup-despliegue.md` |
 | Changelog tecnico | `docs/changelog/` |

--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -1496,6 +1496,8 @@ Anula un contrato pendiente o rechazado. Solo puede hacerlo el casero propietari
 
 ## Fiscal (`/viviendas/:viviendaId`)
 
+El flujo fiscal completo y el checklist manual de cierre estan documentados en `docs/backend/fiscal-cierre-epica.md`. Todos los endpoints de esta seccion son superficies de propietario: no exponen metadatos fiscales privados a inquilinos y dependen del modulo de gastos de la vivienda.
+
 ### GET `/viviendas/:viviendaId/fiscal/:ejercicio`
 
 Devuelve el resumen fiscal anual del propietario para una vivienda concreta, con totales auditables, detalle linea a linea y advertencias de revision.
@@ -1592,6 +1594,11 @@ Descarga un dossier fiscal anual en CSV compatible con Excel para revisar o envi
 - El CSV minimiza datos personales de inquilinos: conserva referencia interna y nombre para trazabilidad de cobros, pero no exporta `documento_identidad`, email ni telefono.
 - Las lineas con importes pendientes, facturas ausentes, categorias fiscales pendientes, periodos incompletos o prorrateos manuales quedan marcadas en la columna `Advertencias`.
 - Las referencias documentales se incluyen como URL (`factura_url` y `justificante_url`) sin duplicar archivos pesados.
+
+**Limites del dossier:**
+- Roomies prepara un dossier revisable, no un modelo tributario oficial.
+- Las categorias, deducibilidad y prorrateos deben confirmarse con asesor fiscal o normativa oficial actualizada.
+- La firma interna de contratos aporta trazabilidad operativa, pero no sustituye un proveedor de firma electronica avanzada/cualificada.
 
 **Respuestas:**
 
@@ -2275,3 +2282,9 @@ Marca un turno como `HECHO`. No tiene body.
 - Inventario guarda quien valido cada item y cuando lo hizo. El listado de casero incluye `revisado_por_inquilino_user`; el de inquilino queda filtrado a vivienda, zonas comunes y habitacion propia.
 - Limpieza usa habitaciones responsables para asignaciones fijas y turnos; `usuario_id` en turnos es un snapshot opcional del ocupante al generar.
 - La exportacion CSV de limpieza puede devolverse como `formato=base64` para escritura nativa movil compatible con Excel.
+
+## Update 2026-05-06 - Cierre epica fiscal
+
+- `GET /api/viviendas/:viviendaId/fiscal/:ejercicio`, `GET /api/viviendas/:viviendaId/fiscal/ocupacion` y `GET /api/viviendas/:viviendaId/fiscal/:ejercicio/dossier` quedan documentados como flujo fiscal completo de propietario.
+- `docs/backend/fiscal-cierre-epica.md` centraliza contrato de exportacion, columnas, checklist manual, matriz issue-archivos-tests y riesgos residuales.
+- El dossier CSV se declara soporte de revision para gestor, no declaracion oficial ni sustituto de asesor fiscal.

--- a/docs/backend/contrato-fiscal-propietario.md
+++ b/docs/backend/contrato-fiscal-propietario.md
@@ -4,6 +4,8 @@
 
 Este contrato define los datos internos que Roomies debe preparar para convertir la actividad economica de alquiler en un resumen fiscal revisable por el casero o por su gestor. La app consolida fuentes, importes, fechas, estados y justificantes; no decide por si sola todas las casuisticas fiscales ni sustituye una revision profesional.
 
+El cierre funcional de la epica, checklist manual, matriz de issues y riesgos residuales viven en `docs/backend/fiscal-cierre-epica.md`.
+
 ## Fuentes auditadas
 
 | Modelo | Uso fiscal | Campos relevantes |
@@ -178,3 +180,5 @@ type FiscalResumenPropietarioDTO = {
 - `GastoRecurrente` no representa un hecho economico hasta generar un `Gasto`.
 - La ausencia de `documento_identidad` en usuarios no bloquea el contrato, pero debe marcarse como dato incompleto en exportaciones fiscales.
 - Las categorias fiscales futuras no deben inferirse desde `concepto` ni desde nombres de vivienda/habitacion.
+- La firma interna de contratos conserva trazabilidad operativa, hash y aceptacion, pero no equivale a firma electronica avanzada o cualificada sin proveedor especializado.
+- El dossier CSV es soporte de revision para gestor; no es un modelo tributario oficial ni valida normativa vigente.

--- a/docs/backend/fiscal-cierre-epica.md
+++ b/docs/backend/fiscal-cierre-epica.md
@@ -1,0 +1,154 @@
+# Cierre de epica fiscal
+
+## Objetivo
+
+Este documento deja una foto de cierre de la epica fiscal. Roomies prepara datos de alquiler, ocupacion, contratos, cobros, facturas y justificantes para que el casero pueda revisarlos o compartirlos con su gestoria. La app no sustituye asesoramiento fiscal, no interpreta normativa oficial en tiempo real y no convierte la firma interna en firma electronica avanzada o cualificada.
+
+## Flujo extremo a extremo
+
+1. El casero mantiene una vivienda con `mod_gastos = true`, habitaciones habitables, inquilinos activos y, si aplica, contratos subidos o firmados.
+2. Los gastos y cobros se registran como `Gasto`, `Deuda`, `GastoRecurrente`, facturas originales y justificantes de pago.
+3. Los metadatos fiscales privados del propietario viven en `Gasto`: `categoria_fiscal`, `deducible_previsto`, `notas_fiscales` y `prorrateo_fiscal`.
+4. El historico de ocupacion se construye preferentemente con `PeriodoOcupacion`; los contratos firmados y los cargos `ALQUILER_HABITACION` quedan como respaldo heredado.
+5. La pantalla `/casero/fiscal` permite seleccionar vivienda y ejercicio, revisar resumen, ocupacion, avisos, lineas fiscales y editar metadatos de gastos.
+6. El casero exporta el dossier anual desde `GET /api/viviendas/:viviendaId/fiscal/:ejercicio/dossier`; el frontend usa `formato=base64` para guardar el CSV desde movil.
+7. El CSV resultante se revisa fuera de Roomies con gestor o asesor fiscal antes de presentarlo o usarlo como soporte declarativo.
+
+## Contrato de exportacion del dossier
+
+Endpoint: `GET /api/viviendas/:viviendaId/fiscal/:ejercicio/dossier`
+
+Permisos:
+
+- Solo `CASERO` propietario de la vivienda.
+- Requiere autenticacion Bearer.
+- Requiere `mod_gastos` activo en la vivienda.
+- Rechaza viviendas ajenas y usuarios `INQUILINO`.
+
+Formatos:
+
+| Formato | Respuesta | Uso |
+|---|---|---|
+| Sin query | `text/csv; charset=utf-8` con `Content-Disposition` | Descarga directa desde cliente web o API. |
+| `?formato=base64` | JSON `{ nombreArchivo, mimeType, columnas, contenidoBase64 }` | Escritura movil desde Expo/FileSystem. |
+
+Nombre de archivo: `dossier-fiscal-{vivienda}-{ejercicio}-{fecha-generacion}.csv`.
+
+Columnas estables:
+
+| Seccion | Columnas |
+|---|---|
+| `RESUMEN` | `Clave`, `Valor`, `Moneda`, `Notas` |
+| `DETALLE` | `Linea ID`, `Naturaleza`, `Modelo origen`, `Gasto ID`, `Deuda ID`, `Concepto`, `Categoria`, `Deducibilidad`, `Importe`, `Moneda`, `Fecha`, `Periodo facturacion`, `Estado pago`, `Factura URL`, `Justificante URL`, `Habitacion ID`, `Habitacion`, `Inquilino ID`, `Inquilino`, `Advertencias` |
+
+Minimizacion de datos:
+
+- No exporta documento de identidad, email ni telefono de inquilinos.
+- Conserva `Inquilino ID` y nombre para trazabilidad operativa de cobros.
+- Incluye URLs de factura y justificante como referencias documentales; no duplica binarios dentro del CSV.
+- Escapa contenido para evitar formula injection al abrir el CSV en hojas de calculo.
+
+Advertencias posibles:
+
+| Codigo | Significado | Accion manual esperada |
+|---|---|---|
+| `FALTA_FACTURA` | La linea no tiene soporte documental adjunto. | Adjuntar factura o marcarla como no deducible segun criterio profesional. |
+| `FALTA_CATEGORIA` | `categoria_fiscal = SIN_CLASIFICAR`. | Clasificar el gasto antes de cerrar el dossier. |
+| `IMPORTE_PENDIENTE` | Hay cobros pendientes. | Verificar si se declara por caja, devengo o criterio aplicable con asesor. |
+| `PERIODO_INCOMPLETO` | Falta informacion de periodo/ocupacion. | Revisar historico de alta/baja, contrato o cargo mensual. |
+| `PRORRATEO_MANUAL` | El propietario fijo un porcentaje manual. | Confirmar que el porcentaje responde al criterio fiscal correcto. |
+
+## Pantalla fiscal de casero
+
+Ruta frontend: `frontend/app/casero/(tabs)/fiscal.tsx`
+
+Visibilidad:
+
+- Solo existe en tabs de casero.
+- El layout global de casero la muestra cuando al menos una vivienda tiene `mod_gastos` activo.
+- No hay tab fiscal para inquilino.
+
+Estados principales:
+
+| Estado | Comportamiento |
+|---|---|
+| Sin viviendas activas | Muestra estado vacio y pide crear vivienda o activar gastos. |
+| Cargando | Carga viviendas, resumen anual y ocupacion. |
+| Error | Muestra mensaje del backend o error generico de modo fiscal. |
+| Con datos | Permite cambiar vivienda/ejercicio, revisar KPIs, ocupacion, advertencias, ingresos, gastos y exportar. |
+| Editando linea | Abre modal para categoria, deducibilidad prevista, notas y prorrateo manual. |
+
+Endpoints consumidos:
+
+| Accion | Endpoint |
+|---|---|
+| Listar viviendas del casero | `GET /api/viviendas` |
+| Cargar resumen fiscal | `GET /api/viviendas/:viviendaId/fiscal/:ejercicio` |
+| Cargar ocupacion fiscal | `GET /api/viviendas/:viviendaId/fiscal/ocupacion?ejercicio=YYYY` |
+| Actualizar metadatos de gasto | `PATCH /api/viviendas/:viviendaId/gastos/:gastoId` |
+| Exportar CSV movil | `GET /api/viviendas/:viviendaId/fiscal/:ejercicio/dossier?formato=base64` |
+
+## Checklist manual reproducible
+
+Preparacion de datos:
+
+- Crear una vivienda de casero con `mod_gastos = true`, tres dormitorios habitables y al menos dos inquilinos.
+- Configurar precios privados por habitacion.
+- Registrar un contrato pendiente y firmarlo con un inquilino.
+- Unir un segundo inquilino sin contrato firmado para conservar contraste de fuentes.
+- Generar o registrar al menos un periodo parcial de ocupacion con alta/baja o cambio de habitacion.
+
+Cobros e ingresos:
+
+- Crear una mensualidad recurrente y verificar que el cron o seed genera cargos del ejercicio.
+- Crear una factura puntual con factura adjunta.
+- Crear una factura puntual sin factura adjunta.
+- Marcar una deuda como `PAGADA` con justificante.
+- Dejar otra deuda como `PENDIENTE`.
+
+Gastos y revision fiscal:
+
+- Clasificar un gasto como `SEGUROS` o `SUMINISTROS`.
+- Dejar un gasto como `SIN_CLASIFICAR`.
+- Editar una linea con `prorrateo_fiscal` manual.
+- Verificar que el inquilino no ve `categoria_fiscal`, `deducible_previsto`, `notas_fiscales` ni `prorrateo_fiscal` en su pantalla de gastos.
+
+Modo fiscal:
+
+- Abrir `/casero/fiscal`.
+- Cambiar vivienda y ejercicio.
+- Confirmar que el resumen separa ingresos emitidos, cobrados, pendientes y gastos por categoria.
+- Confirmar que la ocupacion muestra vivienda, habitaciones, periodos, porcentaje anual y avisos de revision.
+- Abrir el editor de linea fiscal, guardar categoria/notas/prorrateo y recargar.
+- Exportar CSV y abrirlo en Excel/LibreOffice comprobando acentos, columnas y advertencias.
+
+Permisos y errores:
+
+- Entrar como inquilino y confirmar que no existe tab fiscal.
+- Llamar a endpoints fiscales como inquilino y esperar `403`.
+- Desactivar `mod_gastos` en la vivienda y confirmar que endpoints y tabs protegidos quedan bloqueados u ocultos.
+- Intentar consultar una vivienda ajena con un casero diferente y esperar `403` o `404` segun endpoint.
+
+## Matriz de cierre
+
+| Issue | Estado | Archivos principales | Tests documentados |
+|---|---|---|---|
+| #323 contrato de datos | Cerrado documental | `docs/backend/contrato-fiscal-propietario.md`, `backend/prisma/schema.prisma`, `backend/src/services/gasto.service.ts`, `backend/src/controllers/cobros.controller.ts` | Revision documental contra modelos y servicios existentes. |
+| #324 metadatos fiscales | Entregado | `backend/prisma/schema.prisma`, `backend/src/services/gasto.service.ts`, `backend/src/controllers/gasto.controller.ts`, `backend/src/controllers/cobros.controller.ts` | `backend/tests/economico.test.ts` |
+| #325 ocupacion y prorrateos | Entregado | `backend/src/services/fiscal.service.ts`, `backend/src/controllers/fiscal.controller.ts`, `backend/src/routes/fiscal.routes.ts`, `docs/backend/api.md` | `backend/tests/fiscal.service.test.ts`, `backend/tests/fiscal.controller.test.ts` |
+| #326 resumen anual | Entregado | `backend/src/services/fiscal.service.ts`, `backend/src/controllers/fiscal.controller.ts`, `docs/backend/api.md` | `backend/tests/fiscal.service.test.ts`, `backend/tests/fiscal.controller.test.ts` |
+| #327 dossier fiscal | Entregado | `backend/src/services/fiscal.service.ts`, `backend/src/controllers/fiscal.controller.ts`, `docs/backend/api.md` | `backend/tests/fiscal.service.test.ts`, `backend/tests/fiscal.controller.test.ts` |
+| #328 modo fiscal casero | Entregado | `frontend/app/casero/(tabs)/fiscal.tsx`, `frontend/app/casero/(tabs)/_layout.tsx`, `frontend/styles/casero/fiscal.styles.ts` | `frontend/app/__tests__/fiscal.test.tsx`, `frontend/app/__tests__/navigation-smoke.test.tsx` |
+| #329 privacidad y trazabilidad | Entregado | `backend/src/routes/fiscal.routes.ts`, `backend/src/services/fiscal.service.ts`, `docs/changelog/EpicaFiscal/epica-fiscal-issue-329-privacidad-trazabilidad.md` | `backend/tests/fiscal.service.test.ts`, `backend/tests/fiscal.controller.test.ts`, `backend/tests/economico.test.ts`, `frontend/app/__tests__/fiscal.test.tsx` |
+| #337 contratos y firma interna | Incluido en cierre | `backend/prisma/schema.prisma`, `backend/src/controllers/contrato.controller.ts`, `backend/src/routes/contrato.routes.ts`, `frontend/components/contratos/ContratosAlquilerScreen.tsx` | `backend/tests/contrato-issue-337.test.ts`, `backend/tests/fiscal.service.test.ts` |
+| #338 historico explicito de ocupacion | Incluido en cierre | `backend/prisma/schema.prisma`, `backend/src/services/ocupacion.service.ts`, `backend/src/services/fiscal.service.ts`, `backend/src/controllers/inquilino.controller.ts`, `backend/src/controllers/vivienda.controller.ts` | `backend/tests/ocupacion-issue-338.test.ts`, `backend/tests/contrato-issue-337.test.ts`, `backend/tests/fiscal.service.test.ts`, `backend/tests/multitenant-security.test.ts` |
+| #330 cierre documental | Entregado en esta rama | `CONTEXT.md`, `README.md`, `docs/backend/api.md`, `docs/backend/contrato-fiscal-propietario.md`, `docs/backend/fiscal-cierre-epica.md`, `docs/frontend/setup.md`, `docs/changelog/EpicaFiscal/epica-fiscal-issue-330-cierre.md` | Revision documental, `npm test -- fiscal.service.test.ts fiscal.controller.test.ts contrato-issue-337.test.ts ocupacion-issue-338.test.ts` y `npm test -- fiscal.test.tsx navigation-smoke.test.tsx`. |
+
+## Riesgos residuales
+
+- Confirmar con asesor fiscal el tratamiento de gastos deducibles, prorratas, criterio de caja/devengo, uso mixto de vivienda y documentacion exigible por normativa vigente.
+- Las categorias fiscales son ayuda operativa; no constituyen calificacion legal automatica.
+- Las URLs de Cloudinary se entregan solo por endpoints protegidos, pero si el recurso remoto es publico haran falta URLs firmadas o proxy privado para confidencialidad fuerte.
+- La firma interna registra aceptacion, version, hash, usuario y origen tecnico, pero no equivale a firma electronica avanzada o cualificada. Para ese nivel hace falta proveedor especializado.
+- El CSV es un dossier de revision, no un modelo tributario oficial.
+- Los periodos migrados o inferidos conservan `requiere_revision`; deben confirmarse manualmente antes de cerrar un ejercicio real.

--- a/docs/changelog/EpicaFiscal/epica-fiscal-issue-330-cierre.md
+++ b/docs/changelog/EpicaFiscal/epica-fiscal-issue-330-cierre.md
@@ -1,0 +1,26 @@
+# Epica Fiscal - Issue 330 - Documentacion, tests y cierre
+
+## Objetivo
+
+Cerrar la epica fiscal con documentacion de extremo a extremo, checklist manual, matriz de trazabilidad y riesgos legales/fiscales residuales.
+
+## Cambios principales
+
+- Se anade `docs/backend/fiscal-cierre-epica.md` como documento de cierre funcional y tecnico.
+- Se documentan contrato de exportacion, columnas del dossier fiscal, permisos, minimizacion de datos y advertencias del CSV.
+- Se documenta la pantalla fiscal de casero: ruta, visibilidad, estados, endpoints consumidos y flujo de revision/exportacion.
+- Se incorpora checklist manual para vivienda realista con varios inquilinos, facturas con/sin adjunto, gastos sin clasificar, periodos parciales, prorrateo manual, export y errores de permisos.
+- Se deja una matriz issue -> archivos principales -> tests -> estado para #323-#330, #337 y #338.
+- Se actualizan `CONTEXT.md`, `README.md`, `docs/backend/api.md`, `docs/frontend/setup.md` y `docs/backend/contrato-fiscal-propietario.md` con enlaces y limites de cierre.
+
+## Verificacion ejecutada
+
+- `cd backend && npm test -- fiscal.service.test.ts fiscal.controller.test.ts contrato-issue-337.test.ts ocupacion-issue-338.test.ts`
+- `cd frontend && npm test -- fiscal.test.tsx navigation-smoke.test.tsx`
+- Checklist manual de `docs/backend/fiscal-cierre-epica.md`.
+
+## Riesgos residuales
+
+- Roomies no sustituye revision profesional de asesor fiscal ni normativa oficial actualizada.
+- La firma interna no equivale a firma electronica avanzada o cualificada.
+- Las URLs de documentos se entregan por endpoints protegidos, pero no son todavia un sistema de acceso documental privado con URL firmada/proxy.

--- a/docs/frontend/setup.md
+++ b/docs/frontend/setup.md
@@ -95,6 +95,8 @@ frontend/
         _layout.tsx
         viviendas.tsx
         cobros.tsx
+        fiscal.tsx
+        contratos.tsx
         inventario.tsx
         tablon.tsx
         perfil.tsx
@@ -120,6 +122,7 @@ frontend/
         limpieza.tsx
         gastos.tsx
         inventario.tsx
+        contratos.tsx
         perfil.tsx
     tablon/
       [viviendaId].tsx
@@ -161,6 +164,8 @@ frontend/
 | `/legal/privacidad` | `app/legal/privacidad.tsx` | Politica de privacidad versionada |
 | `/casero/viviendas` | `casero/(tabs)/viviendas.tsx` | Lista de viviendas del casero |
 | `/casero/cobros` | `casero/(tabs)/cobros.tsx` | Resumen mensual de cobros por vivienda |
+| `/casero/fiscal` | `casero/(tabs)/fiscal.tsx` | Resumen fiscal anual, ocupacion, revision de lineas y exportacion CSV |
+| `/casero/contratos` | `casero/(tabs)/contratos.tsx` | Gestion de contratos por vivienda, habitacion e inquilino |
 | `/casero/inventario` | `casero/(tabs)/inventario.tsx` | Inventario global del casero |
 | `/casero/tablon` | `casero/(tabs)/tablon.tsx` | Tablon global del casero |
 | `/casero/perfil` | `casero/(tabs)/perfil.tsx` | Perfil del casero |
@@ -178,6 +183,7 @@ frontend/
 | `/inquilino/limpieza` | `inquilino/(tabs)/limpieza.tsx` | Turnos de su habitacion responsable y zonas comunes |
 | `/inquilino/gastos` | `inquilino/(tabs)/gastos.tsx` | Gastos puntuales, deudas, facturas y justificantes |
 | `/inquilino/inventario` | `inquilino/(tabs)/inventario.tsx` | Revision visual del inventario |
+| `/inquilino/contratos` | `inquilino/(tabs)/contratos.tsx` | Revision, firma interna o rechazo de contratos propios |
 | `/inquilino/perfil` | `inquilino/(tabs)/perfil.tsx` | Perfil del inquilino |
 | `/inquilino/nueva-incidencia` | `inquilino/nueva-incidencia.tsx` | Alta de incidencia |
 | `/tablon/:viviendaId` | `tablon/[viviendaId].tsx` | Tablon con vivienda explicita |
@@ -189,9 +195,9 @@ Cada rol tiene su propio grupo `(tabs)`:
 
 | Grupo | Pestanas |
 |---|---|
-| Casero (global) | Mis viviendas · Cobros · Inventario · Tablon · Perfil |
+| Casero (global) | Mis viviendas · Cobros · Fiscal · Contratos · Inventario · Tablon · Perfil |
 | Casero (vivienda) | Resumen · Incidencias · Tablon · Limpieza · Opciones |
-| Inquilino | Mi vivienda · Tablon · Limpieza · Gastos · Inventario · Perfil |
+| Inquilino | Mi vivienda · Tablon · Limpieza · Gastos · Inventario · Contratos · Perfil |
 
 Las rutas fuera de tabs se apilan sobre el tab bar gracias a `casero/_layout.tsx` e `inquilino/_layout.tsx`.
 
@@ -199,6 +205,7 @@ La navegacion es modular por vivienda:
 
 - `mod_limpieza` oculta la tab `Limpieza` en el detalle de vivienda del casero y en el inquilino.
 - `mod_gastos` oculta `Gastos` en inquilino y `Cobros` en casero si ninguna vivienda del casero lo tiene activo.
+- `mod_gastos` tambien protege el modo fiscal y contratos; el casero solo ve `Fiscal` si tiene alguna vivienda con gastos activos.
 - `mod_inventario` oculta `Inventario` en inquilino y casero si no hay viviendas con el modulo activo.
 - El tab `Opciones` (`casero/vivienda/[id]/(tabs)/opciones.tsx`) muestra switches para activar o desactivar modulos via `PATCH /api/viviendas/:id`.
 - Los tabs anidados de vivienda usan `useViviendaIdParam()` para leer el id local con fallback al pathname y evitar colisiones con otras rutas dinamicas.
@@ -293,6 +300,23 @@ La app usa `expo-notifications`.
 - Si alguna deuda hija esta `PAGADA`, el modal deshabilita la edicion del importe y mantiene editables concepto/fecha.
 - Desde el modal y desde la tarjeta se puede subir, reemplazar o abrir la factura original (`factura_url`).
 - `inquilino/(tabs)/gastos.tsx` muestra "Ver factura original" cuando una deuda procede de un gasto con factura adjunta.
+
+## Flujos destacados de la epica fiscal
+
+### Modo fiscal del casero
+
+- `casero/(tabs)/fiscal.tsx` carga viviendas con gastos activos, permite seleccionar ejercicio y consume `GET /api/viviendas/:viviendaId/fiscal/:ejercicio`.
+- La pantalla combina resumen anual, foto de ocupacion, advertencias y lineas revisables de ingresos/gastos.
+- El editor de linea fiscal actualiza `categoria_fiscal`, `deducible_previsto`, `notas_fiscales` y `prorrateo_fiscal` mediante `PATCH /api/viviendas/:viviendaId/gastos/:gastoId`.
+- La accion `Exportar CSV` llama a `GET /api/viviendas/:viviendaId/fiscal/:ejercicio/dossier?formato=base64` para guardar el dossier compatible con Excel.
+- La documentacion de cierre y checklist manual estan en `docs/backend/fiscal-cierre-epica.md`.
+
+### Contratos e historico de ocupacion
+
+- `components/contratos/ContratosAlquilerScreen.tsx` se reutiliza para casero e inquilino.
+- El casero sube PDF o imagen de contrato asociado a vivienda, habitacion e inquilino.
+- El inquilino firma o rechaza desde su tab de contratos; la firma interna registra version, hash, usuario y origen tecnico.
+- La ocupacion fiscal usa `PeriodoOcupacion` como fuente preferente y conserva revision manual para periodos migrados o inferidos.
 
 ## Flujos destacados de la epica 12
 


### PR DESCRIPTION
**Descripción:**
## Objetivo
Cerrar la épica fiscal con documentación de extremo a extremo, checklist manual, trazabilidad de issues y límites legales/fiscales explícitos, para que el modo fiscal del casero quede bien definido y revisable sin ocultar riesgos residuales.

## Cambios principales
* Se añadió `docs/backend/fiscal-cierre-epica.md` con el flujo fiscal completo, contrato de exportación del dossier, checklist manual reproducible y matriz issue -> archivos -> tests.
* Se actualizaron `CONTEXT.md`, `README.md`, `docs/backend/api.md` y `docs/backend/contrato-fiscal-propietario.md` para reflejar el cierre de la épica fiscal y sus límites.
* Se reforzó la documentación del frontend en `docs/frontend/setup.md` con la ruta fiscal, los endpoints consumidos, la exportación CSV y el flujo de contratos e histórico de ocupación.
* Se dejó trazada la relación con las issues #323, #324, #325, #326, #327, #328, #329, #337 y #338.

## UI / UX (Solo si aplica)
* Se documentó la pestaña `Fiscal` del casero y su visibilidad por `mod_gastos`, junto con la reutilización de contratos e histórico de ocupación como soporte operativo.

## Changelog
* `docs/changelog/EpicaFiscal/epica-fiscal-issue-330-cierre.md`