### PR TITLE
[Épica 19] Audita Cloudinary y define el contrato interno de media

### DIFF
--- a/backend/src/services/media.types.ts
+++ b/backend/src/services/media.types.ts
@@ -1,0 +1,79 @@
+export type MediaProvider = 'cloudinary' | 'backblaze' | 'external';
+
+export type MediaVisibility = 'public' | 'private';
+
+export type MediaVariant = 'original' | 'thumbnail' | 'preview' | 'download';
+
+export type MediaPurpose =
+  | 'inventory-photo'
+  | 'expense-invoice'
+  | 'payment-proof'
+  | 'rental-contract';
+
+export type MediaObject = {
+  provider: MediaProvider;
+  key: string;
+  url?: string | null;
+  variant: MediaVariant;
+  mimeType: string;
+  size: number;
+  width?: number | null;
+  height?: number | null;
+  visibility: MediaVisibility;
+  purpose: MediaPurpose;
+  metadata?: Record<string, string | number | boolean | null>;
+};
+
+export type MediaUploadInput = {
+  buffer: Buffer;
+  fileName: string;
+  mimeType: string;
+  size: number;
+  purpose: MediaPurpose;
+  visibility: MediaVisibility;
+  ownerId: number;
+  viviendaId?: number;
+  metadata?: Record<string, string | number | boolean | null>;
+};
+
+export type MediaDeleteInput = {
+  provider: MediaProvider;
+  key: string;
+};
+
+export type MediaUrlInput = {
+  provider: MediaProvider;
+  key: string;
+  expiresInSeconds?: number;
+};
+
+export type MediaMetadataInput = {
+  provider: MediaProvider;
+  key: string;
+};
+
+export type MediaProviderErrorCode =
+  | 'MEDIA_PROVIDER_NOT_CONFIGURED'
+  | 'MEDIA_UPLOAD_FAILED'
+  | 'MEDIA_DELETE_FAILED'
+  | 'MEDIA_NOT_FOUND'
+  | 'MEDIA_UNSUPPORTED_TYPE'
+  | 'MEDIA_PRIVATE_URL_REQUIRED';
+
+export class MediaProviderError extends Error {
+  constructor(
+    public readonly code: MediaProviderErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'MediaProviderError';
+  }
+}
+
+export interface MediaStorageProvider {
+  upload(input: MediaUploadInput): Promise<MediaObject>;
+  delete(input: MediaDeleteInput): Promise<void>;
+  getPublicUrl(input: MediaUrlInput): Promise<string>;
+  getSignedUrl(input: MediaUrlInput): Promise<string>;
+  getMetadata(input: MediaMetadataInput): Promise<MediaObject>;
+}

--- a/docs/backend/magic-links.md
+++ b/docs/backend/magic-links.md
@@ -1,0 +1,196 @@
+# Magic links en Roomies
+
+Este documento resume el flujo de magic links que existe en Roomies para poder reutilizarlo en otro proyecto. En el estado actual de la app, el registro manual ya inicia sesion directamente y crea usuarios con `correo_verificado: true`, pero se conserva el endpoint historico de verificacion por compatibilidad.
+
+## Que es un magic link
+
+Un magic link es un enlace unico enviado por email para confirmar una accion sin que el usuario tenga que copiar codigos. En Roomies se uso para verificar el correo tras el registro:
+
+1. El usuario se registra.
+2. El backend genera un token aleatorio.
+3. El token se guarda en base de datos.
+4. El backend envia un email con un enlace del tipo:
+
+```text
+https://api.miapp.com/api/auth/verificar/<token>
+```
+
+5. Cuando el usuario pulsa el enlace, el backend busca ese token.
+6. Si existe, marca el correo como verificado, borra el token y redirige a la app.
+
+## Para que sirven
+
+En Roomies el caso de uso era confirmar que el email pertenece al usuario antes de permitir el login.
+
+Tambien se pueden usar para:
+
+- Login sin password.
+- Recuperacion de cuenta.
+- Invitaciones a una vivienda, equipo o proyecto.
+- Confirmar cambios sensibles, como email nuevo.
+
+La idea importante es que el enlace debe ser de un solo uso y tener una vida corta.
+
+## Piezas que tenemos en Roomies
+
+### Base de datos
+
+El modelo `Usuario` incluye estos campos:
+
+```prisma
+correo_verificado Boolean
+token_verificacion String?
+```
+
+`correo_verificado` indica si el email ya fue confirmado. `token_verificacion` guarda el token pendiente de usar. Cuando el enlace se consume, se pone a `null`.
+
+### Generacion del token
+
+La implementacion historica generaba el token asi:
+
+```ts
+crypto.randomBytes(32).toString('hex')
+```
+
+Eso produce un token largo y dificil de adivinar. Para otro proyecto, conviene guardar solo un hash del token si el flujo va a ser sensible, pero para una verificacion simple de MVP puede bastar guardar el token plano con caducidad.
+
+### Envio del email
+
+Roomies tiene el servicio `enviarMagicLink(email, nombre, token)` en `backend/src/services/email.service.ts`.
+
+Construye la URL usando `BACKEND_URL`:
+
+```ts
+const url = `${process.env['BACKEND_URL'] ?? 'http://localhost:3001'}/api/auth/verificar/${token}`;
+```
+
+Y envia un email HTML con Nodemailer usando estas variables:
+
+```env
+EMAIL_USER=tu-cuenta@gmail.com
+EMAIL_PASS=contrasena-de-aplicacion
+BACKEND_URL=https://api.miapp.com
+```
+
+En Gmail, `EMAIL_PASS` debe ser una contrasena de aplicacion, no la contrasena normal.
+
+### Endpoint de verificacion
+
+La ruta esta declarada en `backend/src/routes/auth.routes.ts`:
+
+```ts
+router.get('/verificar/:token', verificarEmail);
+```
+
+Y el controlador hace esto:
+
+```ts
+const usuario = await prisma.usuario.findFirst({
+  where: { token_verificacion: token },
+});
+
+if (!usuario) {
+  res.status(200).send('<html>Enlace invalido o expirado</html>');
+  return;
+}
+
+await prisma.usuario.update({
+  where: { id: usuario.id },
+  data: { correo_verificado: true, token_verificacion: null },
+});
+
+res.redirect('roomies://verificacion?status=success');
+```
+
+El redirect final usa el deep link `roomies://` para volver a abrir la app movil tras verificar.
+
+## Como se implementaria en otro proyecto
+
+### Registro con verificacion por email
+
+En el registro:
+
+1. Validar email y password.
+2. Comprobar que el email no existe.
+3. Hashear la password.
+4. Generar `token_verificacion`.
+5. Crear usuario con `correo_verificado: false`.
+6. Enviar email con el magic link.
+7. Responder sin JWT, por ejemplo:
+
+```json
+{
+  "mensaje": "Usuario creado. Revisa tu correo para verificar la cuenta."
+}
+```
+
+Ejemplo de pseudocodigo:
+
+```ts
+const tokenVerificacion = crypto.randomBytes(32).toString('hex');
+
+const usuario = await prisma.usuario.create({
+  data: {
+    email,
+    password_hash,
+    correo_verificado: false,
+    token_verificacion: tokenVerificacion,
+  },
+});
+
+enviarMagicLink(usuario.email, usuario.nombre, tokenVerificacion).catch(console.error);
+
+res.status(201).json({ mensaje: 'Revisa tu correo para verificar la cuenta.' });
+```
+
+### Login bloqueado hasta verificar
+
+En el login, despues de validar la password:
+
+```ts
+if (!usuario.correo_verificado) {
+  res.status(403).json({ error: 'Debes verificar tu correo antes de iniciar sesion.' });
+  return;
+}
+```
+
+Si esta verificado, se emite el JWT normal.
+
+### Verificacion del enlace
+
+El endpoint debe:
+
+1. Recibir `GET /auth/verificar/:token`.
+2. Buscar el usuario por token.
+3. Si no existe, mostrar una pagina sencilla de error.
+4. Si existe, marcar `correo_verificado: true`.
+5. Borrar `token_verificacion`.
+6. Redirigir a la app o a una pantalla web de exito.
+
+## Recomendaciones
+
+- Usar tokens aleatorios largos: minimo 32 bytes.
+- Hacer el enlace de un solo uso borrando el token al consumirlo.
+- Anadir caducidad con un campo tipo `token_verificacion_expira`.
+- No devolver nunca `token_verificacion` en respuestas de API.
+- Enviar el correo de forma asincrona para que un fallo SMTP no rompa todo el registro.
+- En produccion, preferir un proveedor transaccional como Resend, SendGrid, Mailgun, Postmark o SES antes que SMTP de Gmail.
+- Si se usa en login sin password, intercambiar el magic link por una sesion real y no dejar el token reutilizable.
+
+## Estado actual en Roomies
+
+Roomies conserva:
+
+- `GET /api/auth/verificar/:token`.
+- `correo_verificado`.
+- `token_verificacion`.
+- `enviarMagicLink(...)`.
+- Deep link `roomies://verificacion?status=success`.
+
+Pero el flujo activo actual no depende de magic links:
+
+- `POST /auth/register` crea el usuario con `correo_verificado: true`.
+- `POST /auth/register` devuelve `{ token, usuario }`.
+- El login no bloquea temporalmente por `correo_verificado`.
+
+Para reactivar el flujo completo habria que volver a generar el token en registro, enviar el email, responder sin JWT y activar el guard de `correo_verificado` en login.

--- a/docs/backend/media-storage.md
+++ b/docs/backend/media-storage.md
@@ -1,0 +1,115 @@
+# Media storage interno
+
+Issue #347 de la epica #346. Este documento audita el acoplamiento actual con Cloudinary y fija el contrato interno que deberia usar Roomies antes de introducir Backblaze u otro proveedor.
+
+## Estado actual
+
+Roomies usa Cloudinary directamente desde `backend/src/config/cloudinary.config.ts` mediante `multer-storage-cloudinary`. Los controladores reciben `req.file.path` o `req.file.secure_url` y guardan una URL remota en Prisma. No se guarda `public_id`, key portable, provider, tamano, dimensiones ni visibilidad. Tampoco hay borrado remoto cuando se elimina o reemplaza un fichero.
+
+Las variables actuales son:
+
+| Variable | Uso actual |
+| --- | --- |
+| `CLOUDINARY_CLOUD_NAME` | Configura el cloud name de Cloudinary. |
+| `CLOUDINARY_API_KEY` | Configura la API key de Cloudinary. |
+| `CLOUDINARY_API_SECRET` | Configura el API secret de Cloudinary. |
+
+## Matriz de uso Cloudinary
+
+| Flujo | Archivo backend | Archivo frontend | Campo o modelo | Carpeta Cloudinary | Tipo | Privacidad recomendada | Estado de acoplamiento |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Fotos de inventario | `backend/src/routes/inventario.routes.ts`, `backend/src/controllers/inventario.controller.ts` | `frontend/app/casero/(tabs)/inventario.tsx`, `frontend/app/inquilino/(tabs)/inventario.tsx` | `FotoAsset.url` | `roomies-inventario` | Imagen | Privada por vivienda, aunque actualmente se trata como URL directa. | Guarda solo URL; se lista a casero e inquilino autorizado. |
+| Facturas de gastos | `backend/src/routes/gasto.routes.ts`, `backend/src/controllers/gasto.controller.ts`, `backend/src/services/gasto.service.ts` | `frontend/app/casero/(tabs)/cobros.tsx`, `frontend/app/inquilino/(tabs)/gastos.tsx`, `frontend/app/casero/(tabs)/fiscal.tsx` | `Gasto.factura_url` | `roomies-facturas` | Imagen o PDF al crear; imagen al reemplazar | Privada fiscal/financiera. | Guarda URL directa; se exporta tambien en dossier fiscal. |
+| Justificantes de pago | `backend/src/routes/deuda.routes.ts`, `backend/src/controllers/deuda.controller.ts` | `frontend/app/inquilino/(tabs)/gastos.tsx`, `frontend/app/casero/(tabs)/cobros.tsx`, `frontend/app/casero/(tabs)/fiscal.tsx` | `Deuda.justificante_url` | `roomies-justificantes` | Imagen | Privada financiera entre deudor, acreedor/casero y vivienda. | Guarda URL directa; bloquea borrado de factura si existe actividad de pago. |
+| Contratos de alquiler | `backend/src/routes/contrato.routes.ts`, `backend/src/controllers/contrato.controller.ts` | `frontend/components/contratos/ContratosAlquilerScreen.tsx` | `ContratoAlquiler.documento_url`, `documento_nombre`, `documento_mime`, `documento_hash` | `roomies-contratos` | Imagen o PDF | Privada contractual y personal. | Guarda URL directa y hash funcional; no guarda provider/key. |
+| Seeds y datos demo | `backend/prisma/seed.ts` | No aplica | `factura_url`, `justificante_url` de prueba | `demo` | Imagen | Demo, no productiva. | Usa URLs publicas de ejemplo. |
+| Fiscal y exportaciones | `backend/src/services/fiscal.service.ts` | `frontend/app/casero/(tabs)/fiscal.tsx` | Lee `factura_url` y `justificante_url` | No sube | URL existente | Privada fiscal. | Propaga URLs directas a CSV/dossier. |
+
+Referencias documentales actuales: `CONTEXT.md`, `README.md`, `docs/backend/setup.md`, `docs/backend/api.md`, `docs/backend/inventario-assets.md`, `docs/backend/fiscal-cierre-epica.md`, `docs/infra/setup-despliegue.md` y changelogs de Epicas 11, 12, 14, 16 y Fiscal.
+
+## Clasificacion de datos
+
+| Caso | Publico o privado | Motivo |
+| --- | --- | --- |
+| Fotos de inventario de vivienda/habitacion | Privado | Muestran estado del piso y objetos de la vivienda; solo deben verlas casero e inquilinos autorizados. |
+| Facturas originales de gastos | Privado | Pueden contener datos fiscales, importes, proveedor, direccion o datos personales. |
+| Justificantes de pago | Privado | Pueden contener datos bancarios o identificadores de pago. |
+| Contratos de alquiler | Privado alto | Contienen datos identificativos, renta, fechas, firma y trazabilidad contractual. |
+| Fotos publicas de viviendas o habitaciones | Publico si se crea un flujo de anuncios | No existe hoy como flujo diferenciado; debe nacer con `visibility: public`. |
+| Incidencias con adjuntos | Privado | El texto del issue los menciona como futuro caso de uso, pero no hay upload de incidencias actualmente. |
+
+## Contrato interno
+
+El contrato base queda definido en codigo en `backend/src/services/media.types.ts`. La implementacion futura debe inyectar un `MediaStorageProvider` y evitar que rutas y controladores dependan de Cloudinary, Backblaze o `multer-storage-cloudinary`.
+
+La representacion portable de un fichero debe ser:
+
+```ts
+type MediaObject = {
+  provider: 'cloudinary' | 'backblaze' | 'external';
+  key: string;
+  url?: string | null;
+  variant: 'original' | 'thumbnail' | 'preview' | 'download';
+  mimeType: string;
+  size: number;
+  width?: number | null;
+  height?: number | null;
+  visibility: 'public' | 'private';
+  purpose: 'inventory-photo' | 'expense-invoice' | 'payment-proof' | 'rental-contract';
+  metadata?: Record<string, string | number | boolean | null>;
+};
+```
+
+Operaciones obligatorias:
+
+| Operacion | Contrato |
+| --- | --- |
+| `upload(input)` | Recibe buffer, nombre, MIME, tamano, purpose, visibility y owner; devuelve `MediaObject`. |
+| `delete(input)` | Borra por `provider` + `key`; debe ser idempotente o mapear `not found` a un error controlado. |
+| `getPublicUrl(input)` | Devuelve URL estable solo para objetos con `visibility: public`. |
+| `getSignedUrl(input)` | Devuelve URL temporal para objetos privados, con expiracion explicita. |
+| `getMetadata(input)` | Devuelve metadata tecnica y funcional guardada o consultada al proveedor. |
+
+Errores normalizados:
+
+| Codigo | Uso |
+| --- | --- |
+| `MEDIA_PROVIDER_NOT_CONFIGURED` | Faltan credenciales o bucket. Sustituye mensajes acoplados a Cloudinary. |
+| `MEDIA_UPLOAD_FAILED` | El proveedor no confirma la subida. |
+| `MEDIA_DELETE_FAILED` | El proveedor rechaza el borrado. |
+| `MEDIA_NOT_FOUND` | El objeto no existe al leer metadata o generar URL. |
+| `MEDIA_UNSUPPORTED_TYPE` | MIME o extension no permitidos para el purpose. |
+| `MEDIA_PRIVATE_URL_REQUIRED` | Se intento pedir URL publica para un objeto privado. |
+
+## Campos actuales
+
+| Campo actual | Mantener temporalmente | Cambio recomendado |
+| --- | --- | --- |
+| `FotoAsset.url` | Si, como compatibilidad de lectura. | Anadir `provider`, `key`, `mime_type`, `size`, `width`, `height`, `visibility`, `variant` o migrar a una tabla comun `MediaAsset`. |
+| `Gasto.factura_url` | Si, para no romper finanzas ni fiscal. | Sustituir gradualmente por referencia a `MediaAsset` con purpose `expense-invoice`. |
+| `Deuda.justificante_url` | Si, para compatibilidad con app actual. | Sustituir gradualmente por referencia a `MediaAsset` con purpose `payment-proof`. |
+| `ContratoAlquiler.documento_url` | Si, mientras la firma interna depende del documento actual. | Mantener `documento_hash`, `documento_nombre` y `documento_mime`; anadir provider/key y URLs firmadas. |
+| URLs en CSV fiscal | Si, pero con cautela. | Para privados, exportar una referencia interna o URL firmada de corta duracion, no una URL publica permanente. |
+
+## Variables propuestas para Backblaze
+
+Estas variables no se implementan en este issue; solo fijan el nombre esperado para la epica:
+
+| Variable | Proposito |
+| --- | --- |
+| `MEDIA_PROVIDER` | `cloudinary` o `backblaze`; permite activar proveedor sin tocar controladores. |
+| `B2_APPLICATION_KEY_ID` | Key id de Backblaze B2. |
+| `B2_APPLICATION_KEY` | Application key de Backblaze B2. |
+| `B2_BUCKET_ID` | Id del bucket privado. |
+| `B2_BUCKET_NAME` | Nombre humano del bucket. |
+| `B2_ENDPOINT` | Endpoint S3-compatible o API endpoint si se usa SDK nativo. |
+| `B2_PUBLIC_BASE_URL` | Base URL solo para assets publicos si se habilita CDN o bucket publico. |
+| `MEDIA_SIGNED_URL_TTL_SECONDS` | TTL por defecto de URLs firmadas privadas. |
+
+## Plan de migracion recomendado
+
+1. Introducir servicio `media.service` que implemente `MediaStorageProvider` para Cloudinary usando el contrato ya definido.
+2. Cambiar controladores para recibir `MediaObject` y guardar `provider` + `key`, conservando las columnas `*_url` como compatibilidad.
+3. Crear migracion de datos que derive `key` desde URLs actuales cuando sea posible; si no, marcar provider `external`.
+4. Sustituir lecturas de URLs directas por `getSignedUrl` en facturas, justificantes, contratos e inventario privado.
+5. Anadir proveedor Backblaze detras de `MEDIA_PROVIDER` y migrar flujo por flujo.

--- a/docs/changelog/EpicaMedia/epica-media-issue-347-auditoria-media.md
+++ b/docs/changelog/EpicaMedia/epica-media-issue-347-auditoria-media.md
@@ -1,0 +1,20 @@
+# Issue #347 - Auditoria de Cloudinary y contrato interno de media
+
+## Objetivo
+
+Se audita el acoplamiento actual con Cloudinary y se deja definido el contrato tecnico que debera usar Roomies para abstraer subidas, borrados, URLs publicas/firmadas y metadata antes de migrar a Backblaze.
+
+## Cambios
+
+- `backend/src/services/media.types.ts`: anade tipos e interfaz `MediaStorageProvider` con `upload`, `delete`, `getPublicUrl`, `getSignedUrl` y `getMetadata`.
+- `docs/backend/media-storage.md`: documenta la matriz de uso actual de Cloudinary por flujo, privacidad de los datos, estructura portable de `MediaObject`, campos actuales y variables propuestas para Backblaze.
+
+## Decision tecnica
+
+Los ficheros financieros, contractuales e inventario se trataran como privados por defecto. Las URLs publicas quedaran reservadas para futuros flujos publicos explicitos, como anuncios o fotos comerciales de vivienda.
+
+## Pendiente
+
+- Implementar un proveedor Cloudinary detras del contrato.
+- Anadir provider/key y metadata tecnica a Prisma o centralizar los ficheros en una tabla `MediaAsset`.
+- Migrar lecturas privadas a URLs firmadas o proxy protegido.


### PR DESCRIPTION
**Descripción:**
## Objetivo
Cerrar la auditoría técnica de Cloudinary y dejar definido un contrato interno de almacenamiento que permita migrar a Backblaze sin rehacer los flujos de subida, lectura y borrado de media.

## Cambios principales
* Se documenta la matriz de uso actual de Cloudinary por flujo, archivo, modelo y nivel de privacidad en `docs/backend/media-storage.md`.
* Se define en `backend/src/services/media.types.ts` el contrato interno de media con `upload`, `delete`, `getPublicUrl`, `getSignedUrl` y `getMetadata`.
* Se normalizan los tipos portables de media con `provider`, `key`, `variant`, `mimeType`, `size`, `width`, `height`, `visibility` y `metadata`.
* Se identifican los campos actuales que pueden mantenerse temporalmente y los que conviene sustituir gradualmente por una referencia común a `MediaAsset`.
* Se proponen variables de entorno para Backblaze y un plan de migración por fases para no tocar todos los flujos a la vez.
* Se añade el changelog técnico de la decisión en `docs/changelog/EpicaMedia/epica-media-issue-347-auditoria-media.md`.

## UI / UX (Solo si aplica)
* No aplica.

## Changelog
* `docs/changelog/EpicaMedia/epica-media-issue-347-auditoria-media.md`