### PR TITLE
[Épica 346] Procesa imágenes a WebP con variantes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,9 @@ CLOUDINARY_API_SECRET=tu_api_secret
 MEDIA_PROVIDER=backblaze
 MEDIA_SIGNED_URL_TTL_SECONDS=900
 MEDIA_CACHE_CONTROL=public, max-age=31536000, immutable
+MEDIA_IMAGE_MAX_SIZE_BYTES=10485760
+MEDIA_IMAGE_WEBP_QUALITY=82
+MEDIA_IMAGE_KEEP_ORIGINAL=false
 
 # Backblaze B2 S3-compatible (requerido si MEDIA_PROVIDER=backblaze)
 B2_ENDPOINT=https://s3.<region>.backblazeb2.com

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -38,6 +38,24 @@ CLOUDINARY_CLOUD_NAME=tu_cloud_name
 CLOUDINARY_API_KEY=tu_api_key
 CLOUDINARY_API_SECRET=tu_api_secret
 
+# Media storage interno
+# Valores soportados hoy por el contrato interno: backblaze
+MEDIA_PROVIDER=backblaze
+MEDIA_SIGNED_URL_TTL_SECONDS=900
+MEDIA_CACHE_CONTROL=public, max-age=31536000, immutable
+MEDIA_IMAGE_MAX_SIZE_BYTES=10485760
+MEDIA_IMAGE_WEBP_QUALITY=82
+MEDIA_IMAGE_KEEP_ORIGINAL=false
+
+# Backblaze B2 S3-compatible (requerido si MEDIA_PROVIDER=backblaze)
+B2_ENDPOINT=https://s3.<region>.backblazeb2.com
+B2_REGION=<region>
+B2_BUCKET_NAME=roomies-media
+B2_APPLICATION_KEY_ID=tu_key_id
+B2_APPLICATION_KEY=tu_application_key
+# Opcional: base publica/CDN solo para objetos con visibilidad public
+B2_PUBLIC_BASE_URL=https://cdn.tu-dominio.com
+
 # Configuración del Seeder
 SEED_CASERO_PASSWORD=casero123
 SEED_INQUILINO_PASSWORD=inquilino123

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -26,6 +26,7 @@
         "node-cron": "^4.2.1",
         "nodemailer": "^8.0.4",
         "pg": "^8.20.0",
+        "sharp": "^0.34.5",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -860,7 +861,6 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
       "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -889,6 +889,471 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -2754,7 +3219,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -5268,6 +5732,50 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -36,6 +36,7 @@
     "node-cron": "^4.2.1",
     "nodemailer": "^8.0.4",
     "pg": "^8.20.0",
+    "sharp": "^0.34.5",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/backend/src/services/media-image.processor.ts
+++ b/backend/src/services/media-image.processor.ts
@@ -1,0 +1,213 @@
+import path from 'node:path';
+import sharp from 'sharp';
+import { MediaProviderError, type MediaPurpose, type MediaVariant } from './media.types';
+
+export type MediaImageVariant = Extract<MediaVariant, 'original' | 'thumb' | 'medium' | 'large'>;
+
+export type ProcessImageInput = {
+  buffer: Buffer;
+  fileName: string;
+  mimeType: string;
+  size: number;
+  purpose: MediaPurpose;
+  ownerId: number;
+  viviendaId?: number;
+  maxSizeBytes?: number;
+  webpQuality?: number;
+  keepOriginal?: boolean;
+};
+
+export type ProcessedImageVariant = {
+  variant: MediaImageVariant;
+  suggestedKey: string;
+  buffer: Buffer;
+  width: number;
+  height: number;
+  size: number;
+  mimeType: 'image/webp' | 'image/jpeg' | 'image/png';
+  metadata: {
+    originalFileName: string;
+    originalMimeType: string;
+    originalSize: number;
+    variant: MediaImageVariant;
+    width: number;
+    height: number;
+    webpQuality?: number;
+  };
+};
+
+const DEFAULT_MAX_IMAGE_SIZE_BYTES = 10 * 1024 * 1024;
+const DEFAULT_WEBP_QUALITY = 82;
+const MIN_WEBP_QUALITY = 1;
+const MAX_WEBP_QUALITY = 100;
+
+const ALLOWED_MIME_TYPES = new Set(['image/jpeg', 'image/jpg', 'image/png', 'image/webp']);
+const ALLOWED_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.webp']);
+
+const IMAGE_VARIANT_WIDTHS: Array<{ variant: Exclude<MediaImageVariant, 'original'>; width: number }> = [
+  { variant: 'thumb', width: 300 },
+  { variant: 'medium', width: 800 },
+  { variant: 'large', width: 1600 },
+];
+
+function getPositiveIntegerFromEnv(name: string, fallback: number): number {
+  const rawValue = process.env[name];
+  if (!rawValue) {
+    return fallback;
+  }
+
+  const parsed = Number(rawValue);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function getBooleanFromEnv(name: string, fallback: boolean): boolean {
+  const rawValue = process.env[name]?.trim().toLowerCase();
+  if (!rawValue) {
+    return fallback;
+  }
+
+  return ['1', 'true', 'yes', 'si'].includes(rawValue);
+}
+
+function normalizeWebpQuality(value: number): number {
+  return Math.min(Math.max(Math.round(value), MIN_WEBP_QUALITY), MAX_WEBP_QUALITY);
+}
+
+function sanitizeKeySegment(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
+}
+
+function assertSupportedImageType(fileName: string, mimeType: string): void {
+  const normalizedMimeType = mimeType.trim().toLowerCase();
+  const extension = path.extname(fileName).trim().toLowerCase();
+
+  if (!ALLOWED_MIME_TYPES.has(normalizedMimeType) || !ALLOWED_EXTENSIONS.has(extension)) {
+    throw new MediaProviderError(
+      'MEDIA_UNSUPPORTED_TYPE',
+      'Solo se permiten imagenes jpg, jpeg, png o webp.',
+    );
+  }
+}
+
+function assertSizeAllowed(size: number, maxSizeBytes: number): void {
+  if (size > maxSizeBytes) {
+    throw new MediaProviderError(
+      'MEDIA_FILE_TOO_LARGE',
+      `La imagen supera el tamano maximo permitido de ${maxSizeBytes} bytes.`,
+    );
+  }
+}
+
+function buildSuggestedKey(input: ProcessImageInput, variant: MediaImageVariant): string {
+  const today = new Date().toISOString().slice(0, 10);
+  const vivienda = input.viviendaId ? `vivienda-${input.viviendaId}` : 'vivienda-global';
+  const baseName = sanitizeKeySegment(path.basename(input.fileName, path.extname(input.fileName))) || 'imagen';
+  const originalExtension = sanitizeKeySegment(path.extname(input.fileName).replace('.', '')) || 'imagen';
+  const extension = variant === 'original' ? originalExtension : 'webp';
+  return [input.purpose, vivienda, `owner-${input.ownerId}`, today, `${baseName}-${variant}.${extension}`].join('/');
+}
+
+function buildMetadata(
+  input: ProcessImageInput,
+  variant: MediaImageVariant,
+  width: number,
+  height: number,
+  webpQuality?: number,
+): ProcessedImageVariant['metadata'] {
+  return {
+    originalFileName: input.fileName,
+    originalMimeType: input.mimeType,
+    originalSize: input.size,
+    variant,
+    width,
+    height,
+    webpQuality,
+  };
+}
+
+function normalizeOriginalMimeType(mimeType: string): 'image/webp' | 'image/jpeg' | 'image/png' {
+  if (mimeType === 'image/png') {
+    return 'image/png';
+  }
+
+  if (mimeType === 'image/webp') {
+    return 'image/webp';
+  }
+
+  return 'image/jpeg';
+}
+
+async function readImageMetadata(buffer: Buffer): Promise<sharp.Metadata> {
+  try {
+    const metadata = await sharp(buffer).metadata();
+    if (!metadata.width || !metadata.height) {
+      throw new Error('La imagen no contiene dimensiones validas.');
+    }
+
+    return metadata;
+  } catch (error) {
+    if (error instanceof MediaProviderError) {
+      throw error;
+    }
+
+    throw new MediaProviderError('MEDIA_UNSUPPORTED_TYPE', 'La imagen no se pudo leer o esta corrupta.');
+  }
+}
+
+export async function processImageForUpload(input: ProcessImageInput): Promise<ProcessedImageVariant[]> {
+  const maxSizeBytes = input.maxSizeBytes ?? getPositiveIntegerFromEnv('MEDIA_IMAGE_MAX_SIZE_BYTES', DEFAULT_MAX_IMAGE_SIZE_BYTES);
+  const webpQuality = normalizeWebpQuality(
+    input.webpQuality ?? getPositiveIntegerFromEnv('MEDIA_IMAGE_WEBP_QUALITY', DEFAULT_WEBP_QUALITY),
+  );
+  const keepOriginal = input.keepOriginal ?? getBooleanFromEnv('MEDIA_IMAGE_KEEP_ORIGINAL', false);
+
+  assertSupportedImageType(input.fileName, input.mimeType);
+  assertSizeAllowed(input.size, maxSizeBytes);
+
+  const metadata = await readImageMetadata(input.buffer);
+  const variants: ProcessedImageVariant[] = [];
+
+  if (keepOriginal) {
+    variants.push({
+      variant: 'original',
+      suggestedKey: buildSuggestedKey(input, 'original'),
+      buffer: input.buffer,
+      width: metadata.width as number,
+      height: metadata.height as number,
+      size: input.size,
+      mimeType: normalizeOriginalMimeType(input.mimeType),
+      metadata: buildMetadata(input, 'original', metadata.width as number, metadata.height as number),
+    });
+  }
+
+  for (const { variant, width } of IMAGE_VARIANT_WIDTHS) {
+    const output = await sharp(input.buffer)
+      .rotate()
+      .resize({ width, withoutEnlargement: true })
+      .webp({ quality: webpQuality })
+      .toBuffer({ resolveWithObject: true });
+
+    if (!output.info.width || !output.info.height) {
+      throw new MediaProviderError('MEDIA_UPLOAD_FAILED', 'No se pudo generar la variante de imagen.');
+    }
+
+    variants.push({
+      variant,
+      suggestedKey: buildSuggestedKey(input, variant),
+      buffer: output.data,
+      width: output.info.width,
+      height: output.info.height,
+      size: output.info.size,
+      mimeType: 'image/webp',
+      metadata: buildMetadata(input, variant, output.info.width, output.info.height, webpQuality),
+    });
+  }
+
+  return variants;
+}

--- a/backend/src/services/media.types.ts
+++ b/backend/src/services/media.types.ts
@@ -2,7 +2,7 @@ export type MediaProvider = 'cloudinary' | 'backblaze' | 'external';
 
 export type MediaVisibility = 'public' | 'private';
 
-export type MediaVariant = 'original' | 'thumbnail' | 'preview' | 'download';
+export type MediaVariant = 'original' | 'thumbnail' | 'preview' | 'download' | 'thumb' | 'medium' | 'large';
 
 export type MediaPurpose =
   | 'inventory-photo'
@@ -58,6 +58,7 @@ export type MediaProviderErrorCode =
   | 'MEDIA_DELETE_FAILED'
   | 'MEDIA_NOT_FOUND'
   | 'MEDIA_UNSUPPORTED_TYPE'
+  | 'MEDIA_FILE_TOO_LARGE'
   | 'MEDIA_PRIVATE_URL_REQUIRED';
 
 export class MediaProviderError extends Error {

--- a/backend/tests/media-image.processor.test.ts
+++ b/backend/tests/media-image.processor.test.ts
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict';
+import sharp from 'sharp';
+import { describe, test } from 'vitest';
+import { processImageForUpload } from '../src/services/media-image.processor';
+import { MediaProviderError } from '../src/services/media.types';
+
+async function createPng(width: number, height: number): Promise<Buffer> {
+  return sharp({
+    create: {
+      width,
+      height,
+      channels: 3,
+      background: '#67c6a3',
+    },
+  })
+    .png()
+    .toBuffer();
+}
+
+describe('processImageForUpload', () => {
+  test('convierte una imagen valida a variantes WebP listas para subir', async () => {
+    const buffer = await createPng(1200, 600);
+
+    const variants = await processImageForUpload({
+      buffer,
+      fileName: 'Salon Principal.png',
+      mimeType: 'image/png',
+      size: buffer.length,
+      purpose: 'inventory-photo',
+      ownerId: 42,
+      viviendaId: 7,
+      webpQuality: 80,
+    });
+
+    assert.deepEqual(
+      variants.map((variant) => variant.variant),
+      ['thumb', 'medium', 'large'],
+    );
+    assert.deepEqual(
+      variants.map((variant) => variant.width),
+      [300, 800, 1200],
+    );
+    assert.equal(variants[0].height, 150);
+    assert.equal(variants[1].height, 400);
+    assert.equal(variants[2].height, 600);
+
+    for (const variant of variants) {
+      assert.equal(variant.mimeType, 'image/webp');
+      assert.ok(variant.size > 0);
+      assert.ok(variant.buffer.length > 0);
+      assert.match(variant.suggestedKey, /^inventory-photo\/vivienda-7\/owner-42\/\d{4}-\d{2}-\d{2}\/salon-principal-/);
+      assert.equal(variant.metadata.webpQuality, 80);
+      assert.equal(variant.metadata.originalMimeType, 'image/png');
+    }
+  });
+
+  test('no agranda imagenes pequenas al generar variantes', async () => {
+    const buffer = await createPng(180, 90);
+
+    const variants = await processImageForUpload({
+      buffer,
+      fileName: 'thumb.webp',
+      mimeType: 'image/webp',
+      size: buffer.length,
+      purpose: 'payment-proof',
+      ownerId: 3,
+    });
+
+    assert.deepEqual(
+      variants.map((variant) => variant.width),
+      [180, 180, 180],
+    );
+    assert.deepEqual(
+      variants.map((variant) => variant.height),
+      [90, 90, 90],
+    );
+  });
+
+  test('conserva el original solo cuando se pide explicitamente', async () => {
+    const buffer = await createPng(400, 200);
+
+    const variants = await processImageForUpload({
+      buffer,
+      fileName: 'contrato.png',
+      mimeType: 'image/png',
+      size: buffer.length,
+      purpose: 'rental-contract',
+      ownerId: 9,
+      keepOriginal: true,
+    });
+
+    assert.equal(variants[0].variant, 'original');
+    assert.equal(variants[0].mimeType, 'image/png');
+    assert.equal(variants[0].buffer, buffer);
+  });
+
+  test('rechaza tipos no permitidos con error controlado', async () => {
+    await assert.rejects(
+      () =>
+        processImageForUpload({
+          buffer: Buffer.from('pdf'),
+          fileName: 'factura.pdf',
+          mimeType: 'application/pdf',
+          size: 3,
+          purpose: 'expense-invoice',
+          ownerId: 1,
+        }),
+      (error) => error instanceof MediaProviderError && error.code === 'MEDIA_UNSUPPORTED_TYPE',
+    );
+  });
+
+  test('rechaza imagenes demasiado pesadas con error controlado', async () => {
+    const buffer = await createPng(20, 20);
+
+    await assert.rejects(
+      () =>
+        processImageForUpload({
+          buffer,
+          fileName: 'foto.png',
+          mimeType: 'image/png',
+          size: buffer.length,
+          purpose: 'inventory-photo',
+          ownerId: 1,
+          maxSizeBytes: 1,
+        }),
+      (error) => error instanceof MediaProviderError && error.code === 'MEDIA_FILE_TOO_LARGE',
+    );
+  });
+});

--- a/docs/backend/media-storage.md
+++ b/docs/backend/media-storage.md
@@ -106,8 +106,23 @@ Issue #348 implementa el proveedor Backblaze B2 mediante API S3-compatible. Esta
 | `B2_PUBLIC_BASE_URL` | Base URL solo para assets publicos si se habilita CDN o bucket publico. |
 | `MEDIA_SIGNED_URL_TTL_SECONDS` | TTL por defecto de URLs firmadas privadas. |
 | `MEDIA_CACHE_CONTROL` | Cabecera `Cache-Control` aplicada al subir objetos. |
+| `MEDIA_IMAGE_MAX_SIZE_BYTES` | Tamano maximo por imagen antes de procesar; por defecto `10485760` (10 MiB). |
+| `MEDIA_IMAGE_WEBP_QUALITY` | Calidad WebP de las variantes generadas; por defecto `82`, acotada de 1 a 100. |
+| `MEDIA_IMAGE_KEEP_ORIGINAL` | Si vale `true`, el procesador devuelve tambien la variante `original`; por defecto no conserva originales. |
 
 La implementacion vive en `backend/src/services/backblaze-b2-media.provider.ts` y traduce errores S3 a `MediaProviderError` para no filtrar detalles de Backblaze a capas superiores.
+
+## Procesado de imagenes
+
+Issue #349 introduce `backend/src/services/media-image.processor.ts` como paso previo a la subida al proveedor. El servicio acepta buffers de imagen `jpg/jpeg`, `png` o `webp`, rechaza archivos por encima de `MEDIA_IMAGE_MAX_SIZE_BYTES` y normaliza las salidas iniciales a WebP:
+
+| Variante | Ancho maximo | Comportamiento |
+| --- | ---: | --- |
+| `thumb` | 300px | Miniatura para listados y galerias compactas. |
+| `medium` | 800px | Vista intermedia para detalle movil. |
+| `large` | 1600px | Vista amplia sin servir el original pesado. |
+
+Las variantes usan `withoutEnlargement`, por lo que una imagen pequena mantiene sus dimensiones originales y no se escala artificialmente. Cada resultado incluye `buffer`, `suggestedKey`, `width`, `height`, `size`, `mimeType: image/webp`, `variant` y metadata tecnica con nombre, MIME y tamano originales. La variante `original` solo aparece si el flujo llama al servicio con `keepOriginal: true` o se activa `MEDIA_IMAGE_KEEP_ORIGINAL=true`.
 
 ## Plan de migracion recomendado
 

--- a/docs/changelog/issue-349-procesar-imagenes-webp.md
+++ b/docs/changelog/issue-349-procesar-imagenes-webp.md
@@ -1,0 +1,16 @@
+# Issue #349 - Procesar imagenes a WebP y generar variantes
+
+## Objetivo
+
+Preparar el backend para procesar imagenes antes de subirlas a Backblaze B2, evitando servir originales pesados y dejando variantes predecibles para los futuros flujos de media.
+
+## Cambios principales
+
+- `backend/src/services/media-image.processor.ts`: nuevo procesador de imagenes con validacion de tipos `jpg/jpeg`, `png` y `webp`, limite de tamano configurable, conversion a WebP y variantes `thumb`, `medium` y `large`.
+- `backend/src/services/media.types.ts`: ampliados los tipos de variante y errores controlados con `MEDIA_FILE_TOO_LARGE`.
+- `backend/tests/media-image.processor.test.ts`: cobertura del procesado correcto, no escalado de imagenes pequenas, conservacion explicita del original y errores controlados por tipo o tamano.
+- `.env.example`, `backend/.env.example` y `docs/backend/media-storage.md`: documentadas `MEDIA_IMAGE_MAX_SIZE_BYTES`, `MEDIA_IMAGE_WEBP_QUALITY` y `MEDIA_IMAGE_KEEP_ORIGINAL`.
+
+## Verificacion
+
+- `npm test -- media-image.processor.test.ts`


### PR DESCRIPTION
## Objetivo
Preparar el backend para normalizar imágenes antes de subirlas a almacenamiento, reduciendo peso y generando variantes predecibles para los flujos de media de Roomies.

## Cambios principales
- Se añade `backend/src/services/media-image.processor.ts` para validar tipos permitidos, limitar tamaño y convertir imágenes a WebP.
- Se generan variantes `thumb`, `medium` y `large` con anchuras máximas de 300px, 800px y 1600px, sin agrandar imágenes pequeñas.
- Se expone metadata por variante con `suggestedKey`, `width`, `height`, `size`, `mimeType` y `variant`.
- Se amplían los tipos de media con el error controlado `MEDIA_FILE_TOO_LARGE`.
- Se documentan las variables `MEDIA_IMAGE_MAX_SIZE_BYTES`, `MEDIA_IMAGE_WEBP_QUALITY` y `MEDIA_IMAGE_KEEP_ORIGINAL`.
- Se añade cobertura de tests para conversión correcta, límites de tamaño, tipos no permitidos y conservación opcional del original.

## UI / UX (Solo si aplica)
- No aplica; el cambio es backend y de documentación operativa.

## Changelog
- `docs/changelog/issue-349-procesar-imagenes-webp.md`

## Testing
- Tests unitarios nuevos para el procesador de imágenes con fixtures generados en memoria.
- Verificación local del backend con build TypeScript y Prisma completada correctamente.