### PR TITLE
[Épica Media] Migrar subidas de media a Backblaze

### DIFF
--- a/backend/src/config/media-upload.config.ts
+++ b/backend/src/config/media-upload.config.ts
@@ -1,0 +1,59 @@
+import multer from 'multer';
+
+const DEFAULT_MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+
+function getPositiveIntegerFromEnv(name: string, fallback: number): number {
+  const rawValue = process.env[name];
+  if (!rawValue) {
+    return fallback;
+  }
+
+  const parsed = Number(rawValue);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+const imageMaxSizeBytes = getPositiveIntegerFromEnv('MEDIA_IMAGE_MAX_SIZE_BYTES', DEFAULT_MAX_FILE_SIZE_BYTES);
+const documentMaxSizeBytes = getPositiveIntegerFromEnv('MEDIA_DOCUMENT_MAX_SIZE_BYTES', DEFAULT_MAX_FILE_SIZE_BYTES);
+
+const crearUploaderImagen = () =>
+  multer({
+    storage: multer.memoryStorage(),
+    limits: {
+      fileSize: imageMaxSizeBytes,
+      files: 1,
+    },
+    fileFilter: (_req, file, cb) => {
+      if (!['image/jpeg', 'image/jpg', 'image/png', 'image/webp'].includes(file.mimetype)) {
+        cb(new Error('Solo se permiten imagenes jpg, jpeg, png o webp.'));
+        return;
+      }
+
+      cb(null, true);
+    },
+  });
+
+const crearUploaderDocumento = () =>
+  multer({
+    storage: multer.memoryStorage(),
+    limits: {
+      fileSize: documentMaxSizeBytes,
+      files: 1,
+    },
+    fileFilter: (_req, file, cb) => {
+      const esImagen = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp'].includes(file.mimetype);
+      const esPdf = file.mimetype === 'application/pdf';
+
+      if (!esImagen && !esPdf) {
+        cb(new Error('Solo se permiten imagenes jpg, jpeg, png, webp o archivos PDF.'));
+        return;
+      }
+
+      cb(null, true);
+    },
+  });
+
+export const uploadInventarioFoto = crearUploaderImagen();
+export const uploadJustificanteFoto = crearUploaderImagen();
+export const uploadFacturaGasto = crearUploaderDocumento();
+export const uploadFacturaFoto = crearUploaderImagen();
+export const uploadContratoAlquiler = crearUploaderDocumento();

--- a/backend/src/controllers/cobros.controller.ts
+++ b/backend/src/controllers/cobros.controller.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import { prisma } from '../lib/prisma';
 import { TIPOS_GASTO_CASERO } from '../services/gasto.service';
+import { resolveOptionalMediaUrl } from '../services/media-url.service';
 
 const obtenerParamNumerico = (valor: string | string[] | undefined) => {
   const normalizado = Array.isArray(valor) ? valor[0] : valor;
@@ -111,6 +112,26 @@ export const listarCobrosVivienda: express.RequestHandler = async (req, res) => 
   const totalPendiente = sumarImportes(
     deudas.filter((deuda) => deuda.estado === 'PENDIENTE').map((deuda) => deuda.importe),
   );
+  const deudasConUrls = await Promise.all(
+    deudas.map(async (deuda) => ({
+      ...deuda,
+      justificante_url: await resolveOptionalMediaUrl({
+        url: deuda.justificante_url,
+        provider: deuda.justificante_provider,
+        key: deuda.justificante_key,
+        visibility: 'private',
+      }),
+      gasto: {
+        ...deuda.gasto,
+        factura_url: await resolveOptionalMediaUrl({
+          url: deuda.gasto.factura_url,
+          provider: deuda.gasto.factura_provider,
+          key: deuda.gasto.factura_key,
+          visibility: 'private',
+        }),
+      },
+    })),
+  );
 
   res.status(200).json({
     vivienda: {
@@ -127,7 +148,7 @@ export const listarCobrosVivienda: express.RequestHandler = async (req, res) => 
       total_pendiente: totalPendiente,
       total_deudas: deudas.length,
     },
-    deudas: deudas.map((deuda) => ({
+    deudas: deudasConUrls.map((deuda) => ({
       id: deuda.id,
       importe: deuda.importe,
       estado: deuda.estado,

--- a/backend/src/controllers/contrato.controller.ts
+++ b/backend/src/controllers/contrato.controller.ts
@@ -4,8 +4,9 @@ import { RolUsuario } from '../generated/prisma/client';
 import { prisma } from '../lib/prisma';
 import {
   construirCamposMediaDocumento,
-  construirReferenciaMediaDesdeArchivo,
 } from '../services/media-reference.service';
+import { mediaProviderErrorToHttp, uploadDocumentMedia } from '../services/media-upload.service';
+import { resolveOptionalMediaUrl } from '../services/media-url.service';
 import { registrarPeriodoContratoFirmado } from '../services/ocupacion.service';
 
 const ESTADOS_CONTRATO = {
@@ -158,6 +159,26 @@ const validarViviendaCasero = async (viviendaId: number, caseroId: number) =>
     },
   });
 
+async function resolverDocumentoContrato<T extends {
+  documento_url?: string | null;
+  documento_provider?: string | null;
+  documento_key?: string | null;
+}>(contrato: T | null): Promise<T | null> {
+  if (!contrato) {
+    return contrato;
+  }
+
+  return {
+    ...contrato,
+    documento_url: await resolveOptionalMediaUrl({
+      url: contrato.documento_url,
+      provider: contrato.documento_provider,
+      key: contrato.documento_key,
+      visibility: 'private',
+    }),
+  };
+}
+
 export const listarContratosVivienda: express.RequestHandler = async (req, res) => {
   const viviendaId = obtenerParamNumerico(req.params.viviendaId);
   const usuario = req.usuario!;
@@ -189,7 +210,7 @@ export const listarContratosVivienda: express.RequestHandler = async (req, res) 
     include: includeContrato,
   });
 
-  res.status(200).json(contratos);
+  res.status(200).json(await Promise.all(contratos.map((contrato: any) => resolverDocumentoContrato(contrato))));
 };
 
 export const crearContratoAlquiler: express.RequestHandler = async (req, res) => {
@@ -262,12 +283,22 @@ export const crearContratoAlquiler: express.RequestHandler = async (req, res) =>
     return;
   }
 
-  const documentoMedia = construirReferenciaMediaDesdeArchivo({
-    file: req.file,
-    purpose: 'rental-contract',
-    visibility: 'public',
-  });
-  if (!documentoMedia?.url) {
+  let documentoMedia;
+  try {
+    documentoMedia = await uploadDocumentMedia({
+      file: req.file,
+      purpose: 'rental-contract',
+      visibility: 'private',
+      ownerId: usuario.id,
+      viviendaId,
+    });
+  } catch (error) {
+    const mapped = mediaProviderErrorToHttp(error);
+    res.status(mapped.status).json({ error: mapped.message });
+    return;
+  }
+
+  if (!documentoMedia?.key) {
     res.status(500).json({ error: 'No se pudo obtener la referencia del contrato subido.' });
     return;
   }
@@ -326,7 +357,7 @@ export const crearContratoAlquiler: express.RequestHandler = async (req, res) =>
     });
   });
 
-  res.status(201).json(contrato);
+  res.status(201).json(await resolverDocumentoContrato(contrato));
 };
 
 export const firmarContratoAlquiler: express.RequestHandler = async (req, res) => {

--- a/backend/src/controllers/deuda.controller.ts
+++ b/backend/src/controllers/deuda.controller.ts
@@ -1,11 +1,10 @@
 import express from 'express';
-import { cloudinaryEstaConfigurado } from '../config/cloudinary.config';
 import { prisma } from '../lib/prisma';
 import { usuarioPerteneceAVivienda } from '../services/gasto.service';
 import {
   construirCamposMediaDocumento,
-  construirReferenciaMediaDesdeArchivo,
 } from '../services/media-reference.service';
+import { mediaProviderErrorToHttp, uploadImageMedia } from '../services/media-upload.service';
 
 const obtenerParamNumerico = (valor: string | string[] | undefined) => {
   const normalizado = Array.isArray(valor) ? valor[0] : valor;
@@ -20,11 +19,6 @@ const obtenerParamNumerico = (valor: string | string[] | undefined) => {
 export const subirJustificanteDeuda: express.RequestHandler = async (req, res) => {
   const deudaId = obtenerParamNumerico(req.params.deudaId);
   const usuarioId = req.usuario!.id;
-
-  if (!cloudinaryEstaConfigurado) {
-    res.status(500).json({ error: 'Cloudinary no está configurado en el servidor.' });
-    return;
-  }
 
   if (!Number.isInteger(deudaId) || deudaId <= 0) {
     res.status(400).json({ error: 'deudaId inválido.' });
@@ -64,13 +58,23 @@ export const subirJustificanteDeuda: express.RequestHandler = async (req, res) =
     return;
   }
 
-  const justificanteMedia = construirReferenciaMediaDesdeArchivo({
-    file: req.file,
-    purpose: 'payment-proof',
-    visibility: 'public',
-  });
+  let justificanteMedia;
+  try {
+    justificanteMedia = await uploadImageMedia({
+      file: req.file,
+      purpose: 'payment-proof',
+      visibility: 'private',
+      ownerId: usuarioId,
+      viviendaId: deuda.gasto.vivienda_id,
+      preferredVariant: 'medium',
+    });
+  } catch (error) {
+    const mapped = mediaProviderErrorToHttp(error);
+    res.status(mapped.status).json({ error: mapped.message });
+    return;
+  }
 
-  if (!justificanteMedia?.url) {
+  if (!justificanteMedia?.key) {
     res.status(500).json({ error: 'No se pudo obtener la referencia del justificante subido.' });
     return;
   }

--- a/backend/src/controllers/gasto.controller.ts
+++ b/backend/src/controllers/gasto.controller.ts
@@ -1,5 +1,4 @@
 import express from 'express';
-import { cloudinaryEstaConfigurado } from '../config/cloudinary.config';
 import { prisma } from '../lib/prisma';
 import {
   CategoriaFiscalGastoRoomies,
@@ -14,8 +13,9 @@ import {
 } from '../services/gasto.service';
 import {
   construirCamposMediaDocumento,
-  construirReferenciaMediaDesdeArchivo,
 } from '../services/media-reference.service';
+import { mediaProviderErrorToHttp, uploadDocumentMedia, uploadImageMedia } from '../services/media-upload.service';
+import { resolveOptionalMediaUrl } from '../services/media-url.service';
 
 const obtenerParamNumerico = (valor: string | string[] | undefined) => {
   const normalizado = Array.isArray(valor) ? valor[0] : valor;
@@ -185,6 +185,48 @@ const usuarioPuedeAccederAVivienda = async (viviendaId: number, usuarioId: numbe
   return Boolean(habitacion || vivienda);
 };
 
+async function resolverFacturaGasto<T extends {
+  factura_url?: string | null;
+  factura_provider?: string | null;
+  factura_key?: string | null;
+}>(gasto: T): Promise<T> {
+  if (!gasto.factura_url && !gasto.factura_provider && !gasto.factura_key) {
+    return gasto;
+  }
+
+  return {
+    ...gasto,
+    factura_url: await resolveOptionalMediaUrl({
+      url: gasto.factura_url,
+      provider: gasto.factura_provider,
+      key: gasto.factura_key,
+      visibility: 'private',
+    }),
+  };
+}
+
+async function resolverFacturaDeuda<T extends {
+  justificante_url?: string | null;
+  justificante_provider?: string | null;
+  justificante_key?: string | null;
+  gasto: {
+    factura_url?: string | null;
+    factura_provider?: string | null;
+    factura_key?: string | null;
+  };
+}>(deuda: T): Promise<T> {
+  return {
+    ...deuda,
+    justificante_url: await resolveOptionalMediaUrl({
+      url: deuda.justificante_url,
+      provider: deuda.justificante_provider,
+      key: deuda.justificante_key,
+      visibility: 'private',
+    }),
+    gasto: await resolverFacturaGasto(deuda.gasto),
+  };
+}
+
 export const listarGastos: express.RequestHandler = async (req, res) => {
   const viviendaId = obtenerParamNumerico(req.params.viviendaId);
   const usuarioId = req.usuario!.id;
@@ -230,7 +272,9 @@ export const listarGastos: express.RequestHandler = async (req, res) => {
     },
   });
 
-  res.status(200).json(viviendaCasero ? gastos : gastos.map((gasto) => ocultarMetadataFiscal(gasto)));
+  const gastosConUrls = await Promise.all(gastos.map((gasto) => resolverFacturaGasto(gasto)));
+
+  res.status(200).json(viviendaCasero ? gastosConUrls : gastosConUrls.map((gasto) => ocultarMetadataFiscal(gasto)));
 };
 
 export const listarDeudas: express.RequestHandler = async (req, res) => {
@@ -273,8 +317,10 @@ export const listarDeudas: express.RequestHandler = async (req, res) => {
     orderBy: { id: 'desc' },
   });
 
+  const deudasConUrls = await Promise.all(deudas.map((deuda) => resolverFacturaDeuda(deuda)));
+
   res.status(200).json(
-    deudas.map((deuda) => ({
+    deudasConUrls.map((deuda) => ({
       ...deuda,
       categoria: TIPOS_GASTO_CASERO.includes(deuda.gasto.tipo as (typeof TIPOS_GASTO_CASERO)[number])
         ? 'CASERO'
@@ -417,14 +463,16 @@ export const crearGasto: express.RequestHandler = async (req, res) => {
   }
 
   try {
-    const facturaMedia = construirReferenciaMediaDesdeArchivo({
+    const facturaMedia = await uploadDocumentMedia({
       file: req.file,
       purpose: 'expense-invoice',
-      visibility: 'public',
+      visibility: 'private',
+      ownerId: req.usuario!.id,
+      viviendaId,
     });
     const tipoGasto = req.usuario!.rol === 'CASERO' ? 'FACTURA_PUNTUAL' : 'ENTRE_COMPANEROS';
 
-    if (req.file && !facturaMedia?.url) {
+    if (req.file && !facturaMedia?.key) {
       res.status(500).json({ error: 'No se pudo obtener la referencia de la factura subida.' });
       return;
     }
@@ -444,6 +492,12 @@ export const crearGasto: express.RequestHandler = async (req, res) => {
 
     res.status(201).json(gasto);
   } catch (error) {
+    const mapped = mediaProviderErrorToHttp(error);
+    if (mapped.status !== 500) {
+      res.status(mapped.status).json({ error: mapped.message });
+      return;
+    }
+
     const mensaje = error instanceof Error ? error.message : 'No se pudo registrar el gasto.';
     res.status(400).json({ error: mensaje });
   }
@@ -643,7 +697,7 @@ export const eliminarGasto: express.RequestHandler = async (req, res) => {
   }
 
   const tieneActividadDePago = gasto.deudas.some(
-    (deuda) => deuda.estado === 'PAGADA' || Boolean(deuda.justificante_url),
+    (deuda) => deuda.estado === 'PAGADA' || Boolean(deuda.justificante_url) || Boolean(deuda.justificante_key),
   );
 
   if (tieneActividadDePago) {
@@ -667,11 +721,6 @@ export const subirFacturaGasto: express.RequestHandler = async (req, res) => {
   const viviendaId = obtenerParamNumerico(req.params.viviendaId);
   const gastoId = obtenerParamNumerico(req.params.gastoId);
   const usuarioId = req.usuario!.id;
-
-  if (!cloudinaryEstaConfigurado) {
-    res.status(500).json({ error: 'Cloudinary no está configurado en el servidor.' });
-    return;
-  }
 
   if (!Number.isInteger(viviendaId) || viviendaId <= 0) {
     res.status(400).json({ error: 'viviendaId inválido.' });
@@ -712,13 +761,23 @@ export const subirFacturaGasto: express.RequestHandler = async (req, res) => {
     return;
   }
 
-  const facturaMedia = construirReferenciaMediaDesdeArchivo({
-    file: req.file,
-    purpose: 'expense-invoice',
-    visibility: 'public',
-  });
+  let facturaMedia;
+  try {
+    facturaMedia = await uploadImageMedia({
+      file: req.file,
+      purpose: 'expense-invoice',
+      visibility: 'private',
+      ownerId: usuarioId,
+      viviendaId,
+      preferredVariant: 'medium',
+    });
+  } catch (error) {
+    const mapped = mediaProviderErrorToHttp(error);
+    res.status(mapped.status).json({ error: mapped.message });
+    return;
+  }
 
-  if (!facturaMedia?.url) {
+  if (!facturaMedia?.key) {
     res.status(500).json({ error: 'No se pudo obtener la referencia de la factura subida.' });
     return;
   }

--- a/backend/src/controllers/inventario.controller.ts
+++ b/backend/src/controllers/inventario.controller.ts
@@ -1,11 +1,10 @@
 import express from 'express';
-import { cloudinaryEstaConfigurado } from '../config/cloudinary.config';
 import { EstadoItem, RolUsuario } from '../generated/prisma/client';
 import { prisma } from '../lib/prisma';
 import {
   construirCamposFotoAsset,
-  construirReferenciaMediaDesdeArchivo,
 } from '../services/media-reference.service';
+import { mediaProviderErrorToHttp, uploadImageMedia } from '../services/media-upload.service';
 
 const ESTADOS_ITEM_VALIDOS = new Set<EstadoItem>([
   EstadoItem.NUEVO,
@@ -421,11 +420,6 @@ export const subirFotoInventario: express.RequestHandler = async (req, res) => {
   const usuarioId = req.usuario!.id;
   const rol = req.usuario!.rol;
 
-  if (!cloudinaryEstaConfigurado) {
-    res.status(500).json({ error: 'Cloudinary no estÃ¡ configurado en el servidor.' });
-    return;
-  }
-
   if (!Number.isInteger(itemId) || itemId <= 0) {
     res.status(400).json({ error: 'itemId invÃ¡lido.' });
     return;
@@ -470,12 +464,23 @@ export const subirFotoInventario: express.RequestHandler = async (req, res) => {
     return;
   }
 
-  const fotoMedia = construirReferenciaMediaDesdeArchivo({
-    file: req.file,
-    purpose: 'inventory-photo',
-    visibility: 'public',
-  });
-  if (!fotoMedia?.url) {
+  let fotoMedia;
+  try {
+    fotoMedia = await uploadImageMedia({
+      file: req.file,
+      purpose: 'inventory-photo',
+      visibility: 'public',
+      ownerId: usuarioId,
+      viviendaId,
+      preferredVariant: 'medium',
+    });
+  } catch (error) {
+    const mapped = mediaProviderErrorToHttp(error);
+    res.status(mapped.status).json({ error: mapped.message });
+    return;
+  }
+
+  if (!fotoMedia?.key) {
     res.status(500).json({ error: 'No se pudo obtener la referencia de la imagen subida.' });
     return;
   }

--- a/backend/src/routes/contrato.routes.ts
+++ b/backend/src/routes/contrato.routes.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { uploadContratoAlquiler } from '../config/cloudinary.config';
+import { uploadContratoAlquiler } from '../config/media-upload.config';
 import {
   anularContratoAlquiler,
   crearContratoAlquiler,

--- a/backend/src/routes/deuda.routes.ts
+++ b/backend/src/routes/deuda.routes.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { uploadJustificanteFoto } from '../config/cloudinary.config';
+import { uploadJustificanteFoto } from '../config/media-upload.config';
 import { subirJustificanteDeuda } from '../controllers/deuda.controller';
 import { verificarToken } from '../middlewares/auth.middleware';
 import { protegerModuloVivienda, resolverViviendaIdDesdeDeuda } from '../middlewares/module.guard';

--- a/backend/src/routes/gasto.routes.ts
+++ b/backend/src/routes/gasto.routes.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { uploadFacturaFoto, uploadFacturaGasto } from '../config/cloudinary.config';
+import { uploadFacturaFoto, uploadFacturaGasto } from '../config/media-upload.config';
 import { listarCobrosVivienda } from '../controllers/cobros.controller';
 import { verificarToken } from '../middlewares/auth.middleware';
 import { protegerModuloVivienda } from '../middlewares/module.guard';

--- a/backend/src/routes/inventario.routes.ts
+++ b/backend/src/routes/inventario.routes.ts
@@ -5,7 +5,7 @@ import {
   marcarConformidadInventario,
   subirFotoInventario,
 } from '../controllers/inventario.controller';
-import { uploadInventarioFoto } from '../config/cloudinary.config';
+import { uploadInventarioFoto } from '../config/media-upload.config';
 import { verificarToken } from '../middlewares/auth.middleware';
 import { protegerModuloVivienda, resolverViviendaIdDesdeItemInventario } from '../middlewares/module.guard';
 

--- a/backend/src/services/backblaze-b2-media.provider.ts
+++ b/backend/src/services/backblaze-b2-media.provider.ts
@@ -50,6 +50,13 @@ function sanitizeKeySegment(value: string): string {
 }
 
 function buildObjectKey(input: MediaUploadInput): string {
+  if (input.key) {
+    return input.key
+      .split('/')
+      .map((segment) => sanitizeKeySegment(segment) || 'archivo')
+      .join('/');
+  }
+
   const today = new Date().toISOString().slice(0, 10);
   const vivienda = input.viviendaId ? `vivienda-${input.viviendaId}` : 'vivienda-global';
   const extension = sanitizeKeySegment(path.extname(input.fileName).replace('.', ''));
@@ -150,11 +157,11 @@ export class BackblazeB2MediaStorageProvider implements MediaStorageProvider {
       provider: 'backblaze',
       key,
       url: input.visibility === 'public' ? this.buildPublicUrl(key) : null,
-      variant: 'original',
+      variant: input.variant ?? 'original',
       mimeType: input.mimeType,
       size: input.size,
-      width: null,
-      height: null,
+      width: input.width ?? null,
+      height: input.height ?? null,
       visibility: input.visibility,
       purpose: input.purpose,
       metadata: input.metadata,

--- a/backend/src/services/media-image.processor.ts
+++ b/backend/src/services/media-image.processor.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import crypto from 'node:crypto';
 import sharp from 'sharp';
 import { MediaProviderError, type MediaPurpose, type MediaVariant } from './media.types';
 
@@ -110,7 +111,7 @@ function buildSuggestedKey(input: ProcessImageInput, variant: MediaImageVariant)
   const baseName = sanitizeKeySegment(path.basename(input.fileName, path.extname(input.fileName))) || 'imagen';
   const originalExtension = sanitizeKeySegment(path.extname(input.fileName).replace('.', '')) || 'imagen';
   const extension = variant === 'original' ? originalExtension : 'webp';
-  return [input.purpose, vivienda, `owner-${input.ownerId}`, today, `${baseName}-${variant}.${extension}`].join('/');
+  return [input.purpose, vivienda, `owner-${input.ownerId}`, today, `${baseName}-${crypto.randomUUID()}-${variant}.${extension}`].join('/');
 }
 
 function buildMetadata(

--- a/backend/src/services/media-upload.service.ts
+++ b/backend/src/services/media-upload.service.ts
@@ -1,0 +1,168 @@
+import {
+  construirReferenciaMediaDesdeArchivo,
+  type PortableMediaReference,
+} from './media-reference.service';
+import { processImageForUpload, type MediaImageVariant } from './media-image.processor';
+import { createMediaStorageProvider } from './media.service';
+import { MediaProviderError, type MediaPurpose, type MediaVisibility } from './media.types';
+
+type UploadedFileWithLegacyUrl = Express.Multer.File & {
+  path?: string;
+  secure_url?: string;
+  url?: string;
+  filename?: string;
+};
+
+type UploadMediaOptions = {
+  file: Express.Multer.File | undefined;
+  purpose: MediaPurpose;
+  visibility: MediaVisibility;
+  ownerId: number;
+  viviendaId?: number;
+};
+
+type UploadImageOptions = UploadMediaOptions & {
+  preferredVariant?: MediaImageVariant;
+};
+
+function hasLegacyProviderUrl(file: Express.Multer.File): boolean {
+  const legacy = file as UploadedFileWithLegacyUrl;
+  return Boolean(legacy.path ?? legacy.secure_url ?? legacy.url ?? legacy.filename);
+}
+
+function assertFileBuffer(file: Express.Multer.File): Buffer {
+  if (file.buffer?.length) {
+    return file.buffer;
+  }
+
+  throw new MediaProviderError('MEDIA_UPLOAD_FAILED', 'No se pudo leer el archivo recibido.');
+}
+
+function buildLegacyReference(
+  file: Express.Multer.File | undefined,
+  purpose: MediaPurpose,
+  visibility: MediaVisibility,
+) {
+  return construirReferenciaMediaDesdeArchivo({
+    file,
+    purpose,
+    visibility,
+  });
+}
+
+export async function uploadDocumentMedia({
+  file,
+  purpose,
+  visibility,
+  ownerId,
+  viviendaId,
+}: UploadMediaOptions): Promise<PortableMediaReference | null> {
+  if (!file) {
+    return null;
+  }
+
+  if (hasLegacyProviderUrl(file)) {
+    return buildLegacyReference(file, purpose, visibility);
+  }
+
+  const provider = createMediaStorageProvider();
+  const media = await provider.upload({
+    buffer: assertFileBuffer(file),
+    fileName: file.originalname,
+    mimeType: file.mimetype,
+    size: file.size,
+    purpose,
+    visibility,
+    ownerId,
+    viviendaId,
+    metadata: {
+      originalFileName: file.originalname,
+    },
+  });
+
+  if (visibility === 'private' && media.provider === 'backblaze') {
+    const signedUrl = await provider.getSignedUrl({ provider: media.provider, key: media.key });
+    return { ...media, url: signedUrl };
+  }
+
+  return media;
+}
+
+export async function uploadImageMedia({
+  file,
+  purpose,
+  visibility,
+  ownerId,
+  viviendaId,
+  preferredVariant = 'medium',
+}: UploadImageOptions): Promise<PortableMediaReference | null> {
+  if (!file) {
+    return null;
+  }
+
+  if (hasLegacyProviderUrl(file)) {
+    return buildLegacyReference(file, purpose, visibility);
+  }
+
+  const provider = createMediaStorageProvider();
+  const processedVariants = await processImageForUpload({
+    buffer: assertFileBuffer(file),
+    fileName: file.originalname,
+    mimeType: file.mimetype,
+    size: file.size,
+    purpose,
+    ownerId,
+    viviendaId,
+  });
+
+  const uploadedVariants = await Promise.all(
+    processedVariants.map(async (variant) => {
+      const uploaded = await provider.upload({
+        buffer: variant.buffer,
+        fileName: variant.suggestedKey,
+        mimeType: variant.mimeType,
+        size: variant.size,
+        purpose,
+        visibility,
+        ownerId,
+        viviendaId,
+        key: variant.suggestedKey,
+        variant: variant.variant,
+        width: variant.width,
+        height: variant.height,
+        metadata: variant.metadata,
+      });
+
+      const url =
+        visibility === 'private' && uploaded.provider === 'backblaze'
+          ? await provider.getSignedUrl({ provider: uploaded.provider, key: uploaded.key })
+          : uploaded.url;
+
+      return {
+        ...uploaded,
+        url,
+        variant: variant.variant,
+        mimeType: variant.mimeType,
+        size: variant.size,
+        width: variant.width,
+        height: variant.height,
+      };
+    }),
+  );
+
+  return (
+    uploadedVariants.find((variant) => variant.variant === preferredVariant) ??
+    uploadedVariants.find((variant) => variant.variant === 'medium') ??
+    uploadedVariants[0] ??
+    null
+  );
+}
+
+export function mediaProviderErrorToHttp(error: unknown): { status: number; message: string } {
+  if (error instanceof MediaProviderError) {
+    const status = error.code === 'MEDIA_UNSUPPORTED_TYPE' || error.code === 'MEDIA_FILE_TOO_LARGE' ? 400 : 502;
+    return { status, message: error.message };
+  }
+
+  return { status: 500, message: 'No se pudo procesar el archivo subido.' };
+}

--- a/backend/src/services/media-url.service.ts
+++ b/backend/src/services/media-url.service.ts
@@ -1,0 +1,36 @@
+import { createMediaStorageProvider } from './media.service';
+import type { MediaProvider, MediaVisibility } from './media.types';
+
+type MediaUrlFields = {
+  url?: string | null;
+  provider?: string | null;
+  key?: string | null;
+  visibility?: MediaVisibility | null;
+};
+
+export async function resolveMediaUrl(fields: MediaUrlFields): Promise<string | null> {
+  if (fields.provider !== 'backblaze' || !fields.key) {
+    return fields.url ?? null;
+  }
+
+  const provider = createMediaStorageProvider();
+  const input = {
+    provider: fields.provider as MediaProvider,
+    key: fields.key,
+  };
+
+  if (fields.visibility === 'public') {
+    return fields.url ?? provider.getPublicUrl(input);
+  }
+
+  return provider.getSignedUrl(input);
+}
+
+export async function resolveOptionalMediaUrl(fields: MediaUrlFields): Promise<string | null> {
+  try {
+    return await resolveMediaUrl(fields);
+  } catch (error) {
+    console.warn('No se pudo resolver la URL de media.', error);
+    return fields.url ?? null;
+  }
+}

--- a/backend/src/services/media.service.ts
+++ b/backend/src/services/media.service.ts
@@ -2,7 +2,7 @@ import { createBackblazeB2MediaStorageProvider } from './backblaze-b2-media.prov
 import { MediaProviderError, type MediaStorageProvider } from './media.types';
 
 export function createMediaStorageProvider(): MediaStorageProvider {
-  const provider = process.env.MEDIA_PROVIDER?.trim().toLowerCase() ?? 'cloudinary';
+  const provider = process.env.MEDIA_PROVIDER?.trim().toLowerCase() ?? 'backblaze';
 
   if (provider === 'backblaze') {
     return createBackblazeB2MediaStorageProvider();

--- a/backend/src/services/media.types.ts
+++ b/backend/src/services/media.types.ts
@@ -33,6 +33,10 @@ export type MediaUploadInput = {
   visibility: MediaVisibility;
   ownerId: number;
   viviendaId?: number;
+  key?: string;
+  variant?: MediaVariant;
+  width?: number | null;
+  height?: number | null;
   metadata?: Record<string, string | number | boolean | null>;
 };
 

--- a/backend/tests/media-upload.service.test.ts
+++ b/backend/tests/media-upload.service.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import { beforeEach, describe, test, vi } from 'vitest';
+import type { MediaUploadInput } from '../src/services/media.types';
+
+const uploadMock = vi.hoisted(() => vi.fn());
+const getSignedUrlMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../src/services/media.service', () => ({
+  createMediaStorageProvider: () => ({
+    upload: uploadMock,
+    getSignedUrl: getSignedUrlMock,
+  }),
+}));
+
+const { uploadDocumentMedia } = await import('../src/services/media-upload.service');
+
+describe('media upload service', () => {
+  beforeEach(() => {
+    uploadMock.mockReset();
+    getSignedUrlMock.mockReset();
+  });
+
+  test('sube documentos financieros a Backblaze como privados', async () => {
+    uploadMock.mockImplementation(async (input: MediaUploadInput) => ({
+      provider: 'backblaze',
+      key: 'expense-invoice/vivienda-7/owner-42/factura.pdf',
+      url: null,
+      variant: 'original',
+      mimeType: input.mimeType,
+      size: input.size,
+      width: null,
+      height: null,
+      visibility: input.visibility,
+      purpose: input.purpose,
+    }));
+    getSignedUrlMock.mockResolvedValue('https://signed.roomies.test/factura.pdf');
+
+    const media = await uploadDocumentMedia({
+      file: {
+        buffer: Buffer.from('pdf'),
+        originalname: 'factura.pdf',
+        mimetype: 'application/pdf',
+        size: 3,
+      } as Express.Multer.File,
+      purpose: 'expense-invoice',
+      visibility: 'private',
+      ownerId: 42,
+      viviendaId: 7,
+    });
+
+    assert.equal(uploadMock.mock.calls.length, 1);
+    assert.equal(uploadMock.mock.calls[0]?.[0].purpose, 'expense-invoice');
+    assert.equal(uploadMock.mock.calls[0]?.[0].visibility, 'private');
+    assert.equal(uploadMock.mock.calls[0]?.[0].ownerId, 42);
+    assert.equal(getSignedUrlMock.mock.calls[0]?.[0].key, 'expense-invoice/vivienda-7/owner-42/factura.pdf');
+    assert.equal(media?.provider, 'backblaze');
+    assert.equal(media?.url, 'https://signed.roomies.test/factura.pdf');
+  });
+});

--- a/docs/changelog/EpicaMedia/epica-media-issue-351-flujos-backblaze.md
+++ b/docs/changelog/EpicaMedia/epica-media-issue-351-flujos-backblaze.md
@@ -1,0 +1,19 @@
+# Issue #351 - Flujos de subida en Backblaze
+
+## Objetivo
+
+Migrar las subidas reales de media para que dejen de depender de Cloudinary y usen el contrato interno de media con Backblaze B2.
+
+## Cambios principales
+
+- `backend/src/config/media-upload.config.ts`: nuevo `multer` en memoria para fotos y documentos, con limites y validacion por MIME antes de subir al proveedor interno.
+- `backend/src/services/media-upload.service.ts`: centraliza la subida de documentos y el procesado/subida de imagenes WebP, conservando compatibilidad con referencias legacy ya subidas.
+- `backend/src/services/media-url.service.ts`: refresca URLs firmadas para referencias privadas Backblaze antes de responder a la app.
+- `backend/src/routes/*.routes.ts`: inventario, deudas, gastos y contratos usan el uploader interno en lugar de `multer-storage-cloudinary`.
+- `backend/src/controllers/*`: los flujos de inventario, facturas, justificantes, cobros y contratos guardan referencias Backblaze portables; facturas, justificantes y contratos se suben con visibilidad privada y devuelven URL firmada.
+- `backend/src/services/backblaze-b2-media.provider.ts`: permite respetar keys, variante y dimensiones calculadas por el procesador de imagenes.
+
+## Verificacion
+
+- `npm test -- media-image.processor.test.ts media-upload.service.test.ts economico.test.ts inventario-issue-277.test.ts`
+- `npm run build`


### PR DESCRIPTION
## Objetivo
Migrar los flujos reales de subida de archivos para que dejen de depender de Cloudinary y pasen por el contrato interno de media con Backblaze B2, manteniendo referencias portables y protegiendo los documentos privados.

## Cambios principales
* Sustitución de los uploaders de Cloudinary por `multer` en memoria con validación de MIME y límites por tipo de archivo.
* Nuevos servicios para subir documentos e imágenes al proveedor interno, procesar variantes WebP y resolver URLs firmadas para media privada.
* Migración de los flujos de inventario, gastos, justificantes, cobros y contratos a referencias portables con `provider`, `key` y metadatos técnicos.
* Ajuste del proveedor Backblaze para respetar `key`, variante, dimensiones y URLs firmadas.
* Cobertura añadida para la subida de media y verificación de regresión en los flujos económicos e inventario.

## UI / UX (Solo si aplica)
* No aplica.

## Changelog
* `docs/changelog/EpicaMedia/epica-media-issue-351-flujos-backblaze.md`

## Testing
* `npm test -- media-image.processor.test.ts media-upload.service.test.ts economico.test.ts inventario-issue-277.test.ts`
* `npm run build`