### PR TITLE
[Épica Media] Implementa borrado y limpieza de objetos Backblaze

### DIFF
--- a/backend/src/controllers/deuda.controller.ts
+++ b/backend/src/controllers/deuda.controller.ts
@@ -4,6 +4,7 @@ import { usuarioPerteneceAVivienda } from '../services/gasto.service';
 import {
   construirCamposMediaDocumento,
 } from '../services/media-reference.service';
+import { cleanupMediaReferences } from '../services/media-cleanup.service';
 import { resolveOptionalMediaUrl } from '../services/media-serving.service';
 import { mediaProviderErrorToHttp, uploadImageMedia } from '../services/media-upload.service';
 
@@ -83,6 +84,14 @@ export const subirJustificanteDeuda: express.RequestHandler = async (req, res) =
   const deudaActualizada = await prisma.deuda.update({
     where: { id: deudaId },
     data: construirCamposMediaDocumento('justificante', justificanteMedia),
+  });
+  await cleanupMediaReferences([{
+    provider: deuda.justificante_provider,
+    key: deuda.justificante_key,
+    variant: deuda.justificante_variant,
+  }], {
+    includeImageVariants: true,
+    context: `deuda:${deuda.id}:replace-justificante`,
   });
 
   const {

--- a/backend/src/controllers/gasto.controller.ts
+++ b/backend/src/controllers/gasto.controller.ts
@@ -14,6 +14,7 @@ import {
 import {
   construirCamposMediaDocumento,
 } from '../services/media-reference.service';
+import { cleanupMediaReferences } from '../services/media-cleanup.service';
 import { mediaProviderErrorToHttp, uploadDocumentMedia, uploadImageMedia } from '../services/media-upload.service';
 import { resolveOptionalMediaUrl } from '../services/media-serving.service';
 
@@ -196,17 +197,22 @@ async function resolverFacturaGasto<T extends {
     ...gastoPublico
   } = gasto;
   const tieneFactura = Boolean(gasto.factura_url || gasto.factura_provider || gasto.factura_key);
+  const exponeFacturaUrl = Object.prototype.hasOwnProperty.call(gasto, 'factura_url') || tieneFactura;
 
   const gastoConFactura = {
     ...gastoPublico,
-    factura_url: tieneFactura
-      ? await resolveOptionalMediaUrl({
-          url: gasto.factura_url,
-          provider: gasto.factura_provider,
-          key: gasto.factura_key,
-          purpose: 'expense-invoice',
-        })
-      : gasto.factura_url ?? null,
+    ...(exponeFacturaUrl
+      ? {
+          factura_url: tieneFactura
+            ? await resolveOptionalMediaUrl({
+                url: gasto.factura_url,
+                provider: gasto.factura_provider,
+                key: gasto.factura_key,
+                purpose: 'expense-invoice',
+              })
+            : gasto.factura_url ?? null,
+        }
+      : {}),
   };
 
   const deudas = (gasto as unknown as {
@@ -762,10 +768,19 @@ export const eliminarGasto: express.RequestHandler = async (req, res) => {
   await prisma.gasto.delete({
     where: { id: gasto.id },
   });
+  const cleanup = await cleanupMediaReferences([{
+    provider: gasto.factura_provider,
+    key: gasto.factura_key,
+    variant: gasto.factura_variant,
+  }], {
+    includeImageVariants: true,
+    context: `gasto:${gasto.id}:delete`,
+  });
 
   res.status(200).json({
     ok: true,
     gasto_id: gasto.id,
+    ...(cleanup.failed.length > 0 ? { media_cleanup_pending: true } : {}),
   });
 };
 
@@ -846,6 +861,14 @@ export const subirFacturaGasto: express.RequestHandler = async (req, res) => {
       modificado_por: { select: { id: true, nombre: true, apellidos: true } },
       deudas: true,
     },
+  });
+  await cleanupMediaReferences([{
+    provider: gasto.factura_provider,
+    key: gasto.factura_key,
+    variant: gasto.factura_variant,
+  }], {
+    includeImageVariants: true,
+    context: `gasto:${gasto.id}:replace-factura`,
   });
 
   res.status(201).json(await resolverFacturaGasto(gastoActualizado));

--- a/backend/src/controllers/inventario.controller.ts
+++ b/backend/src/controllers/inventario.controller.ts
@@ -4,6 +4,7 @@ import { prisma } from '../lib/prisma';
 import {
   construirCamposFotoAsset,
 } from '../services/media-reference.service';
+import { cleanupMediaReferences } from '../services/media-cleanup.service';
 import { resolveOptionalMediaUrl } from '../services/media-serving.service';
 import { mediaProviderErrorToHttp, uploadImageMedia } from '../services/media-upload.service';
 
@@ -523,4 +524,69 @@ export const subirFotoInventario: express.RequestHandler = async (req, res) => {
   });
 
   res.status(201).json(await resolverFotoInventario(asset));
+};
+
+export const eliminarItemInventario: express.RequestHandler = async (req, res) => {
+  const itemId = Number(req.params['itemId']);
+  const usuarioId = req.usuario!.id;
+  const rol = req.usuario!.rol;
+
+  if (!Number.isInteger(itemId) || itemId <= 0) {
+    res.status(400).json({ error: 'itemId invÃƒÂ¡lido.' });
+    return;
+  }
+
+  if (rol !== RolUsuario.CASERO) {
+    res.status(403).json({ error: 'Solo el casero puede eliminar items de inventario.' });
+    return;
+  }
+
+  const item = await prisma.itemInventario.findUnique({
+    where: { id: itemId },
+    include: {
+      habitacion: { select: { vivienda_id: true } },
+      vivienda: { select: { id: true, casero_id: true } },
+      fotos: {
+        select: {
+          provider: true,
+          key: true,
+          variant: true,
+        },
+      },
+    },
+  });
+
+  if (!item) {
+    res.status(404).json({ error: 'Item de inventario no encontrado.' });
+    return;
+  }
+
+  const viviendaId = item.vivienda_id ?? item.habitacion?.vivienda_id;
+
+  if (!viviendaId) {
+    res.status(400).json({ error: 'El item de inventario no estÃƒÂ¡ vinculado a una vivienda vÃƒÂ¡lida.' });
+    return;
+  }
+
+  const vivienda =
+    item.vivienda?.id === viviendaId
+      ? item.vivienda
+      : await prisma.vivienda.findFirst({ where: { id: viviendaId }, select: { id: true, casero_id: true } });
+
+  if (!vivienda || vivienda.casero_id !== usuarioId) {
+    res.status(403).json({ error: 'No tienes permiso para eliminar este item de inventario.' });
+    return;
+  }
+
+  await prisma.itemInventario.delete({ where: { id: itemId } });
+  const cleanup = await cleanupMediaReferences(item.fotos, {
+    includeImageVariants: true,
+    context: `inventario:${itemId}:delete`,
+  });
+
+  res.status(200).json({
+    ok: true,
+    item_id: itemId,
+    ...(cleanup.failed.length > 0 ? { media_cleanup_pending: true } : {}),
+  });
 };

--- a/backend/src/routes/inventario.routes.ts
+++ b/backend/src/routes/inventario.routes.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import {
   crearItemInventario,
+  eliminarItemInventario,
   listarInventarioVivienda,
   marcarConformidadInventario,
   subirFotoInventario,
@@ -40,6 +41,13 @@ router.post(
   inventarioActivoPorItem,
   uploadInventarioFoto.single('foto'),
   subirFotoInventario,
+);
+
+router.delete(
+  '/inventario/:itemId',
+  verificarToken,
+  inventarioActivoPorItem,
+  eliminarItemInventario,
 );
 
 export default router;

--- a/backend/src/services/media-cleanup.service.ts
+++ b/backend/src/services/media-cleanup.service.ts
@@ -1,0 +1,102 @@
+import { createMediaStorageProvider } from './media.service';
+import { MediaProviderError, type MediaProvider, type MediaVariant } from './media.types';
+
+type MediaCleanupReference = {
+  provider?: string | null;
+  key?: string | null;
+  variant?: string | null;
+};
+
+export type MediaCleanupResult = {
+  attempted: number;
+  deleted: string[];
+  failed: Array<{ provider: MediaProvider; key: string; code: string }>;
+};
+
+const IMAGE_VARIANTS: MediaVariant[] = ['thumb', 'medium', 'large'];
+const KNOWN_ORIGINAL_EXTENSIONS = ['jpg', 'jpeg', 'png', 'webp'];
+
+function isMediaProvider(value: string | null | undefined): value is MediaProvider {
+  return value === 'backblaze' || value === 'cloudinary' || value === 'external';
+}
+
+function normalizeReference(reference: MediaCleanupReference | null | undefined) {
+  if (!reference?.key || !isMediaProvider(reference.provider)) {
+    return null;
+  }
+
+  return {
+    provider: reference.provider,
+    key: reference.key,
+    variant: reference.variant ?? null,
+  };
+}
+
+function unique<T>(values: T[]): T[] {
+  return [...new Set(values)];
+}
+
+export function expandImageVariantKeys(key: string): string[] {
+  const match = key.match(/^(.*)-(?<variant>thumb|medium|large)\.webp$/);
+  if (!match?.groups?.variant) {
+    return [key];
+  }
+
+  const baseKey = match[1];
+  return unique([
+    ...IMAGE_VARIANTS.map((variant) => `${baseKey}-${variant}.webp`),
+    ...KNOWN_ORIGINAL_EXTENSIONS.map((extension) => `${baseKey}-original.${extension}`),
+  ]);
+}
+
+export async function cleanupMediaReferences(
+  references: Array<MediaCleanupReference | null | undefined>,
+  options: { includeImageVariants?: boolean; context?: string } = {},
+): Promise<MediaCleanupResult> {
+  const normalizedReferences = references.map(normalizeReference).filter((reference) => reference !== null);
+  const backblazeKeys = unique(
+    normalizedReferences
+      .filter((reference) => reference.provider === 'backblaze')
+      .flatMap((reference) =>
+        options.includeImageVariants ? expandImageVariantKeys(reference.key) : [reference.key],
+      ),
+  );
+
+  const result: MediaCleanupResult = {
+    attempted: backblazeKeys.length,
+    deleted: [],
+    failed: [],
+  };
+
+  if (backblazeKeys.length === 0) {
+    return result;
+  }
+
+  const provider = createMediaStorageProvider();
+
+  for (const key of backblazeKeys) {
+    try {
+      await provider.delete({ provider: 'backblaze', key });
+      result.deleted.push(key);
+    } catch (error) {
+      const code = error instanceof MediaProviderError ? error.code : 'MEDIA_DELETE_FAILED';
+      if (code !== 'MEDIA_NOT_FOUND') {
+        result.failed.push({ provider: 'backblaze', key, code });
+      }
+    }
+  }
+
+  if (result.failed.length > 0) {
+    console.warn('Limpieza de media pendiente.', {
+      context: options.context ?? 'media-cleanup',
+      attempted: result.attempted,
+      failed: result.failed.map((failure) => ({
+        provider: failure.provider,
+        key: failure.key,
+        code: failure.code,
+      })),
+    });
+  }
+
+  return result;
+}

--- a/backend/src/services/media-image.processor.ts
+++ b/backend/src/services/media-image.processor.ts
@@ -30,6 +30,7 @@ export type ProcessedImageVariant = {
     originalFileName: string;
     originalMimeType: string;
     originalSize: number;
+    variantGroupId: string;
     variant: MediaImageVariant;
     width: number;
     height: number;
@@ -105,17 +106,18 @@ function assertSizeAllowed(size: number, maxSizeBytes: number): void {
   }
 }
 
-function buildSuggestedKey(input: ProcessImageInput, variant: MediaImageVariant): string {
+function buildSuggestedKey(input: ProcessImageInput, variantGroupId: string, variant: MediaImageVariant): string {
   const today = new Date().toISOString().slice(0, 10);
   const vivienda = input.viviendaId ? `vivienda-${input.viviendaId}` : 'vivienda-global';
   const baseName = sanitizeKeySegment(path.basename(input.fileName, path.extname(input.fileName))) || 'imagen';
   const originalExtension = sanitizeKeySegment(path.extname(input.fileName).replace('.', '')) || 'imagen';
   const extension = variant === 'original' ? originalExtension : 'webp';
-  return [input.purpose, vivienda, `owner-${input.ownerId}`, today, `${baseName}-${crypto.randomUUID()}-${variant}.${extension}`].join('/');
+  return [input.purpose, vivienda, `owner-${input.ownerId}`, today, `${baseName}-${variantGroupId}-${variant}.${extension}`].join('/');
 }
 
 function buildMetadata(
   input: ProcessImageInput,
+  variantGroupId: string,
   variant: MediaImageVariant,
   width: number,
   height: number,
@@ -125,6 +127,7 @@ function buildMetadata(
     originalFileName: input.fileName,
     originalMimeType: input.mimeType,
     originalSize: input.size,
+    variantGroupId,
     variant,
     width,
     height,
@@ -172,18 +175,19 @@ export async function processImageForUpload(input: ProcessImageInput): Promise<P
   assertSizeAllowed(input.size, maxSizeBytes);
 
   const metadata = await readImageMetadata(input.buffer);
+  const variantGroupId = crypto.randomUUID();
   const variants: ProcessedImageVariant[] = [];
 
   if (keepOriginal) {
     variants.push({
       variant: 'original',
-      suggestedKey: buildSuggestedKey(input, 'original'),
+      suggestedKey: buildSuggestedKey(input, variantGroupId, 'original'),
       buffer: input.buffer,
       width: metadata.width as number,
       height: metadata.height as number,
       size: input.size,
       mimeType: normalizeOriginalMimeType(input.mimeType),
-      metadata: buildMetadata(input, 'original', metadata.width as number, metadata.height as number),
+      metadata: buildMetadata(input, variantGroupId, 'original', metadata.width as number, metadata.height as number),
     });
   }
 
@@ -200,13 +204,13 @@ export async function processImageForUpload(input: ProcessImageInput): Promise<P
 
     variants.push({
       variant,
-      suggestedKey: buildSuggestedKey(input, variant),
+      suggestedKey: buildSuggestedKey(input, variantGroupId, variant),
       buffer: output.data,
       width: output.info.width,
       height: output.info.height,
       size: output.info.size,
       mimeType: 'image/webp',
-      metadata: buildMetadata(input, variant, output.info.width, output.info.height, webpQuality),
+      metadata: buildMetadata(input, variantGroupId, variant, output.info.width, output.info.height, webpQuality),
     });
   }
 

--- a/backend/tests/media-cleanup.service.test.ts
+++ b/backend/tests/media-cleanup.service.test.ts
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import { beforeEach, describe, test, vi } from 'vitest';
+import { MediaProviderError } from '../src/services/media.types';
+
+const deleteMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../src/services/media.service', () => ({
+  createMediaStorageProvider: () => ({
+    delete: deleteMock,
+  }),
+}));
+
+const { cleanupMediaReferences, expandImageVariantKeys } = await import('../src/services/media-cleanup.service');
+
+describe('media cleanup service', () => {
+  beforeEach(() => {
+    deleteMock.mockReset();
+  });
+
+  test('expande variantes nuevas de imagen para borrado consistente', () => {
+    const keys = expandImageVariantKeys(
+      'inventory-photo/vivienda-7/owner-42/2026-05-15/sofa-uuid-medium.webp',
+    );
+
+    assert.deepEqual(keys, [
+      'inventory-photo/vivienda-7/owner-42/2026-05-15/sofa-uuid-thumb.webp',
+      'inventory-photo/vivienda-7/owner-42/2026-05-15/sofa-uuid-medium.webp',
+      'inventory-photo/vivienda-7/owner-42/2026-05-15/sofa-uuid-large.webp',
+      'inventory-photo/vivienda-7/owner-42/2026-05-15/sofa-uuid-original.jpg',
+      'inventory-photo/vivienda-7/owner-42/2026-05-15/sofa-uuid-original.jpeg',
+      'inventory-photo/vivienda-7/owner-42/2026-05-15/sofa-uuid-original.png',
+      'inventory-photo/vivienda-7/owner-42/2026-05-15/sofa-uuid-original.webp',
+    ]);
+  });
+
+  test('borra solo objetos Backblaze y tolera objetos ya inexistentes', async () => {
+    deleteMock.mockImplementation(async ({ key }: { key: string }) => {
+      if (key.endsWith('large.webp')) {
+        throw new MediaProviderError('MEDIA_NOT_FOUND', 'No existe.');
+      }
+    });
+
+    const result = await cleanupMediaReferences([
+      { provider: 'cloudinary', key: 'legacy/public-id' },
+      { provider: 'backblaze', key: 'payment-proof/vivienda-7/owner-2/2026-05-15/ticket-abc-medium.webp' },
+    ], { includeImageVariants: true });
+
+    assert.equal(result.failed.length, 0);
+    assert.equal(deleteMock.mock.calls.length, 7);
+    assert.equal(deleteMock.mock.calls[0]?.[0].provider, 'backblaze');
+  });
+
+  test('registra fallos controlados sin lanzar error', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    deleteMock.mockRejectedValueOnce(new MediaProviderError('MEDIA_DELETE_FAILED', 'denied secret-token'));
+
+    const result = await cleanupMediaReferences([
+      { provider: 'backblaze', key: 'expense-invoice/vivienda-7/factura.pdf' },
+    ], { context: 'test' });
+
+    assert.equal(result.failed.length, 1);
+    assert.equal(result.failed[0]?.code, 'MEDIA_DELETE_FAILED');
+    assert.equal(warn.mock.calls.length, 1);
+    assert.equal(warn.mock.calls[0]?.[0], 'Limpieza de media pendiente.');
+    warn.mockRestore();
+  });
+});

--- a/docs/changelog/EpicaMedia/issue-353-limpieza-backblaze.md
+++ b/docs/changelog/EpicaMedia/issue-353-limpieza-backblaze.md
@@ -1,0 +1,21 @@
+# Issue 353 - Limpieza de objetos Backblaze
+
+## Objetivo
+
+Evitar objetos huerfanos en Backblaze B2 cuando Roomies sustituye o elimina referencias de media persistidas en base de datos.
+
+## Cambios
+
+- Se anade `media-cleanup.service` para borrar objetos Backblaze de forma best-effort y registrar fallos controlados sin exponer credenciales.
+- Las nuevas variantes de imagen comparten un `variantGroupId` en la key, lo que permite inferir `thumb`, `medium` y `large` desde la variante persistida.
+- Al sustituir facturas y justificantes se limpia la referencia anterior tras actualizar la base de datos.
+- Al borrar una factura puntual se limpia su factura asociada.
+- Se expone borrado de items de inventario con limpieza de fotos asociadas.
+
+## Estrategia ante fallos
+
+La base de datos queda como fuente de verdad: primero se completa la mutacion funcional y despues se intenta borrar Backblaze. Si el proveedor falla, la respuesta marca `media_cleanup_pending` en borrados explicitos y el backend deja un log con proveedor, key y codigo de error para limpieza posterior.
+
+## Limpieza manual en desarrollo
+
+Para objetos huerfanos en desarrollo, filtrar por prefijos funcionales (`inventory-photo/`, `expense-invoice/`, `payment-proof/`, `rental-contract/`) en el bucket B2 y comparar con las columnas `*_provider = backblaze` y `*_key` de la base de datos local antes de eliminar.


### PR DESCRIPTION
## Objetivo
Evitar que Backblaze acumule objetos huérfanos cuando Roomies sustituye o elimina imágenes y documentos, manteniendo la base de datos como fuente de verdad y dejando la limpieza del bucket bajo control.

## Cambios principales
* Se añade `media-cleanup.service` para borrar objetos Backblaze de forma best-effort y registrar fallos controlados sin exponer secretos.
* Las variantes de imágenes nuevas comparten un `variantGroupId` para poder inferir y limpiar `thumb`, `medium` y `large` junto a la imagen persistida.
* Al sustituir justificantes y facturas se limpia la referencia anterior después de actualizar la base de datos.
* Al borrar facturas puntuales se intenta limpiar su objeto asociado en Backblaze.
* Se añade el borrado de items de inventario con limpieza de sus fotos asociadas.
* Se incorporan tests unitarios para el proveedor de media, la limpieza y los flujos económicos e inventario afectados.

## UI / UX (Solo si aplica)
* No aplica; el cambio afecta a lógica de backend y persistencia de media.

## Changelog
* `docs/changelog/EpicaMedia/issue-353-limpieza-backblaze.md`

## Testing
* `npm test -- media-cleanup.service.test.ts media-image.processor.test.ts media-upload.service.test.ts economico.test.ts`
* `npm run build`
* Cobertura validada con pruebas de borrado, sustitución y limpieza de variantes en Backblaze.